### PR TITLE
Added check for having PRECISION_SINGLE and VECTOR_SSE enabled

### DIFF
--- a/src/engine.cpp
+++ b/src/engine.cpp
@@ -20,6 +20,10 @@ Engine::Engine(const EngineSpecification &engine_specification,
           : std::accumulate(engine_specification.beagle_flag_vector_.begin(),
                             engine_specification.beagle_flag_vector_.end(), 0,
                             std::bit_or<FatBeagle::PackedBeagleFlags>());
+  if (beagle_preference_flags & BEAGLE_FLAG_PRECISION_SINGLE
+      && beagle_preference_flags & BEAGLE_FLAG_VECTOR_SSE) {
+    Failwith("Single precision not available with vector SSE");
+  }
   for (size_t i = 0; i < engine_specification.thread_count_; i++) {
     fat_beagles_.push_back(std::make_unique<FatBeagle>(
         model_specification, site_pattern_, beagle_preference_flags,


### PR DESCRIPTION

## Description

Since beagle doesn't support single precision with SSE at the same time, a new check is added to Engine class that will fail to initialize when the combination is requested.

Closes #378 


## Tests

NA


## Checklist:

* [ x] Code follows our detailed [contribution guidelines](CONTRIBUTING.md)
* [ x] `clang-format` has been run
* [ x] TODOs have been eliminated from the code
* [ x] Comments are up to date, document intent, and there are no commented-out code blocks
