### PR TITLE
Replaced header guards with pragma once

### DIFF
--- a/src/ProgressBar.hpp
+++ b/src/ProgressBar.hpp
@@ -1,7 +1,6 @@
 // Modified slightly from https://github.com/prakhar1989/progress-cpp
 
-#ifndef PROGRESSBAR_PROGRESSBAR_HPP
-#define PROGRESSBAR_PROGRESSBAR_HPP
+#pragma once
 
 #include <chrono>
 #include <iomanip>
@@ -69,5 +68,3 @@ class ProgressBar {
     std::cout.flush();
   }
 };
-
-#endif  // PROGRESSBAR_PROGRESSBAR_HPP

--- a/src/alignment.hpp
+++ b/src/alignment.hpp
@@ -1,8 +1,7 @@
 // Copyright 2019-2021 bito project contributors.
 // bito is free software under the GPLv3; see LICENSE file for details.
 
-#ifndef SRC_ALIGNMENT_HPP_
-#define SRC_ALIGNMENT_HPP_
+#pragma once
 
 #include <string>
 #include <utility>
@@ -43,5 +42,3 @@ TEST_CASE("Alignment") {
   CHECK(alignment.IsValid());
 }
 #endif  // DOCTEST_LIBRARY_INCLUDED
-
-#endif  // SRC_ALIGNMENT_HPP_

--- a/src/beagle_accessories.hpp
+++ b/src/beagle_accessories.hpp
@@ -5,8 +5,7 @@
 // time given the tree, and remain const througout any operation-gathering tree
 // traversal.
 
-#ifndef SRC_BEAGLE_ACCESSORIES_HPP_
-#define SRC_BEAGLE_ACCESSORIES_HPP_
+#pragma once
 
 #include <numeric>
 #include <vector>
@@ -65,5 +64,3 @@ struct BeagleAccessories {
     return v;
   }
 };
-
-#endif  // SRC_BEAGLE_ACCESSORIES_HPP_

--- a/src/beagle_flag_names.hpp
+++ b/src/beagle_flag_names.hpp
@@ -5,8 +5,7 @@
 // time given the tree, and remain const througout any operation-gathering tree
 // traversal.
 
-#ifndef SRC_BEAGLE_FLAG_NAMES_HPP_
-#define SRC_BEAGLE_FLAG_NAMES_HPP_
+#pragma once
 
 #include <bitset>
 #include <limits>
@@ -69,5 +68,3 @@ std::string OfBeagleFlags(long flags) {
 }
 
 }  // namespace BeagleFlagNames
-
-#endif  // SRC_BEAGLE_FLAG_NAMES_HPP_

--- a/src/bitset.hpp
+++ b/src/bitset.hpp
@@ -11,8 +11,7 @@
 // Note that we can't use std::bitset because we don't know the size of the
 // bitsets at compile time.
 
-#ifndef SRC_BITSET_HPP_
-#define SRC_BITSET_HPP_
+#pragma once
 
 #include <algorithm>
 #include <functional>
@@ -500,5 +499,3 @@ TEST_CASE("Bitset: Subsplit Sort") {
 }
 
 #endif  // DOCTEST_LIBRARY_INCLUDED
-
-#endif  // SRC_BITSET_HPP_

--- a/src/block_model.hpp
+++ b/src/block_model.hpp
@@ -37,4 +37,3 @@ class BlockModel {
 
 //  This is a virtual class so there are no unit tests. See
 //  substitution_model.hpp.
-

--- a/src/block_model.hpp
+++ b/src/block_model.hpp
@@ -9,8 +9,7 @@
 // The methods provided just wrap methods in BlockSpecification, so see the
 // corresponding docs for a description of what they do.
 
-#ifndef SRC_BLOCK_MODEL_HPP_
-#define SRC_BLOCK_MODEL_HPP_
+#pragma once
 
 #include "block_specification.hpp"
 
@@ -38,4 +37,4 @@ class BlockModel {
 
 //  This is a virtual class so there are no unit tests. See
 //  substitution_model.hpp.
-#endif  // SRC_BLOCK_MODEL_HPP_
+

--- a/src/block_specification.hpp
+++ b/src/block_specification.hpp
@@ -97,4 +97,3 @@ TEST_CASE("BlockSpecification") {
   CHECK_EQ(spec.GetMap(), correct_appended_map);
 }
 #endif  // DOCTEST_LIBRARY_INCLUDED
-

--- a/src/block_specification.hpp
+++ b/src/block_specification.hpp
@@ -9,8 +9,7 @@
 // There is a special key called entire_key_ which gives the entire span of the
 // block.
 
-#ifndef SRC_BLOCK_SPECIFICATION_HPP_
-#define SRC_BLOCK_SPECIFICATION_HPP_
+#pragma once
 
 #include "eigen_sugar.hpp"
 #include "sugar.hpp"
@@ -99,4 +98,3 @@ TEST_CASE("BlockSpecification") {
 }
 #endif  // DOCTEST_LIBRARY_INCLUDED
 
-#endif  // SRC_BLOCK_SPECIFICATION_HPP_

--- a/src/clock_model.hpp
+++ b/src/clock_model.hpp
@@ -44,4 +44,3 @@ class StrictClockModel : public ClockModel {
  private:
   double rate_;
 };
-

--- a/src/clock_model.hpp
+++ b/src/clock_model.hpp
@@ -1,8 +1,7 @@
 // Copyright 2019-2021 bito project contributors.
 // bito is free software under the GPLv3; see LICENSE file for details.
 
-#ifndef SRC_CLOCK_MODEL_HPP_
-#define SRC_CLOCK_MODEL_HPP_
+#pragma once
 
 #include <memory>
 #include <string>
@@ -45,4 +44,4 @@ class StrictClockModel : public ClockModel {
  private:
   double rate_;
 };
-#endif  // SRC_CLOCK_MODEL_HPP_
+

--- a/src/combinatorics.hpp
+++ b/src/combinatorics.hpp
@@ -1,8 +1,7 @@
 // Copyright 2019-2021 bito project contributors.
 // bito is free software under the GPLv3; see LICENSE file for details.
 
-#ifndef SRC_COMBINATORICS_HPP_
-#define SRC_COMBINATORICS_HPP_
+#pragma once
 
 #include <cmath>
 #include <cstddef>
@@ -55,5 +54,3 @@ TEST_CASE("Combinatorics") {
   }
 }
 #endif  // DOCTEST_LIBRARY_INCLUDED
-
-#endif  // SRC_COMBINATORICS_HPP_

--- a/src/csv.hpp
+++ b/src/csv.hpp
@@ -1,8 +1,7 @@
 // Copyright 2019-2021 bito project contributors.
 // bito is free software under the GPLv3; see LICENSE file for details.
 
-#ifndef SRC_CSV_HPP_
-#define SRC_CSV_HPP_
+#pragma once
 
 #include "csv.h"
 #include "sugar.hpp"
@@ -25,4 +24,3 @@ TEST_CASE("CSV I/O") {
 }
 #endif  // DOCTEST_LIBRARY_INCLUDED
 
-#endif  // SRC_CSV_HPP_

--- a/src/csv.hpp
+++ b/src/csv.hpp
@@ -23,4 +23,3 @@ TEST_CASE("CSV I/O") {
   CHECK_EQ(result, correct_result);
 }
 #endif  // DOCTEST_LIBRARY_INCLUDED
-

--- a/src/default_dict.hpp
+++ b/src/default_dict.hpp
@@ -1,8 +1,7 @@
 // Copyright 2019-2021 bito project contributors.
 // bito is free software under the GPLv3; see LICENSE file for details.
 
-#ifndef SRC_DEFAULT_DICT_HPP_
-#define SRC_DEFAULT_DICT_HPP_
+#pragma once
 
 #include <iostream>
 #include <unordered_map>
@@ -76,4 +75,3 @@ TEST_CASE("DefaultDict") {
 
 #endif  // DOCTEST_LIBRARY_INCLUDED
 
-#endif  // SRC_DEFAULT_DICT_HPP_

--- a/src/default_dict.hpp
+++ b/src/default_dict.hpp
@@ -74,4 +74,3 @@ TEST_CASE("DefaultDict") {
 }
 
 #endif  // DOCTEST_LIBRARY_INCLUDED
-

--- a/src/doctest_constants.hpp
+++ b/src/doctest_constants.hpp
@@ -1,8 +1,7 @@
 // Copyright 2019-2021 bito project contributors.
 // bito is free software under the GPLv3; see LICENSE file for details.
 
-#ifndef SRC_DOCTEST_CONSTANTS_HPP_
-#define SRC_DOCTEST_CONSTANTS_HPP_
+#pragma once
 
 #ifdef DOCTEST_LIBRARY_INCLUDED
 
@@ -10,4 +9,4 @@
 const size_t out_of_sample_index = 99999999;
 
 #endif  // DOCTEST_LIBRARY_INCLUDED
-#endif  // SRC_DOCTEST_CONSTANTS_HPP_
+

--- a/src/doctest_constants.hpp
+++ b/src/doctest_constants.hpp
@@ -9,4 +9,3 @@
 const size_t out_of_sample_index = 99999999;
 
 #endif  // DOCTEST_LIBRARY_INCLUDED
-

--- a/src/driver.hpp
+++ b/src/driver.hpp
@@ -3,8 +3,8 @@
 //
 // This class drives tree parsing.
 
-#ifndef SRC_DRIVER_HPP_
-#define SRC_DRIVER_HPP_
+#pragma once
+
 #include <map>
 #include <memory>
 #include <string>
@@ -133,4 +133,3 @@ TEST_CASE("Driver") {
 }
 #endif  // DOCTEST_LIBRARY_INCLUDED
 
-#endif  // SRC_DRIVER_HPP_

--- a/src/driver.hpp
+++ b/src/driver.hpp
@@ -132,4 +132,3 @@ TEST_CASE("Driver") {
   CHECK_EQ(beast_nexus, beast_nexus_gz);
 }
 #endif  // DOCTEST_LIBRARY_INCLUDED
-

--- a/src/eigen_sugar.hpp
+++ b/src/eigen_sugar.hpp
@@ -3,8 +3,7 @@
 //
 // Put Eigen "common" code here.
 
-#ifndef SRC_EIGEN_SUGAR_HPP_
-#define SRC_EIGEN_SUGAR_HPP_
+#pragma once
 
 #include <Eigen/Dense>
 #include <fstream>
@@ -93,4 +92,3 @@ TEST_CASE(
 
 #endif  // DOCTEST_LIBRARY_INCLUDED
 
-#endif  // SRC_EIGEN_SUGAR_HPP_

--- a/src/eigen_sugar.hpp
+++ b/src/eigen_sugar.hpp
@@ -91,4 +91,3 @@ TEST_CASE(
 }
 
 #endif  // DOCTEST_LIBRARY_INCLUDED
-

--- a/src/engine.hpp
+++ b/src/engine.hpp
@@ -51,4 +51,3 @@ class Engine {
 
   const FatBeagle *const GetFirstFatBeagle() const;
 };
-

--- a/src/engine.hpp
+++ b/src/engine.hpp
@@ -4,8 +4,7 @@
 // "Engine" is short for "phylogenetic likelihood computation engine".
 // This engine has FatBeagles as cylinders.
 
-#ifndef SRC_ENGINE_HPP_
-#define SRC_ENGINE_HPP_
+#pragma once
 
 #include <memory>
 #include <utility>
@@ -53,4 +52,3 @@ class Engine {
   const FatBeagle *const GetFirstFatBeagle() const;
 };
 
-#endif  // SRC_ENGINE_HPP_

--- a/src/fat_beagle.hpp
+++ b/src/fat_beagle.hpp
@@ -1,8 +1,7 @@
 // Copyright 2019-2021 bito project contributors.
 // bito is free software under the GPLv3; see LICENSE file for details.
 
-#ifndef SRC_FAT_BEAGLE_HPP_
-#define SRC_FAT_BEAGLE_HPP_
+#pragma once
 
 #include <memory>
 #include <queue>
@@ -158,4 +157,4 @@ std::vector<TOut> FatBeagleParallelize(
 }
 
 // Tests live in rooted_sbn_instance.hpp and unrooted_sbn_instance.hpp.
-#endif  // SRC_FAT_BEAGLE_HPP_
+

--- a/src/fat_beagle.hpp
+++ b/src/fat_beagle.hpp
@@ -157,4 +157,3 @@ std::vector<TOut> FatBeagleParallelize(
 }
 
 // Tests live in rooted_sbn_instance.hpp and unrooted_sbn_instance.hpp.
-

--- a/src/generic_sbn_instance.hpp
+++ b/src/generic_sbn_instance.hpp
@@ -432,4 +432,3 @@ class GenericSBNInstance {
 #ifdef DOCTEST_LIBRARY_INCLUDED
 
 #endif  // DOCTEST_LIBRARY_INCLUDED
-

--- a/src/generic_sbn_instance.hpp
+++ b/src/generic_sbn_instance.hpp
@@ -9,8 +9,7 @@
 // excludes SBN training, which is different based on if we are thinking of trees as
 // rooted or unrooted.
 
-#ifndef SRC_GENERIC_SBN_INSTANCE_HPP_
-#define SRC_GENERIC_SBN_INSTANCE_HPP_
+#pragma once
 
 #include "ProgressBar.hpp"
 #include "alignment.hpp"
@@ -433,4 +432,4 @@ class GenericSBNInstance {
 #ifdef DOCTEST_LIBRARY_INCLUDED
 
 #endif  // DOCTEST_LIBRARY_INCLUDED
-#endif  // SRC_GENERIC_SBN_INSTANCE_HPP_
+

--- a/src/generic_tree_collection.hpp
+++ b/src/generic_tree_collection.hpp
@@ -1,8 +1,7 @@
 // Copyright 2019-2021 bito project contributors.
 // bito is free software under the GPLv3; see LICENSE file for details.
 
-#ifndef SRC_GENERIC_TREE_COLLECTION_HPP_
-#define SRC_GENERIC_TREE_COLLECTION_HPP_
+#pragma once
 
 #include <fstream>
 #include <memory>
@@ -151,4 +150,3 @@ class GenericTreeCollection {
 
 // Tests appear in non-generic subclasses.
 
-#endif  // SRC_GENERIC_TREE_COLLECTION_HPP_

--- a/src/generic_tree_collection.hpp
+++ b/src/generic_tree_collection.hpp
@@ -149,4 +149,3 @@ class GenericTreeCollection {
 };
 
 // Tests appear in non-generic subclasses.
-

--- a/src/gp_dag.hpp
+++ b/src/gp_dag.hpp
@@ -77,4 +77,3 @@ class GPDAG : public TidySubsplitDAG {
                                       bool rotated,
                                       GPOperationVector &operations) const;
 };
-

--- a/src/gp_dag.hpp
+++ b/src/gp_dag.hpp
@@ -5,8 +5,7 @@
 // the generalized pruning operations. Note that rootsplit PCSPs and the DAG root node
 // are excluded from operations.
 
-#ifndef SRC_GP_DAG_HPP_
-#define SRC_GP_DAG_HPP_
+#pragma once
 
 #include "gp_engine.hpp"
 #include "quartet_hybrid_request.hpp"
@@ -79,4 +78,3 @@ class GPDAG : public TidySubsplitDAG {
                                       GPOperationVector &operations) const;
 };
 
-#endif  // SRC_GP_DAG_HPP_

--- a/src/gp_engine.hpp
+++ b/src/gp_engine.hpp
@@ -221,4 +221,3 @@ TEST_CASE("GPEngine") {
 }
 
 #endif  // DOCTEST_LIBRARY_INCLUDED
-

--- a/src/gp_engine.hpp
+++ b/src/gp_engine.hpp
@@ -4,8 +4,7 @@
 // A visitor for GPOperations. See
 // https://arne-mertz.de/2018/05/modern-c-features-stdvariant-and-stdvisit/
 
-#ifndef SRC_GP_ENGINE_HPP_
-#define SRC_GP_ENGINE_HPP_
+#pragma once
 
 #include "eigen_sugar.hpp"
 #include "gp_operation.hpp"
@@ -223,4 +222,3 @@ TEST_CASE("GPEngine") {
 
 #endif  // DOCTEST_LIBRARY_INCLUDED
 
-#endif  // SRC_GP_ENGINE_HPP_

--- a/src/gp_instance.hpp
+++ b/src/gp_instance.hpp
@@ -1,8 +1,7 @@
 // Copyright 2019-2021 bito project contributors.
 // bito is free software under the GPLv3; see LICENSE file for details.
 
-#ifndef SRC_GP_INSTANCE_HPP_
-#define SRC_GP_INSTANCE_HPP_
+#pragma once
 
 #include "gp_dag.hpp"
 #include "gp_engine.hpp"
@@ -96,4 +95,3 @@ class GPInstance {
   StringDoubleVector PrettyIndexedVector(EigenConstVectorXdRef v);
 };
 
-#endif  // SRC_GP_INSTANCE_HPP_

--- a/src/gp_instance.hpp
+++ b/src/gp_instance.hpp
@@ -94,4 +94,3 @@ class GPInstance {
       Node::NodePtrVec &&topologies) const;
   StringDoubleVector PrettyIndexedVector(EigenConstVectorXdRef v);
 };
-

--- a/src/gp_operation.hpp
+++ b/src/gp_operation.hpp
@@ -255,4 +255,3 @@ struct GPOperationOstream {
 
 std::ostream& operator<<(std::ostream& os, GPOperation const& operation);
 std::ostream& operator<<(std::ostream& os, GPOperationVector const& operation_vector);
-

--- a/src/gp_operation.hpp
+++ b/src/gp_operation.hpp
@@ -3,8 +3,7 @@
 //
 // These operations are just declarations. We process them with the GPEngine.
 
-#ifndef GP_OPERATION_HPP_
-#define GP_OPERATION_HPP_
+#pragma once
 
 #include <iostream>
 #include <variant>
@@ -257,4 +256,3 @@ struct GPOperationOstream {
 std::ostream& operator<<(std::ostream& os, GPOperation const& operation);
 std::ostream& operator<<(std::ostream& os, GPOperationVector const& operation_vector);
 
-#endif  // GP_OPERATION_HPP_

--- a/src/intpack.hpp
+++ b/src/intpack.hpp
@@ -37,4 +37,3 @@ TEST_CASE("intpack") {
   CHECK_LT(PackInts(0, 4), PackInts(1, 0));
 }
 #endif  // DOCTEST_LIBRARY_INCLUDED
-

--- a/src/intpack.hpp
+++ b/src/intpack.hpp
@@ -1,8 +1,7 @@
 // Copyright 2019-2021 bito project contributors.
 // bito is free software under the GPLv3; see LICENSE file for details.
 
-#ifndef SRC_INTPACK_HPP_
-#define SRC_INTPACK_HPP_
+#pragma once
 
 #include <cstdint>
 #include <string>
@@ -39,4 +38,3 @@ TEST_CASE("intpack") {
 }
 #endif  // DOCTEST_LIBRARY_INCLUDED
 
-#endif  // SRC_INTPACK_HPP_

--- a/src/mersenne_twister.hpp
+++ b/src/mersenne_twister.hpp
@@ -14,4 +14,3 @@ class MersenneTwister {
   static std::random_device random_device_;
   static std::mt19937 random_generator_;
 };
-

--- a/src/mersenne_twister.hpp
+++ b/src/mersenne_twister.hpp
@@ -1,8 +1,7 @@
 // Copyright 2019-2021 bito project contributors.
 // bito is free software under the GPLv3; see LICENSE file for details.
 
-#ifndef SRC_MERSENNE_TWISTER_HPP_
-#define SRC_MERSENNE_TWISTER_HPP_
+#pragma once
 
 #include <random>
 
@@ -16,4 +15,3 @@ class MersenneTwister {
   static std::mt19937 random_generator_;
 };
 
-#endif  // SRC_MERSENNE_TWISTER_HPP_

--- a/src/mmapped_matrix.hpp
+++ b/src/mmapped_matrix.hpp
@@ -9,8 +9,7 @@
 // Simple example: https://jameshfisher.com/2017/01/28/mmap-file-write/
 // Most complete example: https://gist.github.com/marcetcheverry/991042
 
-#ifndef SRC_MMAPPED_MATRIX_HPP_
-#define SRC_MMAPPED_MATRIX_HPP_
+#pragma once
 
 #include <errno.h>
 #include <fcntl.h>
@@ -106,4 +105,3 @@ TEST_CASE("MmappedMatrix") {
 }
 #endif  // DOCTEST_LIBRARY_INCLUDED
 
-#endif  // SRC_MMAPPED_MATRIX_HPP_

--- a/src/mmapped_matrix.hpp
+++ b/src/mmapped_matrix.hpp
@@ -104,4 +104,3 @@ TEST_CASE("MmappedMatrix") {
   CHECK_EQ(mmapped_matrix.Get()(rows - 1, cols - 1), 5.);
 }
 #endif  // DOCTEST_LIBRARY_INCLUDED
-

--- a/src/mmapped_plv.hpp
+++ b/src/mmapped_plv.hpp
@@ -55,4 +55,3 @@ TEST_CASE("MmappedNucleotidePLV") {
   }
 }
 #endif  // DOCTEST_LIBRARY_INCLUDED
-

--- a/src/mmapped_plv.hpp
+++ b/src/mmapped_plv.hpp
@@ -6,8 +6,7 @@
 // This class is to allocate a very large partial likelihood vector in virtual memory
 // and then cut it up (via Subdivide) into a vector of partial likelihood vectors.
 
-#ifndef SRC_MMAPPED_PLV_HPP_
-#define SRC_MMAPPED_PLV_HPP_
+#pragma once
 
 #include "eigen_sugar.hpp"
 #include "mmapped_matrix.hpp"
@@ -57,4 +56,3 @@ TEST_CASE("MmappedNucleotidePLV") {
 }
 #endif  // DOCTEST_LIBRARY_INCLUDED
 
-#endif  // SRC_MMAPPED_PLV_HPP_

--- a/src/node.hpp
+++ b/src/node.hpp
@@ -29,8 +29,7 @@
 //
 // Equality is in terms of tree topologies. These mutable members don't matter.
 
-#ifndef SRC_NODE_HPP_
-#define SRC_NODE_HPP_
+#pragma once
 
 #include <functional>
 #include <memory>
@@ -319,4 +318,4 @@ TEST_CASE("Node") {
   CHECK_EQ(correct_sisters, sisters);
 }
 #endif  // DOCTEST_LIBRARY_INCLUDED
-#endif  // SRC_NODE_HPP_
+

--- a/src/node.hpp
+++ b/src/node.hpp
@@ -318,4 +318,3 @@ TEST_CASE("Node") {
   CHECK_EQ(correct_sisters, sisters);
 }
 #endif  // DOCTEST_LIBRARY_INCLUDED
-

--- a/src/numerical_utils.hpp
+++ b/src/numerical_utils.hpp
@@ -111,4 +111,3 @@ TEST_CASE("NumericalUtils") {
            "The following floating point problems have been encountered: FE_DIVBYZERO");
 }
 #endif  // DOCTEST_LIBRARY_INCLUDED
-

--- a/src/numerical_utils.hpp
+++ b/src/numerical_utils.hpp
@@ -1,8 +1,7 @@
 // Copyright 2019-2021 bito project contributors.
 // bito is free software under the GPLv3; see LICENSE file for details.
 
-#ifndef SRC_NUMERICAL_UTILS_HPP_
-#define SRC_NUMERICAL_UTILS_HPP_
+#pragma once
 
 #include <fenv.h>
 
@@ -113,4 +112,3 @@ TEST_CASE("NumericalUtils") {
 }
 #endif  // DOCTEST_LIBRARY_INCLUDED
 
-#endif /* SRC_NUMERICAL_UTILS_HPP_ */

--- a/src/optimization.hpp
+++ b/src/optimization.hpp
@@ -1,3 +1,8 @@
+// Copyright 2019-2021 bito project contributors.
+// bito is free software under the GPLv3; see LICENSE file for details.
+
+#pragma once
+
 #include <cmath>
 #include <functional>
 #include <utility>

--- a/src/phylo_model.hpp
+++ b/src/phylo_model.hpp
@@ -38,4 +38,3 @@ class PhyloModel : public BlockModel {
   std::unique_ptr<SiteModel> site_model_;
   std::unique_ptr<ClockModel> clock_model_;
 };
-

--- a/src/phylo_model.hpp
+++ b/src/phylo_model.hpp
@@ -1,8 +1,7 @@
 // Copyright 2019-2021 bito project contributors.
 // bito is free software under the GPLv3; see LICENSE file for details.
 
-#ifndef SRC_PHYLO_MODEL_HPP_
-#define SRC_PHYLO_MODEL_HPP_
+#pragma once
 
 #include <memory>
 
@@ -40,4 +39,3 @@ class PhyloModel : public BlockModel {
   std::unique_ptr<ClockModel> clock_model_;
 };
 
-#endif  // SRC_PHYLO_MODEL_HPP_

--- a/src/psp_indexer.hpp
+++ b/src/psp_indexer.hpp
@@ -69,4 +69,3 @@ class PSPIndexer {
 #ifdef DOCTEST_LIBRARY_INCLUDED
 TEST_CASE("PSPIndexer") {}
 #endif  // DOCTEST_LIBRARY_INCLUDED
-

--- a/src/psp_indexer.hpp
+++ b/src/psp_indexer.hpp
@@ -10,8 +10,7 @@
 // means "not present." This only happens on pendant branches, which do not have
 // a PSP component "below" the pendant branch.
 
-#ifndef SRC_PSP_INDEXER_HPP_
-#define SRC_PSP_INDEXER_HPP_
+#pragma once
 
 #include <memory>
 #include <string>
@@ -70,4 +69,4 @@ class PSPIndexer {
 #ifdef DOCTEST_LIBRARY_INCLUDED
 TEST_CASE("PSPIndexer") {}
 #endif  // DOCTEST_LIBRARY_INCLUDED
-#endif  // SRC_PSP_INDEXER_HPP_
+

--- a/src/quartet_hybrid_request.hpp
+++ b/src/quartet_hybrid_request.hpp
@@ -41,4 +41,3 @@ struct QuartetHybridRequest {
 std::ostream& operator<<(std::ostream& os, QuartetTip const& plv_pcsp);
 std::ostream& operator<<(std::ostream& os, QuartetTipVector const& plv_pcsp_vector);
 std::ostream& operator<<(std::ostream& os, QuartetHybridRequest const& request);
-

--- a/src/quartet_hybrid_request.hpp
+++ b/src/quartet_hybrid_request.hpp
@@ -3,8 +3,7 @@
 //
 // Stores a "request" for a quartet hybrid marginal calculation.
 
-#ifndef SRC_QUARTET_HYBRID_REQUEST_HPP_
-#define SRC_QUARTET_HYBRID_REQUEST_HPP_
+#pragma once
 
 #include <iostream>
 #include <vector>
@@ -43,4 +42,3 @@ std::ostream& operator<<(std::ostream& os, QuartetTip const& plv_pcsp);
 std::ostream& operator<<(std::ostream& os, QuartetTipVector const& plv_pcsp_vector);
 std::ostream& operator<<(std::ostream& os, QuartetHybridRequest const& request);
 
-#endif  // SRC_QUARTET_HYBRID_REQUEST_HPP_

--- a/src/reindexer.hpp
+++ b/src/reindexer.hpp
@@ -1,8 +1,7 @@
 // Copyright 2019-2021 bito project contributors.
 // bito is free software under the GPLv3; see LICENSE file for details.
 
-#ifndef SRC_REINDEX_HPP_
-#define SRC_REINDEX_HPP_
+#pragma once
 
 #include <numeric>
 
@@ -219,4 +218,3 @@ TEST_CASE("ReassignAndShift") {
 
 #endif  // DOCTEST_LIBRARY_INCLUDED
 
-#endif  // SRC_REINDEX_HPP_

--- a/src/reindexer.hpp
+++ b/src/reindexer.hpp
@@ -217,4 +217,3 @@ TEST_CASE("ReassignAndShift") {
 }
 
 #endif  // DOCTEST_LIBRARY_INCLUDED
-

--- a/src/rooted_gradient_transforms.hpp
+++ b/src/rooted_gradient_transforms.hpp
@@ -5,6 +5,8 @@
 // https://github.com/beast-dev/beast-mcmc
 // Credit to Xiang Ji and Marc Suchard.
 
+#pragma once
+
 #include <numeric>
 
 #include "rooted_tree.hpp"

--- a/src/rooted_sbn_instance.hpp
+++ b/src/rooted_sbn_instance.hpp
@@ -462,4 +462,3 @@ TEST_CASE("RootedSBNInstance: SBN parameter round trip") {
 }
 
 #endif  // DOCTEST_LIBRARY_INCLUDED
-

--- a/src/rooted_sbn_instance.hpp
+++ b/src/rooted_sbn_instance.hpp
@@ -1,8 +1,7 @@
 // Copyright 2019-2021 bito project contributors.
 // bito is free software under the GPLv3; see LICENSE file for details.
 
-#ifndef SRC_ROOTED_SBN_INSTANCE_HPP_
-#define SRC_ROOTED_SBN_INSTANCE_HPP_
+#pragma once
 
 #include "csv.hpp"
 #include "generic_sbn_instance.hpp"
@@ -463,4 +462,4 @@ TEST_CASE("RootedSBNInstance: SBN parameter round trip") {
 }
 
 #endif  // DOCTEST_LIBRARY_INCLUDED
-#endif  // SRC_ROOTED_SBN_INSTANCE_HPP_
+

--- a/src/rooted_sbn_support.hpp
+++ b/src/rooted_sbn_support.hpp
@@ -1,8 +1,7 @@
 // Copyright 2019-2021 bito project contributors.
 // bito is free software under the GPLv3; see LICENSE file for details.
 
-#ifndef SRC_ROOTED_SBN_SUPPORT_HPP_
-#define SRC_ROOTED_SBN_SUPPORT_HPP_
+#pragma once
 
 #include "sbn_support.hpp"
 
@@ -48,4 +47,3 @@ class RootedSBNSupport : public SBNSupport {
   }
 };
 
-#endif  // SRC_ROOTED_SBN_SUPPORT_HPP_

--- a/src/rooted_sbn_support.hpp
+++ b/src/rooted_sbn_support.hpp
@@ -46,4 +46,3 @@ class RootedSBNSupport : public SBNSupport {
     return RootedSBNMaps::PCSPCounterOf(topologies);
   }
 };
-

--- a/src/rooted_tree.hpp
+++ b/src/rooted_tree.hpp
@@ -22,8 +22,7 @@
 // n = time difference between this node's height and that of its earliest descendant E
 // d = time difference between the parent's height and that of E.
 
-#ifndef SRC_ROOTED_TREE_HPP_
-#define SRC_ROOTED_TREE_HPP_
+#pragma once
 
 #include "eigen_sugar.hpp"
 #include "tree.hpp"
@@ -158,4 +157,4 @@ TEST_CASE("RootedTree") {
   }
 }
 #endif  // DOCTEST_LIBRARY_INCLUDED
-#endif  // SRC_ROOTED_TREE_HPP_
+

--- a/src/rooted_tree.hpp
+++ b/src/rooted_tree.hpp
@@ -157,4 +157,3 @@ TEST_CASE("RootedTree") {
   }
 }
 #endif  // DOCTEST_LIBRARY_INCLUDED
-

--- a/src/rooted_tree_collection.hpp
+++ b/src/rooted_tree_collection.hpp
@@ -4,8 +4,7 @@
 // A rooted tree collection has a notion of sampling date for the tips of the tree, and
 // all taxa are assumed to share those sampling dates.
 
-#ifndef SRC_ROOTED_TREE_COLLECTION_HPP_
-#define SRC_ROOTED_TREE_COLLECTION_HPP_
+#pragma once
 
 #include "generic_tree_collection.hpp"
 #include "rooted_tree.hpp"
@@ -43,4 +42,3 @@ class RootedTreeCollection : public PreRootedTreeCollection {
 TEST_CASE("RootedTreeCollection") {}
 #endif  // DOCTEST_LIBRARY_INCLUDED
 
-#endif  // SRC_ROOTED_TREE_COLLECTION_HPP_

--- a/src/rooted_tree_collection.hpp
+++ b/src/rooted_tree_collection.hpp
@@ -41,4 +41,3 @@ class RootedTreeCollection : public PreRootedTreeCollection {
 // Test of ParseDatesFromTaxonNames appears in rooted_sbn_instance.hpp.
 TEST_CASE("RootedTreeCollection") {}
 #endif  // DOCTEST_LIBRARY_INCLUDED
-

--- a/src/sbn_maps.hpp
+++ b/src/sbn_maps.hpp
@@ -4,8 +4,7 @@
 // A collection of functions to handle the subsplit support and to turn trees into
 // indexer representations.
 
-#ifndef SRC_SBN_MAPS_HPP_
-#define SRC_SBN_MAPS_HPP_
+#pragma once
 
 #include <unordered_map>
 #include <utility>
@@ -180,4 +179,4 @@ TEST_CASE("SBNMaps") {
 }
 
 #endif  // DOCTEST_LIBRARY_INCLUDED
-#endif  // SRC_SBN_MAPS_HPP_
+

--- a/src/sbn_maps.hpp
+++ b/src/sbn_maps.hpp
@@ -179,4 +179,3 @@ TEST_CASE("SBNMaps") {
 }
 
 #endif  // DOCTEST_LIBRARY_INCLUDED
-

--- a/src/sbn_probability.hpp
+++ b/src/sbn_probability.hpp
@@ -214,4 +214,3 @@ EigenVectorXd ExpectedEMVectorAlpha05() {
 }
 
 #endif  // DOCTEST_LIBRARY_INCLUDED
-

--- a/src/sbn_probability.hpp
+++ b/src/sbn_probability.hpp
@@ -6,8 +6,7 @@
 // We assume that readers are familiar with how the sbn_parameters_ vector is laid out:
 // first probabilities of rootsplits, then conditional probabilities of PCSPs.
 
-#ifndef SRC_SBN_PROBABILITY_HPP_
-#define SRC_SBN_PROBABILITY_HPP_
+#pragma once
 
 #include "eigen_sugar.hpp"
 #include "sbn_maps.hpp"
@@ -215,4 +214,4 @@ EigenVectorXd ExpectedEMVectorAlpha05() {
 }
 
 #endif  // DOCTEST_LIBRARY_INCLUDED
-#endif  // SRC_SBN_PROBABILITY_HPP_
+

--- a/src/sbn_support.hpp
+++ b/src/sbn_support.hpp
@@ -75,4 +75,3 @@ class SBNSupport {
   // convention.
   BitsetSizePairMap parent_to_range_;
 };
-

--- a/src/sbn_support.hpp
+++ b/src/sbn_support.hpp
@@ -13,8 +13,7 @@
 // To learn more about these indexer maps, see the unit tests in rooted_sbn_instance.hpp
 // and unrooted_sbn_instance.hpp.
 
-#ifndef SRC_SBN_SUPPORT_HPP_
-#define SRC_SBN_SUPPORT_HPP_
+#pragma once
 
 #include "psp_indexer.hpp"
 #include "sbn_probability.hpp"
@@ -77,4 +76,3 @@ class SBNSupport {
   BitsetSizePairMap parent_to_range_;
 };
 
-#endif  // SRC_SBN_SUPPORT_HPP_

--- a/src/site_model.hpp
+++ b/src/site_model.hpp
@@ -1,8 +1,7 @@
 // Copyright 2019-2021 bito project contributors.
 // bito is free software under the GPLv3; see LICENSE file for details.
 
-#ifndef SRC_SITE_MODEL_HPP_
-#define SRC_SITE_MODEL_HPP_
+#pragma once
 
 #include <memory>
 #include <numeric>
@@ -108,4 +107,3 @@ TEST_CASE("SiteModel") {
 }
 #endif  // DOCTEST_LIBRARY_INCLUDED
 
-#endif  // SRC_SITE_MODEL_HPP_

--- a/src/site_model.hpp
+++ b/src/site_model.hpp
@@ -106,4 +106,3 @@ TEST_CASE("SiteModel") {
   CHECK_LT(fabs(rates2.dot(proportions) - 1.), 0.0001);
 }
 #endif  // DOCTEST_LIBRARY_INCLUDED
-

--- a/src/site_pattern.hpp
+++ b/src/site_pattern.hpp
@@ -60,4 +60,3 @@ TEST_CASE("SitePattern") {
   CHECK_EQ(symbol_vector, correct_symbol_vector);
 }
 #endif  // DOCTEST_LIBRARY_INCLUDED
-

--- a/src/site_pattern.hpp
+++ b/src/site_pattern.hpp
@@ -3,8 +3,7 @@
 //
 // A class for an alignment that has been compressed into site patterns.
 
-#ifndef SRC_SITE_PATTERN_HPP_
-#define SRC_SITE_PATTERN_HPP_
+#pragma once
 
 #include <string>
 #include <vector>
@@ -61,4 +60,4 @@ TEST_CASE("SitePattern") {
   CHECK_EQ(symbol_vector, correct_symbol_vector);
 }
 #endif  // DOCTEST_LIBRARY_INCLUDED
-#endif  // SRC_SITE_PATTERN_HPP_
+

--- a/src/stick_breaking_transform.hpp
+++ b/src/stick_breaking_transform.hpp
@@ -1,8 +1,7 @@
 // Copyright 2019-2021 bito project contributors.
 // bito is free software under the GPLv3; see LICENSE file for details.
 
-#ifndef SRC_STICK_BREAKING_TRANSFORM_HPP_
-#define SRC_STICK_BREAKING_TRANSFORM_HPP_
+#pragma once
 
 #include "eigen_sugar.hpp"
 
@@ -66,4 +65,3 @@ TEST_CASE("BreakingStickTransform") {
 }
 #endif  // DOCTEST_LIBRARY_INCLUDED
 
-#endif  // SRC_STICK_BREAKING_TRANSFORM_HPP_

--- a/src/stick_breaking_transform.hpp
+++ b/src/stick_breaking_transform.hpp
@@ -64,4 +64,3 @@ TEST_CASE("BreakingStickTransform") {
         doctest::Approx(log_abs_det_jacobian_expected).epsilon(1.e-5));
 }
 #endif  // DOCTEST_LIBRARY_INCLUDED
-

--- a/src/stopwatch.hpp
+++ b/src/stopwatch.hpp
@@ -271,4 +271,3 @@ TEST_CASE("Stopwatch") {
 };
 
 #endif  // DOCTEST_LIBRARY_INCLUDED
-

--- a/src/stopwatch.hpp
+++ b/src/stopwatch.hpp
@@ -11,8 +11,7 @@
 // stopped watch or Start() on a running watch. Clear() removes all memory and stops
 // watch by default, but can optionally restart watch immediatedly.
 
-#ifndef SRC_STOPWATCH_HPP_
-#define SRC_STOPWATCH_HPP_
+#pragma once
 
 // ** Doctest include must go first for all header tests to run.
 #include "doctest.h"
@@ -273,4 +272,3 @@ TEST_CASE("Stopwatch") {
 
 #endif  // DOCTEST_LIBRARY_INCLUDED
 
-#endif  // SRC_STOPWATCH_HPP_

--- a/src/subsplit_dag.hpp
+++ b/src/subsplit_dag.hpp
@@ -326,4 +326,3 @@ class SubsplitDAG {
   void ConnectParentToAllParents(const Bitset &parent_subsplit,
                                  SizeVector &new_edge_idxs);
 };
-

--- a/src/subsplit_dag.hpp
+++ b/src/subsplit_dag.hpp
@@ -31,8 +31,7 @@
 // root node only has rotated children. Children of the DAG root node are called
 // "rootsplits" and partition the whole taxon set.
 
-#ifndef SRC_SUBSPLIT_DAG_HPP_
-#define SRC_SUBSPLIT_DAG_HPP_
+#pragma once
 
 #include "reindexer.hpp"
 #include "rooted_tree_collection.hpp"
@@ -328,4 +327,3 @@ class SubsplitDAG {
                                  SizeVector &new_edge_idxs);
 };
 
-#endif  // SRC_SUBSPLIT_DAG_HPP_

--- a/src/subsplit_dag_action.hpp
+++ b/src/subsplit_dag_action.hpp
@@ -45,4 +45,3 @@ auto TidySubsplitDAGTraversalAction(Args&&... args) {
   };
   return Impl{std::forward<Args>(args)...};
 }
-

--- a/src/subsplit_dag_action.hpp
+++ b/src/subsplit_dag_action.hpp
@@ -3,8 +3,7 @@
 //
 // A class to hold actions that we can perform on the subsplit DAG.
 
-#ifndef SRC_SUBSPLIT_DAG_ACTION_HPP_
-#define SRC_SUBSPLIT_DAG_ACTION_HPP_
+#pragma once
 
 #include <tuple>
 
@@ -47,4 +46,3 @@ auto TidySubsplitDAGTraversalAction(Args&&... args) {
   return Impl{std::forward<Args>(args)...};
 }
 
-#endif  // SRC_SUBSPLIT_DAG_ACTION_HPP_

--- a/src/subsplit_dag_nni.hpp
+++ b/src/subsplit_dag_nni.hpp
@@ -17,8 +17,7 @@
 // parent/child pairs currently in the SubsplitDAG, where the output parent/child pair
 // is not also already in the SubpslitDAG.
 
-#ifndef SRC_SUBSPLIT_DAG_NNI_HPP_
-#define SRC_SUBSPLIT_DAG_NNI_HPP_
+#pragma once
 
 #include "bitset.hpp"
 #include "sugar.hpp"
@@ -148,4 +147,3 @@ TEST_CASE("NNIOperation") {
 
 #endif  // DOCTEST_LIBRARY_INCLUDED
 
-#endif  // SRC_SUBSPLIT_DAG_NNI_HPP_

--- a/src/subsplit_dag_nni.hpp
+++ b/src/subsplit_dag_nni.hpp
@@ -146,4 +146,3 @@ TEST_CASE("NNIOperation") {
 }
 
 #endif  // DOCTEST_LIBRARY_INCLUDED
-

--- a/src/subsplit_dag_node.hpp
+++ b/src/subsplit_dag_node.hpp
@@ -72,4 +72,3 @@ class SubsplitDAGNode {
   SizeVector rootward_rotated_;
   SizeVector rootward_sorted_;
 };
-

--- a/src/subsplit_dag_node.hpp
+++ b/src/subsplit_dag_node.hpp
@@ -13,8 +13,7 @@
 // sorted parents) or if they split apart the left clade of the parent (in which case
 // they are called rotated parents).
 
-#ifndef SRC_SUBSPLIT_DAG_NODE_HPP_
-#define SRC_SUBSPLIT_DAG_NODE_HPP_
+#pragma once
 
 #include "bitset.hpp"
 #include "reindexer.hpp"
@@ -74,4 +73,3 @@ class SubsplitDAGNode {
   SizeVector rootward_sorted_;
 };
 
-#endif  // SRC_SUBSPLIT_DAG_NODE_HPP_

--- a/src/substitution_model.hpp
+++ b/src/substitution_model.hpp
@@ -1,8 +1,8 @@
 // Copyright 2019-2021 bito project contributors.
 // bito is free software under the GPLv3; see LICENSE file for details.
 
-#ifndef SRC_SUBSTITUTION_MODEL_HPP_
-#define SRC_SUBSTITUTION_MODEL_HPP_
+#pragma once
+
 #include <Eigen/Dense>
 #include <memory>
 #include <string>
@@ -168,4 +168,3 @@ TEST_CASE("SubstitutionModel") {
 }
 #endif  // DOCTEST_LIBRARY_INCLUDED
 
-#endif  // SRC_SUBSTITUTION_MODEL_HPP_

--- a/src/substitution_model.hpp
+++ b/src/substitution_model.hpp
@@ -167,4 +167,3 @@ TEST_CASE("SubstitutionModel") {
   CHECK(gtr_model->GetQMatrix().isApprox(hky_model->GetQMatrix()));
 }
 #endif  // DOCTEST_LIBRARY_INCLUDED
-

--- a/src/sugar.hpp
+++ b/src/sugar.hpp
@@ -132,4 +132,3 @@ std::unordered_map<Key, T> UnorderedMapOf(const std::vector<std::pair<Key, T>> &
   }
   return m;
 }
-

--- a/src/sugar.hpp
+++ b/src/sugar.hpp
@@ -1,8 +1,7 @@
 // Copyright 2019-2021 bito project contributors.
 // bito is free software under the GPLv3; see LICENSE file for details.
 
-#ifndef SRC_SUGAR_HPP_
-#define SRC_SUGAR_HPP_
+#pragma once
 
 #include <cassert>
 #include <iostream>
@@ -134,4 +133,3 @@ std::unordered_map<Key, T> UnorderedMapOf(const std::vector<std::pair<Key, T>> &
   return m;
 }
 
-#endif  // SRC_SUGAR_HPP_

--- a/src/task_processor.hpp
+++ b/src/task_processor.hpp
@@ -30,8 +30,7 @@
 // small (put an integer in a dequeue). The overhead of including a true
 // threading library wouldn't be worth it for this example.
 
-#ifndef SRC_TASK_PROCESSOR_HPP_
-#define SRC_TASK_PROCESSOR_HPP_
+#pragma once
 
 #include <condition_variable>
 #include <functional>
@@ -164,4 +163,4 @@ TEST_CASE("TaskProcessor") {
   CHECK_EQ(results, correct_results);
 }
 #endif  // DOCTEST_LIBRARY_INCLUDED
-#endif  // SRC_TASK_PROCESSOR_HPP_
+

--- a/src/task_processor.hpp
+++ b/src/task_processor.hpp
@@ -163,4 +163,3 @@ TEST_CASE("TaskProcessor") {
   CHECK_EQ(results, correct_results);
 }
 #endif  // DOCTEST_LIBRARY_INCLUDED
-

--- a/src/taxon_name_munging.hpp
+++ b/src/taxon_name_munging.hpp
@@ -47,4 +47,3 @@ TEST_CASE("TaxonNameMunging") {
   // Test of TagDateMapOfTagTaxonMap appears in rooted_sbn_instance.hpp.
 }
 #endif  // DOCTEST_LIBRARY_INCLUDED
-

--- a/src/taxon_name_munging.hpp
+++ b/src/taxon_name_munging.hpp
@@ -1,8 +1,7 @@
 // Copyright 2019-2021 bito project contributors.
 // bito is free software under the GPLv3; see LICENSE file for details.
 
-#ifndef SRC_TAXON_NAME_MUNGING_HPP_
-#define SRC_TAXON_NAME_MUNGING_HPP_
+#pragma once
 
 #include <functional>
 
@@ -49,4 +48,3 @@ TEST_CASE("TaxonNameMunging") {
 }
 #endif  // DOCTEST_LIBRARY_INCLUDED
 
-#endif  // SRC_TAXON_NAME_MUNGING_HPP_

--- a/src/tidy_subsplit_dag.hpp
+++ b/src/tidy_subsplit_dag.hpp
@@ -221,4 +221,3 @@ TEST_CASE("TidySubsplitDAG: slicing") {
   // #321 Add test for Tidy traversal.
 }
 #endif  // DOCTEST_LIBRARY_INCLUDED
-

--- a/src/tidy_subsplit_dag.hpp
+++ b/src/tidy_subsplit_dag.hpp
@@ -10,8 +10,7 @@
 // dirty and clean vectors, and updating_below_ as variables. Perhaps these could be
 // part of the Action?
 
-#ifndef SRC_TIDY_SUBSPLIT_DAG_HPP_
-#define SRC_TIDY_SUBSPLIT_DAG_HPP_
+#pragma once
 
 #include "subsplit_dag.hpp"
 
@@ -223,4 +222,3 @@ TEST_CASE("TidySubsplitDAG: slicing") {
 }
 #endif  // DOCTEST_LIBRARY_INCLUDED
 
-#endif  // SRC_TIDY_SUBSPLIT_DAG_HPP_

--- a/src/tree.hpp
+++ b/src/tree.hpp
@@ -1,8 +1,7 @@
 // Copyright 2019-2021 bito project contributors.
 // bito is free software under the GPLv3; see LICENSE file for details.
 
-#ifndef SRC_TREE_HPP_
-#define SRC_TREE_HPP_
+#pragma once
 
 #include <iostream>
 #include <memory>
@@ -64,4 +63,4 @@ inline bool operator!=(const Tree& lhs, const Tree& rhs) { return !(lhs == rhs);
 // Lots of tests in UnrootedTree and RootedTree.
 TEST_CASE("Tree") {}
 #endif  // DOCTEST_LIBRARY_INCLUDED
-#endif  // SRC_TREE_HPP_
+

--- a/src/tree.hpp
+++ b/src/tree.hpp
@@ -63,4 +63,3 @@ inline bool operator!=(const Tree& lhs, const Tree& rhs) { return !(lhs == rhs);
 // Lots of tests in UnrootedTree and RootedTree.
 TEST_CASE("Tree") {}
 #endif  // DOCTEST_LIBRARY_INCLUDED
-

--- a/src/tree_collection.hpp
+++ b/src/tree_collection.hpp
@@ -1,8 +1,7 @@
 // Copyright 2019-2021 bito project contributors.
 // bito is free software under the GPLv3; see LICENSE file for details.
 
-#ifndef SRC_TREE_COLLECTION_HPP_
-#define SRC_TREE_COLLECTION_HPP_
+#pragma once
 
 #include "generic_tree_collection.hpp"
 #include "tree.hpp"
@@ -32,4 +31,3 @@ TEST_CASE("TreeCollection") {
 }
 #endif  // DOCTEST_LIBRARY_INCLUDED
 
-#endif  // SRC_TREE_COLLECTION_HPP_

--- a/src/tree_collection.hpp
+++ b/src/tree_collection.hpp
@@ -30,4 +30,3 @@ TEST_CASE("TreeCollection") {
   CHECK_EQ(collection.TreeCount(), 0);
 }
 #endif  // DOCTEST_LIBRARY_INCLUDED
-

--- a/src/tree_gradient.hpp
+++ b/src/tree_gradient.hpp
@@ -16,4 +16,3 @@ struct PhyloGradient {
   double log_likelihood_;
   GradientMap gradient_;
 };
-

--- a/src/tree_gradient.hpp
+++ b/src/tree_gradient.hpp
@@ -1,8 +1,7 @@
 // Copyright 2019-2021 bito project contributors.
 // bito is free software under the GPLv3; see LICENSE file for details.
 
-#ifndef SRC_TREE_GRADIENT_HPP_
-#define SRC_TREE_GRADIENT_HPP_
+#pragma once
 
 #include <map>
 #include <vector>
@@ -18,4 +17,3 @@ struct PhyloGradient {
   GradientMap gradient_;
 };
 
-#endif  // SRC_TREE_GRADIENT_HPP_

--- a/src/unrooted_sbn_instance.hpp
+++ b/src/unrooted_sbn_instance.hpp
@@ -599,4 +599,3 @@ TEST_CASE("UnrootedSBNInstance: gradient of log q_{phi}(tau) WRT phi") {
   CheckVectorXdEquality(realized_nabla, expected_nabla, 1e-8);
 }
 #endif  // DOCTEST_LIBRARY_INCLUDED
-

--- a/src/unrooted_sbn_instance.hpp
+++ b/src/unrooted_sbn_instance.hpp
@@ -1,8 +1,7 @@
 // Copyright 2019-2021 bito project contributors.
 // bito is free software under the GPLv3; see LICENSE file for details.
 
-#ifndef SRC_UNROOTED_SBN_INSTANCE_HPP_
-#define SRC_UNROOTED_SBN_INSTANCE_HPP_
+#pragma once
 
 #include "generic_sbn_instance.hpp"
 #include "unrooted_sbn_support.hpp"
@@ -600,4 +599,4 @@ TEST_CASE("UnrootedSBNInstance: gradient of log q_{phi}(tau) WRT phi") {
   CheckVectorXdEquality(realized_nabla, expected_nabla, 1e-8);
 }
 #endif  // DOCTEST_LIBRARY_INCLUDED
-#endif  // SRC_UNROOTED_SBN_INSTANCE_HPP_
+

--- a/src/unrooted_sbn_support.hpp
+++ b/src/unrooted_sbn_support.hpp
@@ -1,8 +1,7 @@
 // Copyright 2019-2021 bito project contributors.
 // bito is free software under the GPLv3; see LICENSE file for details.
 
-#ifndef SRC_UNROOTED_SBN_SUPPORT_HPP_
-#define SRC_UNROOTED_SBN_SUPPORT_HPP_
+#pragma once
 
 #include "sbn_maps.hpp"
 #include "sbn_support.hpp"
@@ -49,4 +48,3 @@ class UnrootedSBNSupport : public SBNSupport {
   }
 };
 
-#endif  // SRC_UNROOTED_SBN_SUPPORT_HPP_

--- a/src/unrooted_sbn_support.hpp
+++ b/src/unrooted_sbn_support.hpp
@@ -47,4 +47,3 @@ class UnrootedSBNSupport : public SBNSupport {
     return UnrootedSBNMaps::PCSPCounterOf(topologies);
   }
 };
-

--- a/src/unrooted_tree.hpp
+++ b/src/unrooted_tree.hpp
@@ -1,8 +1,7 @@
 // Copyright 2019-2021 bito project contributors.
 // bito is free software under the GPLv3; see LICENSE file for details.
 
-#ifndef SRC_UNROOTED_TREE_HPP_
-#define SRC_UNROOTED_TREE_HPP_
+#pragma once
 
 #include <vector>
 
@@ -51,4 +50,4 @@ TEST_CASE("UnrootedTree") {
                   std::runtime_error&);
 }
 #endif  // DOCTEST_LIBRARY_INCLUDED
-#endif  // SRC_UNROOTED_TREE_HPP_
+

--- a/src/unrooted_tree.hpp
+++ b/src/unrooted_tree.hpp
@@ -50,4 +50,3 @@ TEST_CASE("UnrootedTree") {
                   std::runtime_error&);
 }
 #endif  // DOCTEST_LIBRARY_INCLUDED
-

--- a/src/unrooted_tree_collection.hpp
+++ b/src/unrooted_tree_collection.hpp
@@ -1,8 +1,7 @@
 // Copyright 2019-2021 bito project contributors.
 // bito is free software under the GPLv3; see LICENSE file for details.
 
-#ifndef SRC_UNROOTED_TREE_COLLECTION_HPP_
-#define SRC_UNROOTED_TREE_COLLECTION_HPP_
+#pragma once
 
 #include "tree_collection.hpp"
 #include "unrooted_tree.hpp"
@@ -21,4 +20,3 @@ class UnrootedTreeCollection : public PreUnrootedTreeCollection {
 TEST_CASE("UnrootedTreeCollection") {}
 #endif  // DOCTEST_LIBRARY_INCLUDED
 
-#endif  // SRC_UNROOTED_TREE_COLLECTION_HPP_

--- a/src/unrooted_tree_collection.hpp
+++ b/src/unrooted_tree_collection.hpp
@@ -19,4 +19,3 @@ class UnrootedTreeCollection : public PreUnrootedTreeCollection {
 #ifdef DOCTEST_LIBRARY_INCLUDED
 TEST_CASE("UnrootedTreeCollection") {}
 #endif  // DOCTEST_LIBRARY_INCLUDED
-

--- a/src/zlib_stream.hpp
+++ b/src/zlib_stream.hpp
@@ -3,8 +3,7 @@
 //
 // Interface to the zlib compression library
 
-#ifndef SRC_ZLIB_STREAM_HPP_
-#define SRC_ZLIB_STREAM_HPP_
+#pragma once
 
 #include <zlib.h>
 
@@ -117,4 +116,3 @@ class ZStringBuf : public std::stringbuf {
 
 }  // namespace zlib
 
-#endif  // SRC_ZLIB_STREAM_HPP_

--- a/src/zlib_stream.hpp
+++ b/src/zlib_stream.hpp
@@ -115,4 +115,3 @@ class ZStringBuf : public std::stringbuf {
 };
 
 }  // namespace zlib
-


### PR DESCRIPTION
## Description

Switched to using #pragma once instead of header guards

Closes #374 

## Tests

NA


## Checklist:

* [x] Code follows our detailed [contribution guidelines](CONTRIBUTING.md)
* [x] `clang-format` has been run
* [x] TODOs have been eliminated from the code
* [x] Comments are up to date, document intent, and there are no commented-out code blocks
