### PR TITLE
Rename & Refactor of DAG Elements

### DIFF
--- a/src/alignment.hpp
+++ b/src/alignment.hpp
@@ -12,17 +12,21 @@ class Alignment {
  public:
   Alignment() = default;
   explicit Alignment(StringStringMap data) : data_(std::move(data)) {}
-
+  // Return map of taxon names to sequence alignments.
   StringStringMap Data() const { return data_; }
+  // Number of taxon sequences in data map.
   size_t SequenceCount() const { return data_.size(); }
+  // The length of the sequence alignments.
   size_t Length() const;
+  // Compare if alignments have same name and sequence data.
   bool operator==(const Alignment& other) const { return data_ == other.Data(); }
-
   // Is the alignment non-empty and do all sequences have the same length?
   bool IsValid() const;
+  // Get alignment sequence by taxon name.
   const std::string& at(const std::string& taxon) const;
-
+  // Load fasta file into Alignment.
   static Alignment ReadFasta(const std::string& fname);
+  // Create a new alignment
   Alignment ExtractSingleColumnAlignment(size_t which_column) const;
 
   static Alignment HelloAlignment() {
@@ -32,6 +36,7 @@ class Alignment {
   }
 
  private:
+  // - Map of alignments: [ taxon name -> alignment sequence ]
   StringStringMap data_;
 };
 

--- a/src/bitset.cpp
+++ b/src/bitset.cpp
@@ -261,9 +261,9 @@ int Bitset::CladeCompare(const Bitset& bitset_a, const Bitset& bitset_b) {
   return (-1 * Bitset::Compare(bitset_a, bitset_b));
 }
 
-int Bitset::CladeCompare(const Bitset& bitset_b) const {
-  const Bitset& bitset_a = *this;
-  return CladeCompare(bitset_a, bitset_b);
+int Bitset::CladeCompare(const Bitset& other) const {
+  const Bitset& bitset = *this;
+  return CladeCompare(bitset, other);
 }
 
 size_t Bitset::MultiCladeGetCladeSize(const size_t clade_count) const {
@@ -348,15 +348,15 @@ int Bitset::SubsplitCompare(const Bitset& subsplit_b) const {
 
 Bitset Bitset::SubsplitRotate() const {
   Assert(size() % 2 == 0, "Bitset::SubsplitRotate requires an even-size bitset.");
-  Bitset clade_0 = SubsplitGetClade(Bitset::SubsplitClade::LEFT);
-  Bitset clade_1 = SubsplitGetClade(Bitset::SubsplitClade::RIGHT);
+  Bitset clade_0 = SubsplitGetClade(Bitset::SubsplitClade::Left);
+  Bitset clade_1 = SubsplitGetClade(Bitset::SubsplitClade::Right);
   return clade_1 + clade_0;
 }
 
 Bitset Bitset::SubsplitSortClades() const {
   Assert(size() % 2 == 0, "Bitset::SubsplitRotate requires an even-size bitset.");
-  Bitset clade_0 = SubsplitGetClade(Bitset::SubsplitClade::LEFT);
-  Bitset clade_1 = SubsplitGetClade(Bitset::SubsplitClade::RIGHT);
+  Bitset clade_0 = SubsplitGetClade(Bitset::SubsplitClade::Left);
+  Bitset clade_1 = SubsplitGetClade(Bitset::SubsplitClade::Right);
   return SubsplitFromUnorderedClades(clade_0, clade_1);
 }
 
@@ -364,9 +364,9 @@ std::string Bitset::SubsplitToString() const { return MultiCladeToString(2); }
 
 std::string Bitset::SubsplitToVectorOfSetBitsAsString() const {
   std::string str;
-  str += SubsplitGetClade(Bitset::SubsplitClade::LEFT).ToVectorOfSetBitsAsString();
+  str += SubsplitGetClade(Bitset::SubsplitClade::Left).ToVectorOfSetBitsAsString();
   str += "|";
-  str += SubsplitGetClade(Bitset::SubsplitClade::RIGHT).ToVectorOfSetBitsAsString();
+  str += SubsplitGetClade(Bitset::SubsplitClade::Right).ToVectorOfSetBitsAsString();
   return str;
 }
 
@@ -387,8 +387,8 @@ Bitset Bitset::SubsplitGetClade(const SubsplitClade which_clade) const {
 bool Bitset::SubsplitIsLeaf() const {
   // A subsplit is a leaf if left clade has a
   bool is_left_clade_singleton =
-      SubsplitGetClade(Bitset::SubsplitClade::LEFT).IsSingleton();
-  bool is_right_clade_empty = SubsplitGetClade(Bitset::SubsplitClade::RIGHT).None();
+      SubsplitGetClade(Bitset::SubsplitClade::Left).IsSingleton();
+  bool is_right_clade_empty = SubsplitGetClade(Bitset::SubsplitClade::Right).None();
   return is_left_clade_singleton && is_right_clade_empty;
 }
 
@@ -396,7 +396,7 @@ bool Bitset::SubsplitIsRoot() const {
   // A subsplit is a root if the left clade contains all taxons and the right clade
   // contains no taxons. If subsplit is valid, then we can assume the right clade is
   // empty.
-  bool is_left_clade_full = SubsplitGetClade(Bitset::SubsplitClade::LEFT).All();
+  bool is_left_clade_full = SubsplitGetClade(Bitset::SubsplitClade::Left).All();
   return is_left_clade_full;
 }
 
@@ -404,27 +404,27 @@ bool Bitset::SubsplitIsRootsplit() const {
   // A subsplit is a rootsplit if the union of the clades contain all clades.
   // But is also not the root, meaning both clades are nonempty.
   bool is_union_of_clades_full = SubsplitCladeUnion().All();
-  bool is_left_clade_nonempty = !SubsplitGetClade(Bitset::SubsplitClade::LEFT).None();
-  bool is_right_clade_nonempty = !SubsplitGetClade(Bitset::SubsplitClade::RIGHT).None();
+  bool is_left_clade_nonempty = !SubsplitGetClade(Bitset::SubsplitClade::Left).None();
+  bool is_right_clade_nonempty = !SubsplitGetClade(Bitset::SubsplitClade::Right).None();
   return is_union_of_clades_full && is_left_clade_nonempty && is_right_clade_nonempty;
 }
 
 bool Bitset::SubsplitIsLeftChildOf(const Bitset& parent) const {
   return (size() == parent.size()) &&
-         (SubsplitCladeUnion() == parent.SubsplitGetClade(Bitset::SubsplitClade::LEFT));
+         (SubsplitCladeUnion() == parent.SubsplitGetClade(Bitset::SubsplitClade::Left));
 }
 
 bool Bitset::SubsplitIsRightChildOf(const Bitset& parent) const {
   return (size() == parent.size()) &&
          (SubsplitCladeUnion() ==
-          parent.SubsplitGetClade(Bitset::SubsplitClade::RIGHT));
+          parent.SubsplitGetClade(Bitset::SubsplitClade::Right));
 }
 
 Bitset Bitset::SubsplitCladeUnion() const {
   Assert(size() % SubsplitCladeCount == 0,
          "Size isn't 0 mod 2 in Bitset::SubsplitCladeUnion.");
-  return SubsplitGetClade(Bitset::SubsplitClade::LEFT) |
-         SubsplitGetClade(Bitset::SubsplitClade::RIGHT);
+  return SubsplitGetClade(Bitset::SubsplitClade::Left) |
+         SubsplitGetClade(Bitset::SubsplitClade::Right);
 }
 
 bool Bitset::SubsplitIsWhichChildOf(const Bitset& parent, const Bitset& child) {
@@ -451,8 +451,8 @@ bool Bitset::SubsplitIsAdjacent(const Bitset& subsplit_a, const Bitset& subsplit
 }
 
 bool Bitset::SubsplitIsValid() const {
-  return SubsplitGetClade(Bitset::SubsplitClade::LEFT)
-      .IsDisjoint(SubsplitGetClade(Bitset::SubsplitClade::RIGHT));
+  return SubsplitGetClade(Bitset::SubsplitClade::Left)
+      .IsDisjoint(SubsplitGetClade(Bitset::SubsplitClade::Right));
 }
 
 // ** Edge functions
@@ -470,10 +470,10 @@ Bitset Bitset::Edge(const Bitset& parent_subsplit, const Bitset& child_subsplit)
 
   if (child_subsplit.SubsplitIsLeftChildOf(parent_subsplit)) {
     return parent_subsplit.SubsplitRotate() +
-           child_subsplit.SubsplitGetClade(Bitset::SubsplitClade::RIGHT);
+           child_subsplit.SubsplitGetClade(Bitset::SubsplitClade::Right);
   } else {
     return parent_subsplit +
-           child_subsplit.SubsplitGetClade(Bitset::SubsplitClade::RIGHT);
+           child_subsplit.SubsplitGetClade(Bitset::SubsplitClade::Right);
   }
 }
 
@@ -498,34 +498,34 @@ Bitset Bitset::EdgeGetClade(const size_t which_clade) const {
   return MultiCladeGetClade(which_clade, 3);
 }
 
-Bitset Bitset::EdgeGetClade(const EdgeClade which_clade) const {
+Bitset Bitset::EdgeGetClade(const PCSPClade which_clade) const {
   size_t which_clade_idx =
-      static_cast<std::underlying_type<EdgeClade>::type>(which_clade);
+      static_cast<std::underlying_type<PCSPClade>::type>(which_clade);
   return MultiCladeGetClade(which_clade_idx, 3);
 }
 
 Bitset Bitset::EdgeGetParentSubsplit() const {
-  Bitset sister = EdgeGetClade(Bitset::EdgeClade::SISTER);
-  Bitset focal = EdgeGetClade(Bitset::EdgeClade::FOCAL);
+  Bitset sister = EdgeGetClade(Bitset::PCSPClade::Sister);
+  Bitset focal = EdgeGetClade(Bitset::PCSPClade::Focal);
   return Bitset::Subsplit(sister, focal);
 }
 
 Bitset Bitset::EdgeGetChildSubsplit() const {
-  Bitset focal = EdgeGetClade(Bitset::EdgeClade::FOCAL);
-  Bitset child_0 = EdgeGetClade(Bitset::EdgeClade::LEFT_CHILD);
+  Bitset focal = EdgeGetClade(Bitset::PCSPClade::Focal);
+  Bitset child_0 = EdgeGetClade(Bitset::PCSPClade::LeftChild);
   Bitset child_1 = focal & ~child_0;
   return Bitset::Subsplit(child_0, child_1);
 }
 
-std::string Bitset::EdgeToString() const { return MultiCladeToString(EdgeCladeCount); }
+std::string Bitset::EdgeToString() const { return MultiCladeToString(PCSPCladeCount); }
 
 bool Bitset::EdgeIsValid() const {
-  if (size() % EdgeCladeCount != 0) {
+  if (size() % PCSPCladeCount != 0) {
     return false;
   }
-  Bitset sister = EdgeGetClade(Bitset::EdgeClade::SISTER);
-  Bitset focal = EdgeGetClade(Bitset::EdgeClade::FOCAL);
-  Bitset child_0 = EdgeGetClade(Bitset::EdgeClade::LEFT_CHILD);
+  Bitset sister = EdgeGetClade(Bitset::PCSPClade::Sister);
+  Bitset focal = EdgeGetClade(Bitset::PCSPClade::Focal);
+  Bitset child_0 = EdgeGetClade(Bitset::PCSPClade::LeftChild);
   // The parent clades should be disjoint.
   if (!sister.IsDisjoint(focal)) {
     return false;
@@ -543,10 +543,10 @@ bool Bitset::EdgeIsValid() const {
 }
 
 bool Bitset::EdgeIsLeaf() const {
-  Assert(size() % EdgeCladeCount == 0, "Size isn't 0 mod 3 in Bitset::EdgeIsLeaf.");
+  Assert(size() % PCSPCladeCount == 0, "Size isn't 0 mod 3 in Bitset::EdgeIsLeaf.");
   // If third clade of Edge is empty, that means that the associated clade's sorted
   // subsplit is empty, so it is leaf.
-  return EdgeGetClade(Bitset::EdgeClade::LEFT_CHILD).None();
+  return EdgeGetClade(Bitset::PCSPClade::LeftChild).None();
 }
 
 Bitset Bitset::EdgeSortClades() const {
@@ -556,7 +556,7 @@ Bitset Bitset::EdgeSortClades() const {
 }
 
 bool Bitset::EdgeIsParentRootsplit() const {
-  Assert(size() % EdgeCladeCount == 0,
+  Assert(size() % PCSPCladeCount == 0,
          "Size isn't 0 mod 3 in Bitset::EdgeIsRootsplit.");
   return EdgeGetParentSubsplit().SubsplitIsRootsplit();
 }
@@ -591,9 +591,9 @@ Bitset Bitset::LeafSubsplitOfNonemptyClade(const Bitset& nonempty_clade) {
 void AssertSubsplitIsLeafAdjacent(const Bitset& subsplit) {
   // For subsplit to be adjacent to
   bool is_left_clade_nonempty =
-      subsplit.SubsplitGetClade(Bitset::SubsplitClade::LEFT).Any();
+      subsplit.SubsplitGetClade(Bitset::SubsplitClade::Left).Any();
   bool is_right_clade_singleton =
-      subsplit.SubsplitGetClade(Bitset::SubsplitClade::RIGHT).IsSingleton();
+      subsplit.SubsplitGetClade(Bitset::SubsplitClade::Right).IsSingleton();
   Assert(is_left_clade_nonempty && is_right_clade_singleton,
          "Assertion SisterAndLeafSubsplit failed: we want the left-hand clade of the "
          "subsplit be "
@@ -605,7 +605,7 @@ Bitset Bitset::LeafSubsplitOfParentSubsplit(const Bitset& parent_subsplit) {
   // Put the right-hand clade of the subsplit as the nonzero contents of the leaf
   // subsplit.
   return LeafSubsplitOfNonemptyClade(
-      parent_subsplit.SubsplitGetClade(Bitset::SubsplitClade::RIGHT));
+      parent_subsplit.SubsplitGetClade(Bitset::SubsplitClade::Right));
 }
 
 Bitset Bitset::EdgeToLeaf(const Bitset& parent_subsplit) {
@@ -617,7 +617,7 @@ Bitset Bitset::EdgeToLeaf(const Bitset& parent_subsplit) {
   return leaf;
 }
 
-Bitset Bitset::RootSubsplitOfTaxonCount(const size_t taxon_count) {
+Bitset Bitset::UCASubsplitOfTaxonCount(const size_t taxon_count) {
   Bitset zeros(taxon_count);
   return ~zeros + zeros;
 }
@@ -631,7 +631,7 @@ Bitset Bitset::RootsplitOfClade(const Bitset& clade) {
 Bitset Bitset::EdgeToRootsplit(const Bitset& rootsplit) {
   Assert(rootsplit.SubsplitIsRootsplit(),
          "Given subsplit is not rootsplit in Bitset::EdgeToRootsplit.");
-  return Edge(RootSubsplitOfTaxonCount(rootsplit.size() / 2), rootsplit);
+  return Edge(UCASubsplitOfTaxonCount(rootsplit.size() / 2), rootsplit);
 }
 
 Bitset Bitset::Remap(const Bitset& bitset, const SizeOptionVector& idx_table) {

--- a/src/bitset.cpp
+++ b/src/bitset.cpp
@@ -392,9 +392,9 @@ bool Bitset::SubsplitIsLeaf() const {
   return is_left_clade_singleton && is_right_clade_empty;
 }
 
-bool Bitset::SubsplitIsRoot() const {
-  // A subsplit is a root if the left clade contains all taxons and the right clade
-  // contains no taxons. If subsplit is valid, then we can assume the right clade is
+bool Bitset::SubsplitIsUCA() const {
+  // A subsplit is a root if the left clade contains all taxa and the right clade
+  // contains no taxa. If subsplit is valid, then we can assume the right clade is
   // empty.
   bool is_left_clade_full = SubsplitGetClade(Bitset::SubsplitClade::Left).All();
   return is_left_clade_full;

--- a/src/bitset.cpp
+++ b/src/bitset.cpp
@@ -261,14 +261,14 @@ int Bitset::CladeCompare(const Bitset& bitset_a, const Bitset& bitset_b) {
   return (-1 * Bitset::Compare(bitset_a, bitset_b));
 }
 
-int Bitset::CladeCompare(const Bitset& that_bitset) const {
-  const Bitset& this_bitset = *this;
-  return CladeCompare(this_bitset, that_bitset);
+int Bitset::CladeCompare(const Bitset& bitset_b) const {
+  const Bitset& bitset_a = *this;
+  return CladeCompare(bitset_a, bitset_b);
 }
 
 size_t Bitset::MultiCladeGetCladeSize(const size_t clade_count) const {
   Assert(size() % clade_count == 0,
-         "Bitset::MultiCladeGetCladeSize: Size isn't evenly divisible by clade_count.");
+         "Bitset::MultiCladeGetCladeSize: size isn't evenly divisible by clade_count.");
   return size() / clade_count;
 }
 
@@ -283,9 +283,7 @@ Bitset Bitset::MultiCladeGetClade(const size_t i, const size_t clade_count) cons
 }
 
 std::string Bitset::MultiCladeToString(const size_t clade_count) const {
-  Assert(size() % clade_count == 0,
-         "Size isn't a multiple of clade_count in Bitset::MultiCladeToString.");
-  size_t clade_size = size() / clade_count;
+  size_t clade_size = MultiCladeGetCladeSize(clade_count);
   std::string str;
   for (size_t i = 0; i < value_.size(); ++i) {
     str += (value_[i] ? '1' : '0');
@@ -350,15 +348,15 @@ int Bitset::SubsplitCompare(const Bitset& subsplit_b) const {
 
 Bitset Bitset::SubsplitRotate() const {
   Assert(size() % 2 == 0, "Bitset::SubsplitRotate requires an even-size bitset.");
-  Bitset clade_0 = SubsplitGetClade(0);
-  Bitset clade_1 = SubsplitGetClade(1);
+  Bitset clade_0 = SubsplitGetClade(Bitset::SubsplitClade::LEFT);
+  Bitset clade_1 = SubsplitGetClade(Bitset::SubsplitClade::RIGHT);
   return clade_1 + clade_0;
 }
 
-Bitset Bitset::SubsplitSort() const {
+Bitset Bitset::SubsplitSortClades() const {
   Assert(size() % 2 == 0, "Bitset::SubsplitRotate requires an even-size bitset.");
-  Bitset clade_0 = SubsplitGetClade(0);
-  Bitset clade_1 = SubsplitGetClade(1);
+  Bitset clade_0 = SubsplitGetClade(Bitset::SubsplitClade::LEFT);
+  Bitset clade_1 = SubsplitGetClade(Bitset::SubsplitClade::RIGHT);
   return SubsplitFromUnorderedClades(clade_0, clade_1);
 }
 
@@ -366,62 +364,76 @@ std::string Bitset::SubsplitToString() const { return MultiCladeToString(2); }
 
 std::string Bitset::SubsplitToVectorOfSetBitsAsString() const {
   std::string str;
-  str += SubsplitGetClade(0).ToVectorOfSetBitsAsString();
+  str += SubsplitGetClade(Bitset::SubsplitClade::LEFT).ToVectorOfSetBitsAsString();
   str += "|";
-  str += SubsplitGetClade(1).ToVectorOfSetBitsAsString();
+  str += SubsplitGetClade(Bitset::SubsplitClade::RIGHT).ToVectorOfSetBitsAsString();
   return str;
 }
 
-size_t Bitset::SubsplitGetCladeSize() const { return MultiCladeGetCladeSize(2); }
+size_t Bitset::SubsplitGetCladeSize() const {
+  return MultiCladeGetCladeSize(SubsplitCladeCount);
+}
 
-Bitset Bitset::SubsplitGetClade(size_t i) const { return MultiCladeGetClade(i, 2); }
+Bitset Bitset::SubsplitGetClade(const size_t which_clade) const {
+  return MultiCladeGetClade(which_clade, SubsplitCladeCount);
+}
 
-Bitset Bitset::SubsplitGetCladeByBinaryOrder(size_t i) const {
-  Assert(i < 2, "SubsplitGetClade index too large.");
-  // The clades appear in taxon ordering (opposite of binary ordering); see "Clade
-  // Methods" in header file for details.
-  Bitset clade_0 = SubsplitGetClade(1);
-  Bitset clade_1 = SubsplitGetClade(0);
-  Assert(clade_1 > clade_0,
-         "Bitset::SubsplitGetClade: Subsplit clade_1 should be larger than clade_0 (in "
-         "binary rep).");
-  return i == 0 ? clade_0 : clade_1;
+Bitset Bitset::SubsplitGetClade(const SubsplitClade which_clade) const {
+  size_t which_clade_idx =
+      static_cast<std::underlying_type<SubsplitClade>::type>(which_clade);
+  return MultiCladeGetClade(which_clade_idx, SubsplitCladeCount);
 }
 
 bool Bitset::SubsplitIsLeaf() const {
-  return SubsplitGetClade(0).IsSingleton() && SubsplitGetClade(1).None();
+  // A subsplit is a leaf if left clade has a
+  bool is_left_clade_singleton =
+      SubsplitGetClade(Bitset::SubsplitClade::LEFT).IsSingleton();
+  bool is_right_clade_empty = SubsplitGetClade(Bitset::SubsplitClade::RIGHT).None();
+  return is_left_clade_singleton && is_right_clade_empty;
 }
 
-bool Bitset::SubsplitIsRoot() const { return SubsplitGetClade(0).All(); }
+bool Bitset::SubsplitIsRoot() const {
+  // A subsplit is a root if the left clade contains all taxons and the right clade
+  // contains no taxons. If subsplit is valid, then we can assume the right clade is
+  // empty.
+  bool is_left_clade_full = SubsplitGetClade(Bitset::SubsplitClade::LEFT).All();
+  return is_left_clade_full;
+}
 
 bool Bitset::SubsplitIsRootsplit() const {
-  return SubsplitCladeUnion().All() &&
-         SubsplitGetClade(0).IsDisjoint(SubsplitGetClade(1)) &&
-         !SubsplitGetClade(0).All();
+  // A subsplit is a rootsplit if the union of the clades contain all clades.
+  // But is also not the root, meaning both clades are nonempty.
+  bool is_union_of_clades_full = SubsplitCladeUnion().All();
+  bool is_left_clade_nonempty = !SubsplitGetClade(Bitset::SubsplitClade::LEFT).None();
+  bool is_right_clade_nonempty = !SubsplitGetClade(Bitset::SubsplitClade::RIGHT).None();
+  return is_union_of_clades_full && is_left_clade_nonempty && is_right_clade_nonempty;
 }
 
-bool Bitset::SubsplitIsRotatedChildOf(const Bitset& other) const {
-  return (size() == other.size()) &&
-         (SubsplitCladeUnion() == other.SubsplitGetClade(0));
+bool Bitset::SubsplitIsLeftChildOf(const Bitset& parent) const {
+  return (size() == parent.size()) &&
+         (SubsplitCladeUnion() == parent.SubsplitGetClade(Bitset::SubsplitClade::LEFT));
 }
 
-bool Bitset::SubsplitIsSortedChildOf(const Bitset& other) const {
-  return (size() == other.size()) &&
-         (SubsplitCladeUnion() == other.SubsplitGetClade(1));
+bool Bitset::SubsplitIsRightChildOf(const Bitset& parent) const {
+  return (size() == parent.size()) &&
+         (SubsplitCladeUnion() ==
+          parent.SubsplitGetClade(Bitset::SubsplitClade::RIGHT));
 }
 
 Bitset Bitset::SubsplitCladeUnion() const {
-  Assert(size() % 2 == 0, "Size isn't 0 mod 2 in Bitset::SubsplitCladeUnion.");
-  return SubsplitGetClade(0) | SubsplitGetClade(1);
+  Assert(size() % SubsplitCladeCount == 0,
+         "Size isn't 0 mod 2 in Bitset::SubsplitCladeUnion.");
+  return SubsplitGetClade(Bitset::SubsplitClade::LEFT) |
+         SubsplitGetClade(Bitset::SubsplitClade::RIGHT);
 }
 
 bool Bitset::SubsplitIsWhichChildOf(const Bitset& parent, const Bitset& child) {
   Assert(parent.size() == child.size(),
          "Bitset::SubsplitIsWhichChildOf() bitsets are different sizes.");
   Bitset child_union = child.SubsplitCladeUnion();
-  for (bool is_rotated : {false, true}) {
-    if (child_union == parent.SubsplitGetClade(is_rotated)) {
-      return is_rotated;
+  for (bool clade : {0, 1}) {
+    if (child_union == parent.SubsplitGetClade(clade)) {
+      return clade;
     }
   }
   // If it reaches the end, then it is not a parent.
@@ -429,69 +441,91 @@ bool Bitset::SubsplitIsWhichChildOf(const Bitset& parent, const Bitset& child) {
       "Bitset::SubsplitIsWhichChildOf(): given parent is not a parent of given child.");
 }
 
+bool Bitset::SubsplitIsParentChildPair(const Bitset& parent, const Bitset& child) {
+  return child.SubsplitIsLeftChildOf(parent) || child.SubsplitIsRightChildOf(parent);
+}
+
+bool Bitset::SubsplitIsAdjacent(const Bitset& subsplit_a, const Bitset& subsplit_b) {
+  return SubsplitIsParentChildPair(subsplit_a, subsplit_b) ||
+         SubsplitIsParentChildPair(subsplit_b, subsplit_a);
+}
+
 bool Bitset::SubsplitIsValid() const {
-  return SubsplitGetClade(0).IsDisjoint(SubsplitGetClade(1));
+  return SubsplitGetClade(Bitset::SubsplitClade::LEFT)
+      .IsDisjoint(SubsplitGetClade(Bitset::SubsplitClade::RIGHT));
 }
 
-// ** PCSP functions
+// ** Edge functions
 
-Bitset Bitset::PCSP(const Bitset& parent_subsplit, const Bitset& child_subsplit) {
-  Assert((child_subsplit.SubsplitIsRotatedChildOf(parent_subsplit) ||
-          child_subsplit.SubsplitIsSortedChildOf(parent_subsplit)) &&
-             child_subsplit.SubsplitGetClade(0).IsDisjoint(
-                 child_subsplit.SubsplitGetClade(1)),
-         "PCSP(): given bitsets are not a valid parent/child pair.");
-  Bitset pcsp(3 * parent_subsplit.size() / 2);
-  pcsp.CopyFrom((child_subsplit.SubsplitIsRotatedChildOf(parent_subsplit)
-                     ? parent_subsplit.SubsplitRotate()
-                     : parent_subsplit),
-                0, false);
-  pcsp.CopyFrom(child_subsplit.SubsplitGetCladeByBinaryOrder(0), parent_subsplit.size(),
-                false);
-  return pcsp;
+Bitset Bitset::Edge(const Bitset& parent_subsplit, const Bitset& child_subsplit) {
+  // Assert that:
+  // - child_subsplit is either a sorted or rotated child of parent_subsplit.
+  // - child_subsplit forms a valid subsplit.
+  bool is_parent_valid = parent_subsplit.SubsplitIsValid();
+  bool is_child_valid = child_subsplit.SubsplitIsValid();
+  bool is_pair_valid = child_subsplit.SubsplitIsLeftChildOf(parent_subsplit) ||
+                       child_subsplit.SubsplitIsRightChildOf(parent_subsplit);
+  Assert(is_parent_valid && is_child_valid && is_pair_valid,
+         "Edge(): given bitsets are not a valid parent/child pair.");
+
+  if (child_subsplit.SubsplitIsLeftChildOf(parent_subsplit)) {
+    return parent_subsplit.SubsplitRotate() +
+           child_subsplit.SubsplitGetClade(Bitset::SubsplitClade::RIGHT);
+  } else {
+    return parent_subsplit +
+           child_subsplit.SubsplitGetClade(Bitset::SubsplitClade::RIGHT);
+  }
 }
 
-Bitset Bitset::PCSP(const Bitset& sister_clade, const Bitset& focal_clade,
+Bitset Bitset::Edge(const Bitset& sister_clade, const Bitset& focal_clade,
                     const Bitset& sorted_child_clade) {
   Assert(sister_clade.size() == focal_clade.size() &&
              focal_clade.size() == sorted_child_clade.size(),
-         "PCSP(): all clades must be of equal size.");
+         "Edge(): all clades must be of equal size.");
   Bitset pcsp = sister_clade + focal_clade + sorted_child_clade;
-  Assert(pcsp.PCSPIsValid(), "PCSP(): given clades form an invalid PCSP.");
+  Assert(pcsp.EdgeIsValid(), "Edge(): given clades form an invalid Edge.");
   return pcsp;
 }
 
-Bitset Bitset::PCSP(const std::string sister_clade, const std::string focal_clade,
+Bitset Bitset::Edge(const std::string sister_clade, const std::string focal_clade,
                     const std::string sorted_child_clade) {
-  return PCSP(Bitset(sister_clade), Bitset(focal_clade), Bitset(sorted_child_clade));
+  return Edge(Bitset(sister_clade), Bitset(focal_clade), Bitset(sorted_child_clade));
 }
 
-size_t Bitset::PCSPGetCladeSize() const { return MultiCladeGetCladeSize(3); }
+size_t Bitset::EdgeGetCladeSize() const { return MultiCladeGetCladeSize(3); }
 
-Bitset Bitset::PCSPGetClade(const size_t i) const { return MultiCladeGetClade(i, 3); }
+Bitset Bitset::EdgeGetClade(const size_t which_clade) const {
+  return MultiCladeGetClade(which_clade, 3);
+}
 
-Bitset Bitset::PCSPGetParentSubsplit() const {
-  Bitset sister = PCSPGetClade(0);
-  Bitset focal = PCSPGetClade(1);
+Bitset Bitset::EdgeGetClade(const EdgeClade which_clade) const {
+  size_t which_clade_idx =
+      static_cast<std::underlying_type<EdgeClade>::type>(which_clade);
+  return MultiCladeGetClade(which_clade_idx, 3);
+}
+
+Bitset Bitset::EdgeGetParentSubsplit() const {
+  Bitset sister = EdgeGetClade(Bitset::EdgeClade::SISTER);
+  Bitset focal = EdgeGetClade(Bitset::EdgeClade::FOCAL);
   return Bitset::Subsplit(sister, focal);
 }
 
-Bitset Bitset::PCSPGetChildSubsplit() const {
-  Bitset focal = PCSPGetClade(1);
-  Bitset child_0 = PCSPGetClade(2);
+Bitset Bitset::EdgeGetChildSubsplit() const {
+  Bitset focal = EdgeGetClade(Bitset::EdgeClade::FOCAL);
+  Bitset child_0 = EdgeGetClade(Bitset::EdgeClade::LEFT_CHILD);
   Bitset child_1 = focal & ~child_0;
   return Bitset::Subsplit(child_0, child_1);
 }
 
-std::string Bitset::PCSPToString() const { return MultiCladeToString(3); }
+std::string Bitset::EdgeToString() const { return MultiCladeToString(EdgeCladeCount); }
 
-bool Bitset::PCSPIsValid() const {
-  if (size() % 3 != 0) {
+bool Bitset::EdgeIsValid() const {
+  if (size() % EdgeCladeCount != 0) {
     return false;
   }
-  Bitset sister = PCSPGetClade(0);
-  Bitset focal = PCSPGetClade(1);
-  Bitset child_0 = PCSPGetClade(2);
+  Bitset sister = EdgeGetClade(Bitset::EdgeClade::SISTER);
+  Bitset focal = EdgeGetClade(Bitset::EdgeClade::FOCAL);
+  Bitset child_0 = EdgeGetClade(Bitset::EdgeClade::LEFT_CHILD);
   // The parent clades should be disjoint.
   if (!sister.IsDisjoint(focal)) {
     return false;
@@ -508,26 +542,34 @@ bool Bitset::PCSPIsValid() const {
   return true;
 }
 
-bool Bitset::PCSPIsFake() const {
-  Assert(size() % 3 == 0, "Size isn't 0 mod 3 in Bitset::PCSPIsFake.");
-  // If third clade of PCSP is empty, that means that the associated clade's sorted
-  // subsplit is empty, so it is fake.
-  return PCSPGetClade(2).None();
+bool Bitset::EdgeIsLeaf() const {
+  Assert(size() % EdgeCladeCount == 0, "Size isn't 0 mod 3 in Bitset::EdgeIsLeaf.");
+  // If third clade of Edge is empty, that means that the associated clade's sorted
+  // subsplit is empty, so it is leaf.
+  return EdgeGetClade(Bitset::EdgeClade::LEFT_CHILD).None();
 }
 
-bool Bitset::PCSPIsParentRootsplit() const {
-  Assert(size() % 3 == 0, "Size isn't 0 mod 3 in Bitset::PCSPIsRootsplit.");
-  return PCSPGetParentSubsplit().SubsplitIsRootsplit();
+Bitset Bitset::EdgeSortClades() const {
+  Bitset parent = EdgeGetParentSubsplit();
+  Bitset child = EdgeGetChildSubsplit();
+  return Bitset::Edge(parent, child);
 }
 
-SizePair Bitset::PCSPGetChildSubsplitTaxonCounts() const {
-  auto clade_size = PCSPGetCladeSize();
+bool Bitset::EdgeIsParentRootsplit() const {
+  Assert(size() % EdgeCladeCount == 0,
+         "Size isn't 0 mod 3 in Bitset::EdgeIsRootsplit.");
+  return EdgeGetParentSubsplit().SubsplitIsRootsplit();
+}
+
+SizePair Bitset::EdgeGetChildSubsplitTaxonCounts() const {
+  auto clade_size = EdgeGetCladeSize();
   auto total_clade_taxon_count =
-      std::count(value_.begin() + clade_size, value_.begin() + 2 * clade_size, true);
+      std::count(value_.begin() + clade_size,
+                 value_.begin() + SubsplitCladeCount * clade_size, true);
   auto clade0_taxon_count =
-      std::count(value_.begin() + 2 * clade_size, value_.end(), true);
+      std::count(value_.begin() + SubsplitCladeCount * clade_size, value_.end(), true);
   Assert(clade0_taxon_count < total_clade_taxon_count,
-         "PCSPGetChildSubsplitTaxonCounts: not a proper PCSP bitset.");
+         "EdgeGetChildSubsplitTaxonCounts: not a proper Edge bitset.");
   return {static_cast<size_t>(clade0_taxon_count),
           static_cast<size_t>(total_clade_taxon_count - clade0_taxon_count)};
 }
@@ -539,54 +581,60 @@ Bitset Bitset::Singleton(size_t n, size_t which_on) {
   return singleton;
 }
 
-Bitset Bitset::FakeSubsplit(const Bitset& nonzero_contents) {
-  Bitset fake(2 * nonzero_contents.size());
-  // Put the nonzero contents on the left of the fake subsplit.
-  fake.CopyFrom(nonzero_contents, 0, false);
-  return fake;
+Bitset Bitset::LeafSubsplitOfNonemptyClade(const Bitset& nonempty_clade) {
+  // Leaf pairs a nonempty left clade and an empty right clade.
+  Bitset leaf_subsplit =
+      Bitset::Subsplit(nonempty_clade, Bitset(nonempty_clade.size(), false));
+  return leaf_subsplit;
 }
 
-void AssertSisterAndLeafSubsplit(const Bitset& subsplit) {
-  Assert(
-      subsplit.SubsplitGetClade(0).Any() && subsplit.SubsplitGetClade(1).IsSingleton(),
-      "Assertion failed: we want the left-hand clade of the subsplit be "
-      "non-empty and the right-hand clade be a singleton.");
+void AssertSubsplitIsLeafAdjacent(const Bitset& subsplit) {
+  // For subsplit to be adjacent to
+  bool is_left_clade_nonempty =
+      subsplit.SubsplitGetClade(Bitset::SubsplitClade::LEFT).Any();
+  bool is_right_clade_singleton =
+      subsplit.SubsplitGetClade(Bitset::SubsplitClade::RIGHT).IsSingleton();
+  Assert(is_left_clade_nonempty && is_right_clade_singleton,
+         "Assertion SisterAndLeafSubsplit failed: we want the left-hand clade of the "
+         "subsplit be "
+         "non-empty and the right-hand clade be a singleton.");
 }
 
-Bitset Bitset::FakeChildSubsplit(const Bitset& parent_subsplit) {
-  AssertSisterAndLeafSubsplit(parent_subsplit);
-  // Put the right-hand clade of the subsplit as the nonzero contents of the fake
+Bitset Bitset::LeafSubsplitOfParentSubsplit(const Bitset& parent_subsplit) {
+  AssertSubsplitIsLeafAdjacent(parent_subsplit);
+  // Put the right-hand clade of the subsplit as the nonzero contents of the leaf
   // subsplit.
-  return FakeSubsplit(parent_subsplit.SubsplitGetClade(1));
+  return LeafSubsplitOfNonemptyClade(
+      parent_subsplit.SubsplitGetClade(Bitset::SubsplitClade::RIGHT));
 }
 
-Bitset Bitset::FakePCSP(const Bitset& parent_subsplit) {
-  AssertSisterAndLeafSubsplit(parent_subsplit);
+Bitset Bitset::EdgeToLeaf(const Bitset& parent_subsplit) {
+  AssertSubsplitIsLeafAdjacent(parent_subsplit);
   const auto taxon_count = parent_subsplit.SubsplitGetCladeSize();
-  Bitset fake(3 * taxon_count);
-  // Put the nonzero contents on the left of the fake subsplit.
-  fake.CopyFrom(parent_subsplit, 0, false);
-  return fake;
+  Bitset leaf(3 * taxon_count);
+  // Put the nonzero contents on the left of the leaf subsplit.
+  leaf.CopyFrom(parent_subsplit, 0, false);
+  return leaf;
 }
 
-Bitset Bitset::DAGRootSubsplitOfTaxonCount(const size_t taxon_count) {
+Bitset Bitset::RootSubsplitOfTaxonCount(const size_t taxon_count) {
   Bitset zeros(taxon_count);
   return ~zeros + zeros;
 }
 
-Bitset Bitset::RootsplitOfHalf(const Bitset& subsplit_half) {
-  Bitset half = subsplit_half;
+Bitset Bitset::RootsplitOfClade(const Bitset& clade) {
+  Bitset half = clade;
   half.Minorize();
   return ~half + half;
 }
 
-Bitset Bitset::PCSPOfRootsplit(const Bitset& rootsplit) {
+Bitset Bitset::EdgeToRootsplit(const Bitset& rootsplit) {
   Assert(rootsplit.SubsplitIsRootsplit(),
-         "Given subsplit is not rootsplit in Bitset::PCSPOfRootsplit.");
-  return PCSP(DAGRootSubsplitOfTaxonCount(rootsplit.size() / 2), rootsplit);
+         "Given subsplit is not rootsplit in Bitset::EdgeToRootsplit.");
+  return Edge(RootSubsplitOfTaxonCount(rootsplit.size() / 2), rootsplit);
 }
 
-Bitset Remap(const Bitset& bitset, const SizeOptionVector& idx_table) {
+Bitset Bitset::Remap(const Bitset& bitset, const SizeOptionVector& idx_table) {
   Bitset result(idx_table.size(), false);
   for (size_t i = 0; i < idx_table.size(); ++i) {
     if (idx_table[i].has_value() && bitset[idx_table[i].value()]) {

--- a/src/bitset.cpp
+++ b/src/bitset.cpp
@@ -427,7 +427,8 @@ Bitset Bitset::SubsplitCladeUnion() const {
          SubsplitGetClade(Bitset::SubsplitClade::Right);
 }
 
-bool Bitset::SubsplitIsChildOfWhichParentClade(const Bitset& parent, const Bitset& child) {
+bool Bitset::SubsplitIsChildOfWhichParentClade(const Bitset& parent,
+                                               const Bitset& child) {
   Assert(parent.size() == child.size(),
          "Bitset::SubsplitIsChildOfWhichParentClade() bitsets are different sizes.");
   Bitset child_union = child.SubsplitCladeUnion();
@@ -438,7 +439,8 @@ bool Bitset::SubsplitIsChildOfWhichParentClade(const Bitset& parent, const Bitse
   }
   // If it reaches the end, then it is not a parent.
   Failwith(
-      "Bitset::SubsplitIsChildOfWhichParentClade(): given parent is not a parent of given child.");
+      "Bitset::SubsplitIsChildOfWhichParentClade(): given parent is not a parent of "
+      "given child.");
 }
 
 bool Bitset::SubsplitIsParentChildPair(const Bitset& parent, const Bitset& child) {

--- a/src/bitset.cpp
+++ b/src/bitset.cpp
@@ -380,6 +380,7 @@ Bitset Bitset::SubsplitGetClade(const size_t which_clade) const {
 
 Bitset Bitset::SubsplitGetClade(const SubsplitClade which_clade) const {
   size_t which_clade_idx =
+      // #350 discuss this cast
       static_cast<std::underlying_type<SubsplitClade>::type>(which_clade);
   return MultiCladeGetClade(which_clade_idx, SubsplitCladeCount);
 }

--- a/src/bitset.cpp
+++ b/src/bitset.cpp
@@ -393,7 +393,7 @@ bool Bitset::SubsplitIsLeaf() const {
 }
 
 bool Bitset::SubsplitIsUCA() const {
-  // A subsplit is a root if the left clade contains all taxa and the right clade
+  // A subsplit is a UCA if the left clade contains all taxa and the right clade
   // contains no taxa. If subsplit is valid, then we can assume the right clade is
   // empty.
   bool is_left_clade_full = SubsplitGetClade(Bitset::SubsplitClade::Left).All();
@@ -402,7 +402,7 @@ bool Bitset::SubsplitIsUCA() const {
 
 bool Bitset::SubsplitIsRootsplit() const {
   // A subsplit is a rootsplit if the union of the clades contain all clades.
-  // But is also not the root, meaning both clades are nonempty.
+  // But is also not the UCA, meaning both clades are nonempty.
   bool is_union_of_clades_full = SubsplitCladeUnion().All();
   bool is_left_clade_nonempty = !SubsplitGetClade(Bitset::SubsplitClade::Left).None();
   bool is_right_clade_nonempty = !SubsplitGetClade(Bitset::SubsplitClade::Right).None();
@@ -432,6 +432,7 @@ bool Bitset::SubsplitIsChildOfWhichParentClade(const Bitset& parent,
   Assert(parent.size() == child.size(),
          "Bitset::SubsplitIsChildOfWhichParentClade() bitsets are different sizes.");
   Bitset child_union = child.SubsplitCladeUnion();
+  // #350 why not use the left and right here?
   for (bool clade : {false, true}) {
     if (child_union == parent.SubsplitGetClade(clade)) {
       return clade;
@@ -494,6 +495,9 @@ Bitset Bitset::PCSP(const std::string sister_clade, const std::string focal_clad
   return PCSP(Bitset(sister_clade), Bitset(focal_clade), Bitset(sorted_child_clade));
 }
 
+// #350 I'd argue that if we are going to use SubsplitCladeCount (and I'm not sure about
+// that) then we should use something like that here. Oh wait, there is a
+// PCSPCladeCount.
 size_t Bitset::PCSPGetCladeSize() const { return MultiCladeGetCladeSize(3); }
 
 Bitset Bitset::PCSPGetClade(const size_t which_clade) const {

--- a/src/bitset.cpp
+++ b/src/bitset.cpp
@@ -457,7 +457,7 @@ bool Bitset::SubsplitIsValid() const {
       .IsDisjoint(SubsplitGetClade(Bitset::SubsplitClade::Right));
 }
 
-// ** Edge functions
+// ** PCSP functions
 
 Bitset Bitset::PCSP(const Bitset& parent_subsplit, const Bitset& child_subsplit) {
   // Assert that:
@@ -485,7 +485,7 @@ Bitset Bitset::PCSP(const Bitset& sister_clade, const Bitset& focal_clade,
              focal_clade.size() == sorted_child_clade.size(),
          "PCSP(): all clades must be of equal size.");
   Bitset pcsp = sister_clade + focal_clade + sorted_child_clade;
-  Assert(pcsp.PCSPIsValid(), "PCSP(): given clades form an invalid Edge.");
+  Assert(pcsp.PCSPIsValid(), "PCSP(): given clades form an invalid PCSP.");
   return pcsp;
 }
 
@@ -547,7 +547,7 @@ bool Bitset::PCSPIsValid() const {
 bool Bitset::PCSPChildIsLeaf() const {
   Assert(size() % PCSPCladeCount == 0,
          "Size isn't 0 mod 3 in Bitset::PCSPChildIsLeaf.");
-  // If third clade of Edge is empty, that means that the associated clade's sorted
+  // If third clade of PCSP is empty, that means that the associated clade's sorted
   // subsplit is empty, so it is leaf.
   return PCSPGetClade(Bitset::PCSPClade::LeftChild).None();
 }
@@ -560,7 +560,7 @@ Bitset Bitset::PCSPSortClades() const {
 
 bool Bitset::PCSPIsParentRootsplit() const {
   Assert(size() % PCSPCladeCount == 0,
-         "Size isn't 0 mod 3 in Bitset::EdgeIsRootsplit.");
+         "Size isn't 0 mod 3 in Bitset::PCSPIsParentRootsplit.");
   return PCSPGetParentSubsplit().SubsplitIsRootsplit();
 }
 
@@ -572,13 +572,14 @@ SizePair Bitset::PCSPGetChildSubsplitTaxonCounts() const {
   auto clade0_taxon_count =
       std::count(value_.begin() + SubsplitCladeCount * clade_size, value_.end(), true);
   Assert(clade0_taxon_count < total_clade_taxon_count,
-         "PCSPGetChildSubsplitTaxonCounts: not a proper Edge bitset.");
+         "PCSPGetChildSubsplitTaxonCounts: not a proper PCSP bitset.");
   return {static_cast<size_t>(clade0_taxon_count),
           static_cast<size_t>(total_clade_taxon_count - clade0_taxon_count)};
 }
 
 Bitset Bitset::Singleton(size_t n, size_t which_on) {
-  Assert(which_on < n, "which_on too big in Bitset::Singleton.");
+  Assert(which_on < n,
+         "Bitset::Singleton(): selected 'on' bit is out of range for bitset size.");
   Bitset singleton(n);
   singleton.set(which_on);
   return singleton;
@@ -633,7 +634,7 @@ Bitset Bitset::RootsplitSubsplitOfClade(const Bitset& clade) {
 
 Bitset Bitset::PCSPFromUCAToRootsplit(const Bitset& rootsplit) {
   Assert(rootsplit.SubsplitIsRootsplit(),
-         "Given subsplit is not rootsplit in Bitset::EdgeToRootsplit.");
+         "Given subsplit is not rootsplit in Bitset::PCSPFromUCAToRootsplit.");
   return PCSP(UCASubsplitOfTaxonCount(rootsplit.size() / 2), rootsplit);
 }
 

--- a/src/bitset.hpp
+++ b/src/bitset.hpp
@@ -140,11 +140,12 @@ class Bitset {
 
   // ** Subsplit Methods
   // These methods require bitset to represent "subsplits".  Subsplits represent nodes
-  // within the SubsplitDAG.  A subsplit are composed of two equal-sized, disjoint "clades",
-  // representing a fork in the DAG and the taxon sets descending from the left and right
-  // sides of the fork. Clades are normally stored in a sorted order wrt to their
-  // lexicographic taxon ordering: the smaller "left" (or "sorted") clade stored in the
-  // 0-position, and the larger "right" (or "rotated") clade in the 1-position.
+  // within the SubsplitDAG.  A subsplit are composed of two equal-sized, disjoint
+  // "clades", representing a fork in the DAG and the taxon sets descending from the
+  // left and right sides of the fork. Clades are normally stored in a sorted order wrt
+  // to their lexicographic taxon ordering: the smaller "left" (or "sorted") clade
+  // stored in the 0-position, and the larger "right" (or "rotated") clade in the
+  // 1-position.
 
   static inline size_t SubsplitCladeCount = 2;
   enum class SubsplitClade : bool {
@@ -223,7 +224,8 @@ class Bitset {
   Bitset SubsplitCladeUnion() const;
   // Get whether the given child is the sorted (false, 0-position) or rotated (true,
   // 1-position) child to the given parent.
-  static bool SubsplitIsChildOfWhichParentClade(const Bitset &parent, const Bitset &child);
+  static bool SubsplitIsChildOfWhichParentClade(const Bitset &parent,
+                                                const Bitset &child);
   // Check whether subsplits form a child/parent pair.
   static bool SubsplitIsParentChildPair(const Bitset &parent, const Bitset &child);
   // Check whether subsplits are adjacent/related (whether either is the parent of the
@@ -235,11 +237,11 @@ class Bitset {
 
   // ** PCSP methods
   // These functions require the bitset to be a "PCSP bitset" (parent-child subsplit
-  // pair). PCSP represent edges between nodes within the SubsplitDAG. They are composed of
-  // three equal-sized "clades": (0) sister clade of parent, (1) focal clade of parent, 
-  // (2) the left clade of the child. We define the "left" clade of a child subsplit that has a bitset
-  // with the smaller lexicographic representation. The remaining clade are well-defined relative to the
-  // focal parent subsplit.
+  // pair). PCSP represent edges between nodes within the SubsplitDAG. They are composed
+  // of three equal-sized "clades": (0) sister clade of parent, (1) focal clade of
+  // parent, (2) the left clade of the child. We define the "left" clade of a child
+  // subsplit that has a bitset with the smaller lexicographic representation. The
+  // remaining clade are well-defined relative to the focal parent subsplit.
   //
   // For example, `100|011|001` is composed of the clades `100`, `011` and `001`.
   // If the taxa are x0, x1, and x2 then this means the parent subsplit is (A,
@@ -266,9 +268,10 @@ class Bitset {
   static Bitset PCSP(const std::string sister_clade, const std::string focal_clade,
                      const std::string sorted_child_clade);
   // Special Constructors:
-  // Make a PCSP from parent subsplit to child leaf subsplit. Asserts that the left-hand clade of
-  // the parent subsplit is non-empty and that the right-hand clade is a singleton.
-  // This leaf subsplit has parent subsplit on the left and all zeroes on the right.
+  // Make a PCSP from parent subsplit to child leaf subsplit. Asserts that the left-hand
+  // clade of the parent subsplit is non-empty and that the right-hand clade is a
+  // singleton. This leaf subsplit has parent subsplit on the left and all zeroes on the
+  // right.
   static Bitset PCSPFromRightParentCladeToLeaf(const Bitset &parent_subsplit);
   // Given a rootsplit, get the PCSP connecting the DAG root node to that rootsplit
   // (e.g. '1100|0011' would return '0000|1111|0011').
@@ -419,10 +422,11 @@ TEST_CASE("Bitset: Clades, Subsplits, Edges") {
   CHECK_EQ(Bitset("010101").SubsplitToVectorOfSetBitsAsString(), "1|0,2");
 
   CHECK_EQ(Bitset("101010").SubsplitIsLeftChildOf(Bitset("111000")), true);
-  // CHECK_EQ(Bitset::SubsplitIsChildOfWhichParentClade(Bitset("111000"), Bitset("101010")),true);
+  // CHECK_EQ(Bitset::SubsplitIsChildOfWhichParentClade(Bitset("111000"),
+  // Bitset("101010")),true);
   CHECK_EQ(Bitset("00100001").SubsplitIsRightChildOf(Bitset("11000011")), true);
-  // CHECK_EQ(Bitset::SubsplitIsChildOfWhichParentClade(Bitset("000111"), Bitset("101010")),
-  // false);
+  // CHECK_EQ(Bitset::SubsplitIsChildOfWhichParentClade(Bitset("000111"),
+  // Bitset("101010")), false);
   CHECK_EQ(Bitset("010001").SubsplitIsLeftChildOf(Bitset("110001")), false);
   CHECK_EQ(Bitset("010001").SubsplitIsRightChildOf(Bitset("01000011")), false);
   // Should throw because Bitsets can't be divided into equal-sized clades.

--- a/src/bitset.hpp
+++ b/src/bitset.hpp
@@ -201,6 +201,7 @@ class Bitset {
   // taxon set.
   size_t SubsplitGetCladeSize() const;
   // Get clade according to its taxon ordering.
+  // #350 why do we want these two overloads?
   Bitset SubsplitGetClade(const size_t which_clade) const;
   Bitset SubsplitGetClade(const SubsplitClade which_clade) const;
   // Output subsplit as string of "1" and "0" characters, with each clade separated by a
@@ -405,7 +406,7 @@ TEST_CASE("Bitset") {
   CHECK_EQ(Bitset("0000").ToVectorOfSetBitsAsString(), "");
 }
 
-TEST_CASE("Bitset: Clades, Subsplits, Edges") {
+TEST_CASE("Bitset: Clades, Subsplits, PCSPs") {
   auto p = Bitset("000111");
   // Subsplit: 000|111
   CHECK_EQ(p.SubsplitGetClade(Bitset::SubsplitClade::Left), Bitset("000"));
@@ -421,6 +422,7 @@ TEST_CASE("Bitset: Clades, Subsplits, Edges") {
   CHECK_EQ(Bitset("010101").SubsplitToVectorOfSetBitsAsString(), "1|0,2");
 
   CHECK_EQ(Bitset("101010").SubsplitIsLeftChildOf(Bitset("111000")), true);
+  // #350 commented out code
   // CHECK_EQ(Bitset::SubsplitIsChildOfWhichParentClade(Bitset("111000"),
   // Bitset("101010")),true);
   CHECK_EQ(Bitset("00100001").SubsplitIsRightChildOf(Bitset("11000011")), true);

--- a/src/bitset.hpp
+++ b/src/bitset.hpp
@@ -120,7 +120,7 @@ class Bitset {
   // specific member of that taxon set.
   //
   // There are bitset "types" composed of multiple clades (here, called a
-  // MultiClade). Subsplits are composed of two clades and Edges are composed of three
+  // MultiClade). Subsplits are composed of two clades and PCSPs are composed of three
   // clades.
 
   // Comparator: Clades are sorted with respect to the lexigraphical representation of
@@ -143,9 +143,8 @@ class Bitset {
   // within the SubsplitDAG.  A subsplit are composed of two equal-sized, disjoint
   // "clades", representing a fork in the DAG and the taxon sets descending from the
   // left and right sides of the fork. Clades are normally stored in a sorted order wrt
-  // to their lexicographic taxon ordering: the smaller "left" (or "sorted") clade
-  // stored in the 0-position, and the larger "right" (or "rotated") clade in the
-  // 1-position.
+  // to their lexicographic taxon ordering: the smaller "left" clade stored in the
+  // 0-position, and the larger "right" clade in the 1-position.
 
   static inline size_t SubsplitCladeCount = 2;
   enum class SubsplitClade : bool {

--- a/src/bitset.hpp
+++ b/src/bitset.hpp
@@ -211,13 +211,13 @@ class Bitset {
   std::string SubsplitToVectorOfSetBitsAsString() const;
   // Is this the subsplit of a leaf node?
   bool SubsplitIsLeaf() const;
-  // Is this the subsplit of root node?
-  bool SubsplitIsRoot() const;
+  // Is this the UCA subsplit?
+  bool SubsplitIsUCA() const;
   // Is this the subsplit of a rootsplit?
   bool SubsplitIsRootsplit() const;
-  // Is this the left/rotated clade of the given subsplit?
+  // Is this the left clade of the given subsplit?
   bool SubsplitIsLeftChildOf(const Bitset &parent) const;
-  // Is this the right/sorted clade of the given subsplit?
+  // Is this the right clade of the given subsplit?
   bool SubsplitIsRightChildOf(const Bitset &parent) const;
   // Get the union of the two clades.
   Bitset SubsplitCladeUnion() const;

--- a/src/bitset.hpp
+++ b/src/bitset.hpp
@@ -34,8 +34,10 @@ class Bitset {
 
   // ** std::bitset Interface Methods
   // These methods are modeled after the std::bitset interface.
-  //
+
+  // Get ith bit in Bitset.
   bool operator[](size_t i) const;
+  // Get the number of bits in Bitset.
   size_t size() const;
   // Set given index to true.
   void set(size_t i, bool value = true);
@@ -69,12 +71,13 @@ class Bitset {
 
   // ** Bitset Methods
   // These methods are not from the std::bitset interface.
-  //
+
   // Special Constructors:
   // Make a bitset with only the specified entry turned on.
   static Bitset Singleton(size_t n, size_t which_on);
   // Sets entire bitset to false.
   void Zero();
+
   // Generates hash value from bitset.
   size_t Hash() const;
   // Outputs bitset as a string of "1" and "0"s.
@@ -103,26 +106,30 @@ class Bitset {
   std::optional<uint32_t> SingletonOption() const;
   // Output as string of comma-separated indices.
   std::string ToVectorOfSetBitsAsString() const;
+  // Returns a new Bitset with size equal to `idx_table`'s size. Each entry
+  // of the new bitset is determined as follows:
+  // - If the `idx_table` entry is an integer i, then the value is the ith
+  //   entry of `bitset`.
+  // - If the entry is nullopt, then the value is False (i.e. zero).
+  static Bitset Remap(const Bitset &bitset, const SizeOptionVector &idx_table);
 
   // ** Clade / MultiClade Methods
   // These methods require bitsets to represent "clades". A clade is an expression of a
-  // subset of a taxon set.  The size of the taxon set is equal to the size of the
+  // subset of a taxon set.  The size of the total taxon set is equal to the size of the
   // clade's bitset, with each bit index representing a inclusion/exclusion of a
   // specific member of that taxon set.
   //
   // There are bitset "types" composed of multiple clades (here, called a
-  // MultiClade). Subsplits are composed of two clades and PCSPs are composed of three
+  // MultiClade). Subsplits are composed of two clades and Edges are composed of three
   // clades.
-  //
+
   // Comparator: Clades are sorted with respect to the lexigraphical representation of
   // their taxon subset. (e.g. If two clades are "010" and "101", then their taxon
   // subsets are {b} and {a,c}. "b" > "a", therefore "010" > "101".) Note: Sorting by
   // taxon representation gives the precise opposite ordering to sorting by binary
-  // representation (except in the case of zero/empty set).
-  //
-  // Issue #375 - We need to refactor.
+  // representation (except in the case of zero/empty set!).
   static int CladeCompare(const Bitset &bitset_a, const Bitset &bitset_b);
-  int CladeCompare(const Bitset &other) const;
+  int CladeCompare(const Bitset &bitset_b) const;
   // For a specified number of clades, return the clade/taxon size.
   size_t MultiCladeGetCladeSize(const size_t clade_count) const;
   // For a specified number of clades, return a bitset of the ith clade.
@@ -134,13 +141,20 @@ class Bitset {
   // ** Subsplit Methods
   // These methods require bitset to represent "subsplits".  A subsplit is of even
   // length, consisting of two equal-sized, disjoint "clades", representing the two
-  // sides of the subsplit. Clades are stored in a sorted order wrt to their
-  // lexicographic taxon ordering: the smaller "left" or "sorted" clade stored in the
-  // 0-position, and the larger "right" or "rotated" clade in the 1-position.
-  //
+  // sides of the subsplit. Clades are normally stored in a sorted order wrt to their
+  // lexicographic taxon ordering: the smaller "left" (or "sorted") clade stored in the
+  // 0-position, and the larger "right" (or "rotated") clade in the 1-position.
+
+  static inline size_t SubsplitCladeCount = 2;
+  enum class SubsplitClade : bool {
+    LEFT = 0,  /* ROTATED, LEXICO_SMALLER, BIN_LARGER */
+    RIGHT = 1, /* SORTED, LEXICO_LARGER, BIN_SMALLER */
+  };
+
   // Constructors:
   // Each argument represents one of the clade of the subsplit.
   // Each clade follows the corresponding Bitset constructor.
+  //
   // Build a Subsplit bitset out of a compatible pair of clades.
   static Bitset Subsplit(const Bitset &clade_0, const Bitset &clade_1);
   // Builds Clades from strings of "1" and "0" characters.
@@ -148,29 +162,28 @@ class Bitset {
   // Builds Clades of size `n` with only indices in the clade vectors set to true.
   static Bitset Subsplit(const SizeVector clade_0, const SizeVector clade_1,
                          const size_t n);
-  // Given two arbitrarily ordered clades, return a subsplit with the clades in sorted
-  // order by taxon representation.
+  // Given two arbitrarily ordered clades of same length, return a subsplit with the
+  // clades in sorted order by taxon representation.
   static Bitset SubsplitFromUnorderedClades(const Bitset &clade_0,
                                             const Bitset &clade_1);
   // Special Constructors:
-  // A "fake" subsplit is a subsplit where one of the clades is equal to the empty set
-  // (zero). In practice, these are allowed in only two cases: When subsplit is a leaf
-  // or root.  A leaf should only have a single member in its non-empty clade, and a
-  // root should have the full taxon set in its non-empty clade.
+  // A "leaf" (formerly "leaf") subsplit is a subsplit where one of the clades is equal
+  // to the empty set (zero). In practice, these are allowed in only two cases: When
+  // subsplit is a leaf or root.  A leaf should only have a single member in its
+  // non-empty clade, and a root should have the full taxon set in its non-empty clade.
   //
-  // Make a "fake" subsplit (pairs nonzero_clade with a zero clade)
-  static Bitset FakeSubsplit(const Bitset &nonzero_clade);
-  // Make a "fake" child subsplit of a given parent; assert that the left-hand clade of
-  // the parent subsplit is non-empty and that the right-hand clade is a singleton.
-  // This fake subsplit has this singleton on the left and all zeroes on the right.
-  static Bitset FakeChildSubsplit(const Bitset &parent_subsplit);
-  // Get the subsplit of the DAG root node with a taxon count.
+  // Make a "leaf" subsplit (pairs given nonempty_clade with an empty_clade).
+  static Bitset LeafSubsplitOfNonemptyClade(const Bitset &nonempty_clade);
+  // Make a "leaf" child subsplit of a given parent subsplit. The leftside clade of
+  // the parent subsplit must be non-empty and the rightside clade must be a singleton.
+  static Bitset LeafSubsplitOfParentSubsplit(const Bitset &parent_subsplit);
+  // Get the subsplit of the DAG root node with the given taxon count.
   // Since subsplit bitsets are always big-small, the DAG root node subsplit
   // consists of all 1s then 0s (e.g. 5 would return '11111|00000').
-  static Bitset DAGRootSubsplitOfTaxonCount(const size_t taxon_count);
+  static Bitset RootSubsplitOfTaxonCount(const size_t taxon_count);
   // Get the full rootsplit bitset out of a rootsplit half.
   // Note: the first half of the rootsplit bitset is always larger than the second.
-  static Bitset RootsplitOfHalf(const Bitset &rootsplit_half);
+  static Bitset RootsplitOfClade(const Bitset &clade);
   // Comparator:
   // Subsplits are sorting on the following:
   // (1) The number of taxa in each of their subsplits.
@@ -181,18 +194,13 @@ class Bitset {
   // Flip the order of the two clades of a subsplit.
   Bitset SubsplitRotate() const;
   // Sorts clades of subsplit so that they are ordered by their taxon representation.
-  Bitset SubsplitSort() const;
+  Bitset SubsplitSortClades() const;
   // Gets the size of each of each clade. This is the same as the size of the whole
   // taxon set.
   size_t SubsplitGetCladeSize() const;
   // Get clade according to its taxon ordering.
-  // Issue #375 - We need to refactor.
   Bitset SubsplitGetClade(const size_t which_clade) const;
-  // Get clade according to its binary ordering:
-  // Get "clade 0" (the clade bitset with the smaller binary representation)
-  // or "clade 1" (the clade bitset with the larger binary representation).
-  // Issue #375 - We need to refactor.
-  Bitset SubsplitGetCladeByBinaryOrder(const size_t i) const;
+  Bitset SubsplitGetClade(const SubsplitClade which_clade) const;
   // Output subsplit as string of "1" and "0" characters, with each clade separated by a
   // "|".
   std::string SubsplitToString() const;
@@ -205,25 +213,30 @@ class Bitset {
   bool SubsplitIsRoot() const;
   // Is this the subsplit of a rootsplit?
   bool SubsplitIsRootsplit() const;
-  // Is this the rotated clade of the given subsplit?
-  bool SubsplitIsRotatedChildOf(const Bitset &other) const;
-  // Is this the sorted clade of the given subsplit?
-  bool SubsplitIsSortedChildOf(const Bitset &other) const;
+  // Is this the left/rotated clade of the given subsplit?
+  bool SubsplitIsLeftChildOf(const Bitset &parent) const;
+  // Is this the right/sorted clade of the given subsplit?
+  bool SubsplitIsRightChildOf(const Bitset &parent) const;
   // Get the union of the two clades.
   Bitset SubsplitCladeUnion() const;
-  // Get whether the given child is the sorted or rotated child to the given parent.
+  // Get whether the given child is the sorted (false, 0-position) or rotated (true,
+  // 1-position) child to the given parent.
   static bool SubsplitIsWhichChildOf(const Bitset &parent, const Bitset &child);
+  // Check whether subsplits form a child/parent pair.
+  static bool SubsplitIsParentChildPair(const Bitset &parent, const Bitset &child);
+  // Check whether subsplits are adjacent/related (whether either is the parent of the
+  // other).
+  static bool SubsplitIsAdjacent(const Bitset &subsplit_a, const Bitset &subsplit_b);
   // Check whether bitset represents valid Subsplit (contains two equal-sized, disjoint
   // clades).
   bool SubsplitIsValid() const;
 
-  // ** PCSP methods
-  // These functions require the bitset to be a "PCSP bitset" with three
-  // equal-sized "clades".
-  // The first clade represents the sister clade, the second the focal clade,
-  // and the third clade describes the "sorted" clade of the child subsplit.
-  // We define "sorted" as the clade of a child subsplit that has a bitset with
-  // the smaller binary representation.
+  // ** Edge methods
+  // These functions require the bitset to be a "edge bitset"  (also called PCSP, or
+  // parent-child subsplit pair). Edges are composed of three equal-sized "clades". The
+  // first clade represents the sister clade, the second the focal clade, and the third
+  // clade describes the "sorted" clade of the child subsplit. We define "sorted" as the
+  // clade of a child subsplit that has a bitset with the smaller binary representation.
   // The clades are well defined relative to the cut parent: the other part of
   // the subsplit, "rotated clade" is the cut parent set, minus the "sorted clade".
   //
@@ -232,54 +245,66 @@ class Bitset {
   // BC) with bitset `100|011`, and the child subsplit is (B, C) with bitset
   // `010|001.` Child_0 is the clade `001` and child_1 is the clade `010.`
   //
-  // For rootsplit PCSPs where the parent subsplit is the DAG root node, the PCSP
+  // For rootsplit Edges where the parent subsplit is the DAG root node, the Edge
   // is the sister clade (all 0s), the focal clade (all 1s), and "clade 0". For
-  // example, `000111010` is the PCSP from the DAG root node to the rootsplit (AC, B).
+  // example, `000111010` is the Edge from the DAG root node to the rootsplit (AC, B).
   // See the unit tests at the bottom for more examples.
-  //
+
+  static inline size_t EdgeCladeCount = 3;
+  enum class EdgeClade : size_t {
+    SISTER = 0,
+    FOCAL = 1,
+    LEFT_CHILD = 2 /* ROTATED_CHILD */
+  };
+
   // Constructors:
-  // Build a PCSP bitset from a compatible parent-child pair of
+  // Build a Edge bitset from a compatible parent-child pair of
   // Subsplit bitsets.
-  static Bitset PCSP(const Bitset &parent_subsplit, const Bitset &child_subsplit);
-  // Build a PCSP bitset from explicit sister, focal, and sorted-child clades.
-  static Bitset PCSP(const Bitset &sister_clade, const Bitset &focal_clade,
+  static Bitset Edge(const Bitset &parent_subsplit, const Bitset &child_subsplit);
+  // Build a Edge bitset from explicit sister, focal, and sorted-child clades.
+  static Bitset Edge(const Bitset &sister_clade, const Bitset &focal_clade,
                      const Bitset &sorted_child_clade);
   // Builds sister, focal, and sorted-child clades from strings of "1" and "0"
   // characters.
-  static Bitset PCSP(const std::string sister_clade, const std::string focal_clade,
+  static Bitset Edge(const std::string sister_clade, const std::string focal_clade,
                      const std::string sorted_child_clade);
   // Special Constructors:
-  // Make a "fake" PCSP of a given parent subsplit; assert that the left-hand clade of
+  // Make a "leaf" Edge of a given parent subsplit; assert that the left-hand clade of
   // the parent subsplit is non-empty and that the right-hand clade is a singleton.
-  // This fake subsplit has parent subsplit on the left and all zeroes on the right.
-  static Bitset FakePCSP(const Bitset &parent_subsplit);
-  // Given a rootsplit, get the PCSP connecting the DAG root node to that rootsplit
+  // This leaf subsplit has parent subsplit on the left and all zeroes on the right.
+  static Bitset EdgeToLeaf(const Bitset &parent_subsplit);
+  // Given a rootsplit, get the Edge connecting the DAG root node to that rootsplit
   // (e.g. '1100|0011' would return '0000|1111|0011').
-  static Bitset PCSPOfRootsplit(const Bitset &rootsplit);
-  // Output PCSP as string of "1" and "0" characters, with each clade separated by a
+  static Bitset EdgeToRootsplit(const Bitset &rootsplit);
+  // Output Edge as string of "1" and "0" characters, with each clade separated by a
   // "|".
-  std::string PCSPToString() const;
-  // Checks whether bitset represents a valid set of taxon clades for PCSP.
-  bool PCSPIsValid() const;
-  // Checks whether the PCSP clade-side edge goes to a fake subsplit.
-  bool PCSPIsFake() const;
+  std::string EdgeToString() const;
+  // Checks whether bitset represents a valid set of taxon clades for Edge.
+  bool EdgeIsValid() const;
+  // Checks whether the Edge clade-side edge goes to a leaf subsplit.
+  bool EdgeIsLeaf() const;
+  // Sorts Edge so that parent and child are rotated properly so that second clade is
+  // the focal clade of the parent and third clade is the sorted side of the child.
+  Bitset EdgeSortClades() const;
   // Do the sister and focal clades union to the whole taxon set?
-  // Method excludes rootsplit PCSPs where sister and focal clades
+  // Method excludes rootsplit Edges where sister and focal clades
   // also union to the whole taxon set.
-  bool PCSPIsParentRootsplit() const;
+  bool EdgeIsParentRootsplit() const;
   // Gets the size of each of each clade. This is the same as the size of the whole
   // taxon set.
-  size_t PCSPGetCladeSize() const;
-  // Get the ith clade of the PCSP.
-  Bitset PCSPGetClade(const size_t i) const;
-  // Get the parent subsplit of the PCSP.
-  Bitset PCSPGetParentSubsplit() const;
-  // Get the child subsplit of the PCSP.
-  Bitset PCSPGetChildSubsplit() const;
+  size_t EdgeGetCladeSize() const;
+  // Get the ith clade of the Edge.
+  Bitset EdgeGetClade(const size_t which_clade) const;
+  Bitset EdgeGetClade(const EdgeClade which_clade) const;
+  // Get the parent subsplit of the Edge.
+  Bitset EdgeGetParentSubsplit() const;
+  // Get the child subsplit of the Edge.
+  Bitset EdgeGetChildSubsplit() const;
   // Get the number of taxa in each side of the child subsplit.
-  SizePair PCSPGetChildSubsplitTaxonCounts() const;
+  SizePair EdgeGetChildSubsplitTaxonCounts() const;
 
- private:
+ protected:
+  // Vector of bits.
   std::vector<bool> value_;
 };
 
@@ -296,13 +321,6 @@ struct equal_to<Bitset> {
   bool operator()(const Bitset &lhs, const Bitset &rhs) const { return lhs == rhs; }
 };
 }  // namespace std
-
-// Returns a new Bitset with size equal to `idx_table`'s size. Each entry
-// of the new bitset is determined as follows:
-// - If the `idx_table` entry is an integer i, then the value is the ith
-//   entry of `bitset`.
-// - If the entry is nullopt, then the value is False (i.e. zero).
-Bitset Remap(const Bitset &bitset, const SizeOptionVector &idx_table);
 
 #ifdef DOCTEST_LIBRARY_INCLUDED
 
@@ -388,53 +406,54 @@ TEST_CASE("Bitset") {
   CHECK_EQ(Bitset("0000").ToVectorOfSetBitsAsString(), "");
 }
 
-TEST_CASE("Bitset: Clades, Subsplits, PCSPs") {
+TEST_CASE("Bitset: Clades, Subsplits, Edges") {
   auto p = Bitset("000111");
+  // Subsplit: 000|111
+  CHECK_EQ(p.SubsplitGetClade(Bitset::SubsplitClade::LEFT), Bitset("000"));
+  CHECK_EQ(p.SubsplitGetClade(Bitset::SubsplitClade::RIGHT), Bitset("111"));
+  // Edge: 00|01|11
+  CHECK_EQ(p.EdgeGetClade(Bitset::EdgeClade::SISTER), Bitset("00"));
+  CHECK_EQ(p.EdgeGetClade(Bitset::EdgeClade::FOCAL), Bitset("01"));
+  CHECK_EQ(p.EdgeGetClade(Bitset::EdgeClade::LEFT_CHILD), Bitset("11"));
 
-  CHECK_EQ(p.SubsplitGetClade(0), Bitset("000"));
-  CHECK_EQ(p.SubsplitGetClade(1), Bitset("111"));
-  CHECK_EQ(p.PCSPGetClade(0), Bitset("00"));
-  CHECK_EQ(p.PCSPGetClade(1), Bitset("01"));
-  CHECK_EQ(p.PCSPGetClade(2), Bitset("11"));
-
-  CHECK_EQ(Bitset("10010110").SubsplitGetCladeByBinaryOrder(0), Bitset("0110"));
-  CHECK_EQ(Bitset("10010110").SubsplitGetCladeByBinaryOrder(1), Bitset("1001"));
-  CHECK_THROWS(Bitset("01101001").SubsplitGetCladeByBinaryOrder(1));
   CHECK_EQ(Bitset("11001010").SubsplitCladeUnion(), Bitset("1110"));
 
   CHECK_EQ(Bitset("10011100").SubsplitRotate(), Bitset("11001001"));
   CHECK_EQ(Bitset("010101").SubsplitToVectorOfSetBitsAsString(), "1|0,2");
 
-  CHECK_EQ(Bitset("101010").SubsplitIsRotatedChildOf(Bitset("111000")), true);
-  CHECK_EQ(Bitset("00100001").SubsplitIsSortedChildOf(Bitset("11000011")), true);
-  CHECK_EQ(Bitset("010001").SubsplitIsRotatedChildOf(Bitset("110001")), false);
-  CHECK_EQ(Bitset("010001").SubsplitIsSortedChildOf(Bitset("01000011")), false);
+  CHECK_EQ(Bitset("101010").SubsplitIsLeftChildOf(Bitset("111000")), true);
+  // CHECK_EQ(Bitset::SubsplitIsWhichChildOf(Bitset("111000"), Bitset("101010")),true);
+  CHECK_EQ(Bitset("00100001").SubsplitIsRightChildOf(Bitset("11000011")), true);
+  // CHECK_EQ(Bitset::SubsplitIsWhichChildOf(Bitset("000111"), Bitset("101010")),
+  // false);
+  CHECK_EQ(Bitset("010001").SubsplitIsLeftChildOf(Bitset("110001")), false);
+  CHECK_EQ(Bitset("010001").SubsplitIsRightChildOf(Bitset("01000011")), false);
   // Should throw because Bitsets can't be divided into equal-sized clades.
-  CHECK_THROWS(Bitset("11010").SubsplitIsRotatedChildOf(Bitset("10101")));
-  CHECK_THROWS(Bitset("11010").SubsplitIsSortedChildOf(Bitset("10101")));
+  CHECK_THROWS(Bitset("11010").SubsplitIsLeftChildOf(Bitset("10101")));
+  CHECK_THROWS(Bitset("11010").SubsplitIsRightChildOf(Bitset("10101")));
 
   CHECK_EQ(Bitset("101010").SubsplitIsRootsplit(), true);
   CHECK_EQ(Bitset("111000").SubsplitIsRootsplit(), false);
   CHECK_EQ(Bitset("11000001").SubsplitIsRootsplit(), false);
 
-  CHECK_EQ(Bitset("011101").PCSPIsValid(), false);
-  CHECK_EQ(Bitset("000111").PCSPIsValid(), false);
-  CHECK_EQ(Bitset("100100").PCSPIsValid(), false);
-  CHECK_EQ(Bitset("100011001").PCSPIsValid(), true);
+  CHECK_EQ(Bitset("011101").EdgeIsValid(), false);
+  CHECK_EQ(Bitset("000111").EdgeIsValid(), false);
+  CHECK_EQ(Bitset("100100").EdgeIsValid(), false);
+  CHECK_EQ(Bitset("100011001").EdgeIsValid(), true);
 
-  CHECK_EQ(Bitset("100011001").PCSPIsFake(), false);
-  CHECK_EQ(Bitset("100011000").PCSPIsFake(), true);
+  CHECK_EQ(Bitset("100011001").EdgeIsLeaf(), false);
+  CHECK_EQ(Bitset("100011000").EdgeIsLeaf(), true);
 
-  CHECK_EQ(Bitset("000111010").PCSPIsParentRootsplit(), false);
-  CHECK_EQ(Bitset("000111000100").PCSPIsParentRootsplit(), false);
-  CHECK_EQ(Bitset("101010000").PCSPIsParentRootsplit(), true);
+  CHECK_EQ(Bitset("000111010").EdgeIsParentRootsplit(), false);
+  CHECK_EQ(Bitset("000111000100").EdgeIsParentRootsplit(), false);
+  CHECK_EQ(Bitset("101010000").EdgeIsParentRootsplit(), true);
 
-  CHECK_EQ(Bitset("100011001").PCSPGetParentSubsplit(), Bitset("100011"));
-  CHECK_EQ(Bitset("011100001").PCSPGetParentSubsplit(), Bitset("100011"));
-  CHECK_EQ(Bitset("100011001").PCSPGetChildSubsplit(), Bitset("010001"));
-  CHECK_EQ(Bitset("100001110001").PCSPGetChildSubsplit(), Bitset("01100001"));
-  CHECK_EQ(Bitset("100001110001").PCSPGetChildSubsplitTaxonCounts(), SizePair({1, 2}));
-  CHECK_EQ(Bitset("100000111100101").PCSPGetChildSubsplitTaxonCounts(),
+  CHECK_EQ(Bitset("100011001").EdgeGetParentSubsplit(), Bitset("100011"));
+  CHECK_EQ(Bitset("011100001").EdgeGetParentSubsplit(), Bitset("100011"));
+  CHECK_EQ(Bitset("100011001").EdgeGetChildSubsplit(), Bitset("010001"));
+  CHECK_EQ(Bitset("100001110001").EdgeGetChildSubsplit(), Bitset("01100001"));
+  CHECK_EQ(Bitset("100001110001").EdgeGetChildSubsplitTaxonCounts(), SizePair({1, 2}));
+  CHECK_EQ(Bitset("100000111100101").EdgeGetChildSubsplitTaxonCounts(),
            SizePair({2, 2}));
 
   CHECK_EQ(Bitset::Singleton(4, 2), Bitset("0010"));
@@ -445,34 +464,36 @@ TEST_CASE("Bitset: Clades, Subsplits, PCSPs") {
   CHECK_THROWS(Bitset::Subsplit(Bitset("1100"), Bitset("001")));
   CHECK_THROWS(Bitset::Subsplit(Bitset("111"), Bitset("001")));
 
-  CHECK_EQ(Bitset("000110010"), Bitset::PCSP(Bitset("110000"), Bitset("100010")));
-  CHECK_EQ(Bitset("110001000"), Bitset::PCSP(Bitset("110001"), Bitset("001000")));
+  CHECK_EQ(Bitset("000110010"), Bitset::Edge(Bitset("110000"), Bitset("100010")));
+  CHECK_EQ(Bitset("110001000"), Bitset::Edge(Bitset("110001"), Bitset("001000")));
   // Invalid parent-child pair.
-  CHECK_THROWS(Bitset::PCSP(Bitset("110001"), Bitset("010001")));
-  CHECK_THROWS(Bitset::PCSP(Bitset("11000101"), Bitset("010001")));
-  CHECK_THROWS(Bitset::PCSP(Bitset("110001"), Bitset("110100")));
+  CHECK_THROWS(Bitset::Edge(Bitset("110001"), Bitset("010001")));
+  CHECK_THROWS(Bitset::Edge(Bitset("11000101"), Bitset("010001")));
+  CHECK_THROWS(Bitset::Edge(Bitset("110001"), Bitset("110100")));
 
-  CHECK_EQ(Bitset::RootsplitOfHalf(Bitset("0011")), Bitset("11000011"));
-  CHECK_EQ(Bitset::PCSPOfRootsplit(Bitset("11000011")), Bitset("000011110011"));
+  CHECK_EQ(Bitset::RootsplitOfClade(Bitset("0011")), Bitset("11000011"));
+  CHECK_EQ(Bitset::EdgeToRootsplit(Bitset("11000011")), Bitset("000011110011"));
 
   CHECK_EQ(Bitset("010000").SubsplitIsLeaf(), true);
   CHECK_EQ(Bitset("010010").SubsplitIsLeaf(), false);
   CHECK_EQ(Bitset("111000").SubsplitIsLeaf(), false);
-  CHECK_EQ(Bitset::FakeSubsplit(Bitset("010")), Bitset("010000"));
-  CHECK_EQ(Bitset::FakeChildSubsplit(Bitset("100001")), Bitset("001000"));
-  CHECK_THROWS(Bitset::FakeChildSubsplit(Bitset("100011")));
-  CHECK_EQ(Bitset::FakePCSP(Bitset("100001")), Bitset("100001000"));
-  CHECK_THROWS(Bitset::FakePCSP(Bitset("0000110")));
-  CHECK_THROWS(Bitset::FakePCSP(Bitset("100101")));
+  CHECK_EQ(Bitset::LeafSubsplitOfNonemptyClade(Bitset("010")), Bitset("010000"));
+  CHECK_EQ(Bitset::LeafSubsplitOfParentSubsplit(Bitset("100001")), Bitset("001000"));
+  CHECK_THROWS(Bitset::LeafSubsplitOfParentSubsplit(Bitset("100011")));
+  CHECK_EQ(Bitset::EdgeToLeaf(Bitset("100001")), Bitset("100001000"));
+  CHECK_THROWS(Bitset::EdgeToLeaf(Bitset("0000110")));
+  CHECK_THROWS(Bitset::EdgeToLeaf(Bitset("100101")));
 
   // Restrict a bitset.
-  CHECK_EQ(Remap(Bitset("10101010101"), {0, 2, 4, 6, 8, 10}), Bitset("111111"));
+  CHECK_EQ(Bitset::Remap(Bitset("10101010101"), {0, 2, 4, 6, 8, 10}), Bitset("111111"));
   // If we apply this remap 3 times we should get back to where we started.
   SizeOptionVector rotate120{6, 7, 8, 0, 1, 2, 3, 4, 5};
   auto to_rotate = Bitset("110010100");
-  CHECK_EQ(Remap(Remap(Remap(to_rotate, rotate120), rotate120), rotate120), to_rotate);
+  CHECK_EQ(Bitset::Remap(Bitset::Remap(Bitset::Remap(to_rotate, rotate120), rotate120),
+                         rotate120),
+           to_rotate);
   // "Lift" a bitset.
-  CHECK_EQ(Remap(Bitset("11"), {0, std::nullopt, 1}), Bitset("101"));
+  CHECK_EQ(Bitset::Remap(Bitset("11"), {0, std::nullopt, 1}), Bitset("101"));
 }
 
 TEST_CASE("Bitset: Subsplit Sort") {

--- a/src/bitset.hpp
+++ b/src/bitset.hpp
@@ -129,7 +129,7 @@ class Bitset {
   // taxon representation gives the precise opposite ordering to sorting by binary
   // representation (except in the case of zero/empty set!).
   static int CladeCompare(const Bitset &bitset_a, const Bitset &bitset_b);
-  int CladeCompare(const Bitset &bitset_b) const;
+  int CladeCompare(const Bitset &other) const;
   // For a specified number of clades, return the clade/taxon size.
   size_t MultiCladeGetCladeSize(const size_t clade_count) const;
   // For a specified number of clades, return a bitset of the ith clade.
@@ -147,8 +147,8 @@ class Bitset {
 
   static inline size_t SubsplitCladeCount = 2;
   enum class SubsplitClade : bool {
-    LEFT = 0,  /* ROTATED, LEXICO_SMALLER, BIN_LARGER */
-    RIGHT = 1, /* SORTED, LEXICO_LARGER, BIN_SMALLER */
+    Left = 0,  
+    Right = 1, 
   };
 
   // Constructors:
@@ -167,7 +167,7 @@ class Bitset {
   static Bitset SubsplitFromUnorderedClades(const Bitset &clade_0,
                                             const Bitset &clade_1);
   // Special Constructors:
-  // A "leaf" (formerly "leaf") subsplit is a subsplit where one of the clades is equal
+  // A "leaf subsplit" is a subsplit where one of the clades is equal
   // to the empty set (zero). In practice, these are allowed in only two cases: When
   // subsplit is a leaf or root.  A leaf should only have a single member in its
   // non-empty clade, and a root should have the full taxon set in its non-empty clade.
@@ -177,10 +177,10 @@ class Bitset {
   // Make a "leaf" child subsplit of a given parent subsplit. The leftside clade of
   // the parent subsplit must be non-empty and the rightside clade must be a singleton.
   static Bitset LeafSubsplitOfParentSubsplit(const Bitset &parent_subsplit);
-  // Get the subsplit of the DAG root node with the given taxon count.
+  // Make the UCA (universal common ancestor) subsplit of the DAG root node with the given taxon count.
   // Since subsplit bitsets are always big-small, the DAG root node subsplit
   // consists of all 1s then 0s (e.g. 5 would return '11111|00000').
-  static Bitset RootSubsplitOfTaxonCount(const size_t taxon_count);
+  static Bitset UCASubsplitOfTaxonCount(const size_t taxon_count);
   // Get the full rootsplit bitset out of a rootsplit half.
   // Note: the first half of the rootsplit bitset is always larger than the second.
   static Bitset RootsplitOfClade(const Bitset &clade);
@@ -250,11 +250,11 @@ class Bitset {
   // example, `000111010` is the Edge from the DAG root node to the rootsplit (AC, B).
   // See the unit tests at the bottom for more examples.
 
-  static inline size_t EdgeCladeCount = 3;
-  enum class EdgeClade : size_t {
-    SISTER = 0,
-    FOCAL = 1,
-    LEFT_CHILD = 2 /* ROTATED_CHILD */
+  static inline size_t PCSPCladeCount = 3;
+  enum class PCSPClade : size_t {
+    Sister = 0,
+    Focal = 1,
+    LeftChild = 2
   };
 
   // Constructors:
@@ -295,7 +295,7 @@ class Bitset {
   size_t EdgeGetCladeSize() const;
   // Get the ith clade of the Edge.
   Bitset EdgeGetClade(const size_t which_clade) const;
-  Bitset EdgeGetClade(const EdgeClade which_clade) const;
+  Bitset EdgeGetClade(const PCSPClade which_clade) const;
   // Get the parent subsplit of the Edge.
   Bitset EdgeGetParentSubsplit() const;
   // Get the child subsplit of the Edge.
@@ -409,12 +409,12 @@ TEST_CASE("Bitset") {
 TEST_CASE("Bitset: Clades, Subsplits, Edges") {
   auto p = Bitset("000111");
   // Subsplit: 000|111
-  CHECK_EQ(p.SubsplitGetClade(Bitset::SubsplitClade::LEFT), Bitset("000"));
-  CHECK_EQ(p.SubsplitGetClade(Bitset::SubsplitClade::RIGHT), Bitset("111"));
+  CHECK_EQ(p.SubsplitGetClade(Bitset::SubsplitClade::Left), Bitset("000"));
+  CHECK_EQ(p.SubsplitGetClade(Bitset::SubsplitClade::Right), Bitset("111"));
   // Edge: 00|01|11
-  CHECK_EQ(p.EdgeGetClade(Bitset::EdgeClade::SISTER), Bitset("00"));
-  CHECK_EQ(p.EdgeGetClade(Bitset::EdgeClade::FOCAL), Bitset("01"));
-  CHECK_EQ(p.EdgeGetClade(Bitset::EdgeClade::LEFT_CHILD), Bitset("11"));
+  CHECK_EQ(p.EdgeGetClade(Bitset::PCSPClade::Sister), Bitset("00"));
+  CHECK_EQ(p.EdgeGetClade(Bitset::PCSPClade::Focal), Bitset("01"));
+  CHECK_EQ(p.EdgeGetClade(Bitset::PCSPClade::LeftChild), Bitset("11"));
 
   CHECK_EQ(Bitset("11001010").SubsplitCladeUnion(), Bitset("1110"));
 

--- a/src/generic_sbn_instance.hpp
+++ b/src/generic_sbn_instance.hpp
@@ -353,7 +353,8 @@ class GenericSBNInstance {
   // The input to this function is a parent subsplit (of length 2n).
   Node::NodePtr SampleTopology(const Bitset &parent_subsplit) const {
     auto process_subsplit = [this](const Bitset &parent) {
-      auto singleton_option = parent.SubsplitGetClade(1).SingletonOption();
+      auto singleton_option =
+          parent.SubsplitGetClade(Bitset::SubsplitClade::RIGHT).SingletonOption();
       if (singleton_option) {
         return Node::Leaf(*singleton_option);
       }  // else

--- a/src/generic_sbn_instance.hpp
+++ b/src/generic_sbn_instance.hpp
@@ -354,7 +354,7 @@ class GenericSBNInstance {
   Node::NodePtr SampleTopology(const Bitset &parent_subsplit) const {
     auto process_subsplit = [this](const Bitset &parent) {
       auto singleton_option =
-          parent.SubsplitGetClade(Bitset::SubsplitClade::RIGHT).SingletonOption();
+          parent.SubsplitGetClade(Bitset::SubsplitClade::Right).SingletonOption();
       if (singleton_option) {
         return Node::Leaf(*singleton_option);
       }  // else

--- a/src/gp_dag.hpp
+++ b/src/gp_dag.hpp
@@ -4,6 +4,7 @@
 // The purpose of this class is to hold a DAG that we use to build up the operations for
 // the generalized pruning operations. Note that rootsplit PCSPs and the DAG root node
 // are excluded from operations.
+// GPOperationVectors are then consumed and calculated by GPEngine::ProcessOperations().
 
 #pragma once
 
@@ -25,8 +26,14 @@ class GPDAG : public TidySubsplitDAG {
   using TidySubsplitDAG::TidySubsplitDAG;
 
   // Get the index of a PLV of a given type and with a given index.
+  static PLVType RPLVType(bool rotated);
   static size_t GetPLVIndexStatic(PLVType plv_type, size_t node_count, size_t src_idx);
   size_t GetPLVIndex(PLVType plv_type, size_t src_idx) const;
+
+  // ** GPOperations:
+  // These methods generate a serial vector of operations, but perform no computation.
+  // These operation vectors can then be computed and consumed by the
+  // GPEngine::ProcessOperations().
 
   // Optimize branch lengths without handling out of date PLVs.
   [[nodiscard]] GPOperationVector ApproximateBranchLengthOptimization() const;

--- a/src/gp_doctest.cpp
+++ b/src/gp_doctest.cpp
@@ -656,26 +656,26 @@ TEST_CASE("GPInstance: IsValidAddNodePair tests") {
   auto inst = GPInstanceOfFiles(fasta_path, "data/five_taxon_rooted_more_2.nwk");
   auto& dag = inst.GetDAG();
 
-  // (NOT_VALID) Nodes are not adjacent (12|34 and 2|4).
-  CHECK(!dag.IsValidAddNodePair(Bitset::Subsplit("01100", "00011"),
+  // Nodes are not adjacent (12|34 and 2|4).
+  CHECK_FALSE(dag.IsValidAddNodePair(Bitset::Subsplit("01100", "00011"),
                                 Bitset::Subsplit("00100", "00001")));
-  // (NOT_VALID) Nodes have 5 taxa while the DAG has 4 (12|34 and 1|2).
-  CHECK(!dag.IsValidAddNodePair(Bitset::Subsplit("011000", "000110"),
+  // Nodes have 5 taxa while the DAG has 4 (12|34 and 1|2).
+  CHECK_FALSE(dag.IsValidAddNodePair(Bitset::Subsplit("011000", "000110"),
                                 Bitset::Subsplit("010000", "001000")));
   // (NOT_VALID) Parent node does not have a parent (12|3 and 1|2).
-  CHECK(!dag.IsValidAddNodePair(Bitset::Subsplit("01100", "00010"),
+  CHECK_FALSE(dag.IsValidAddNodePair(Bitset::Subsplit("01100", "00010"),
                                 Bitset::Subsplit("01000", "00100")));
   // (NOT_VALID) Rotated clade of the parent node does not have a child (02|134 and
   // 1|34).
-  CHECK(!dag.IsValidAddNodePair(Bitset::Subsplit("10100", "01011"),
+  CHECK_FALSE(dag.IsValidAddNodePair(Bitset::Subsplit("10100", "01011"),
                                 Bitset::Subsplit("01000", "00011")));
   // (NOT_VALID) Rotated clade of the child node does not have a child (0123|4 and
   // 023|1).
-  CHECK(!dag.IsValidAddNodePair(Bitset::Subsplit("11110", "00001"),
+  CHECK_FALSE(dag.IsValidAddNodePair(Bitset::Subsplit("11110", "00001"),
                                 Bitset::Subsplit("10110", "01000")));
   // (NOT_VALID) Sorted clade of the child node does not have a child (0123|4 and
   // 0|123).
-  CHECK(!dag.IsValidAddNodePair(Bitset::Subsplit("11110", "00001"),
+  CHECK_FALSE(dag.IsValidAddNodePair(Bitset::Subsplit("11110", "00001"),
                                 Bitset::Subsplit("10000", "01110")));
   // (VALID) Valid new node pair (0123|4 and 012|3).
   CHECK(dag.IsValidAddNodePair(Bitset::Subsplit("11110", "00001"),

--- a/src/gp_doctest.cpp
+++ b/src/gp_doctest.cpp
@@ -14,6 +14,7 @@
 
 using namespace GPOperations;  // NOLINT
 
+// #350 consider use of GPCSP.
 // GPCSP stands for generalized PCSP-- see text.
 
 // Let the "venus" node be the common ancestor of mars and saturn.

--- a/src/gp_doctest.cpp
+++ b/src/gp_doctest.cpp
@@ -662,22 +662,22 @@ TEST_CASE("GPInstance: IsValidAddNodePair tests") {
   // Nodes have 5 taxa while the DAG has 4 (12|34 and 1|2).
   CHECK_FALSE(dag.IsValidAddNodePair(Bitset::Subsplit("011000", "000110"),
                                      Bitset::Subsplit("010000", "001000")));
-  // (NOT_VALID) Parent node does not have a parent (12|3 and 1|2).
+  // Parent node does not have a parent (12|3 and 1|2).
   CHECK_FALSE(dag.IsValidAddNodePair(Bitset::Subsplit("01100", "00010"),
                                      Bitset::Subsplit("01000", "00100")));
-  // (NOT_VALID) Rotated clade of the parent node does not have a child (02|134 and
+  // Rotated clade of the parent node does not have a child (02|134 and
   // 1|34).
   CHECK_FALSE(dag.IsValidAddNodePair(Bitset::Subsplit("10100", "01011"),
                                      Bitset::Subsplit("01000", "00011")));
-  // (NOT_VALID) Rotated clade of the child node does not have a child (0123|4 and
+  // Rotated clade of the child node does not have a child (0123|4 and
   // 023|1).
   CHECK_FALSE(dag.IsValidAddNodePair(Bitset::Subsplit("11110", "00001"),
                                      Bitset::Subsplit("10110", "01000")));
-  // (NOT_VALID) Sorted clade of the child node does not have a child (0123|4 and
+  // Sorted clade of the child node does not have a child (0123|4 and
   // 0|123).
   CHECK_FALSE(dag.IsValidAddNodePair(Bitset::Subsplit("11110", "00001"),
                                      Bitset::Subsplit("10000", "01110")));
-  // (VALID) Valid new node pair (0123|4 and 012|3).
+  // Valid new node pair (0123|4 and 012|3).
   CHECK(dag.IsValidAddNodePair(Bitset::Subsplit("11110", "00001"),
                                Bitset::Subsplit("11100", "00010")));
 }

--- a/src/gp_doctest.cpp
+++ b/src/gp_doctest.cpp
@@ -658,25 +658,25 @@ TEST_CASE("GPInstance: IsValidAddNodePair tests") {
 
   // Nodes are not adjacent (12|34 and 2|4).
   CHECK_FALSE(dag.IsValidAddNodePair(Bitset::Subsplit("01100", "00011"),
-                                Bitset::Subsplit("00100", "00001")));
+                                     Bitset::Subsplit("00100", "00001")));
   // Nodes have 5 taxa while the DAG has 4 (12|34 and 1|2).
   CHECK_FALSE(dag.IsValidAddNodePair(Bitset::Subsplit("011000", "000110"),
-                                Bitset::Subsplit("010000", "001000")));
+                                     Bitset::Subsplit("010000", "001000")));
   // (NOT_VALID) Parent node does not have a parent (12|3 and 1|2).
   CHECK_FALSE(dag.IsValidAddNodePair(Bitset::Subsplit("01100", "00010"),
-                                Bitset::Subsplit("01000", "00100")));
+                                     Bitset::Subsplit("01000", "00100")));
   // (NOT_VALID) Rotated clade of the parent node does not have a child (02|134 and
   // 1|34).
   CHECK_FALSE(dag.IsValidAddNodePair(Bitset::Subsplit("10100", "01011"),
-                                Bitset::Subsplit("01000", "00011")));
+                                     Bitset::Subsplit("01000", "00011")));
   // (NOT_VALID) Rotated clade of the child node does not have a child (0123|4 and
   // 023|1).
   CHECK_FALSE(dag.IsValidAddNodePair(Bitset::Subsplit("11110", "00001"),
-                                Bitset::Subsplit("10110", "01000")));
+                                     Bitset::Subsplit("10110", "01000")));
   // (NOT_VALID) Sorted clade of the child node does not have a child (0123|4 and
   // 0|123).
   CHECK_FALSE(dag.IsValidAddNodePair(Bitset::Subsplit("11110", "00001"),
-                                Bitset::Subsplit("10000", "01110")));
+                                     Bitset::Subsplit("10000", "01110")));
   // (VALID) Valid new node pair (0123|4 and 012|3).
   CHECK(dag.IsValidAddNodePair(Bitset::Subsplit("11110", "00001"),
                                Bitset::Subsplit("11100", "00010")));

--- a/src/gp_doctest.cpp
+++ b/src/gp_doctest.cpp
@@ -720,22 +720,18 @@ TEST_CASE("GPInstance: AddNodePair tests") {
   const auto child_node = dag.GetDAGNode(dag.GetDAGNodeId(child_subsplit));
   std::map<bool, SizeVector> correct_parents_of_parent{{true, {}}, {false, {16, 14}}};
   std::map<bool, SizeVector> parents_of_parent{
-      {true, parent_node->GetRootwardLeftward()},
-      {false, parent_node->GetRootwardRightward()}};
+      {true, parent_node->GetLeftRootward()}, {false, parent_node->GetRightRootward()}};
   CHECK_EQ(parents_of_parent, correct_parents_of_parent);
   std::map<bool, SizeVector> children_of_parent{
-      {true, parent_node->GetLeafwardLeftward()},
-      {false, parent_node->GetLeafwardRightward()}};
+      {true, parent_node->GetLeftLeafward()}, {false, parent_node->GetRightLeafward()}};
   std::map<bool, SizeVector> correct_children_of_parent{{true, {12}}, {false, {3}}};
   CHECK_EQ(children_of_parent, correct_children_of_parent);
   std::map<bool, SizeVector> parents_of_children{
-      {true, child_node->GetRootwardLeftward()},
-      {false, child_node->GetRootwardRightward()}};
+      {true, child_node->GetLeftRootward()}, {false, child_node->GetRightRootward()}};
   std::map<bool, SizeVector> correct_parents_of_children{{true, {13}}, {false, {}}};
   CHECK_EQ(parents_of_children, correct_parents_of_children);
-  std::map<bool, SizeVector> children_of_child{
-      {true, child_node->GetLeafwardLeftward()},
-      {false, child_node->GetLeafwardRightward()}};
+  std::map<bool, SizeVector> children_of_child{{true, child_node->GetLeftLeafward()},
+                                               {false, child_node->GetRightLeafward()}};
   std::map<bool, SizeVector> correct_children_of_child{{true, {2}}, {false, {4}}};
   CHECK_EQ(children_of_child, correct_children_of_child);
   // Check that node_reindexer and edge_reindexer are correct.
@@ -755,8 +751,8 @@ TEST_CASE("GPInstance: AddNodePair tests") {
   const auto& node_14 = dag.GetDAGNode(14);
   CHECK_EQ(node_14->GetBitset().ToString(), "0100000111");
   // Check that node fields were updated correctly.
-  const auto& sorted_parents_14 = node_14->GetRootwardRightward();
-  const auto& sorted_children_14 = node_14->GetLeafwardRightward();
+  const auto& sorted_parents_14 = node_14->GetRightRootward();
+  const auto& sorted_children_14 = node_14->GetRightLeafward();
   CHECK(std::find(sorted_parents_14.begin(), sorted_parents_14.end(), 13) ==
         sorted_parents_14.end());
   CHECK(std::find(sorted_parents_14.begin(), sorted_parents_14.end(), 15) !=

--- a/src/gp_engine.cpp
+++ b/src/gp_engine.cpp
@@ -12,11 +12,12 @@ GPEngine::GPEngine(SitePattern site_pattern, size_t plv_count, size_t gpcsp_coun
                    EigenVectorXd unconditional_node_probabilities,
                    EigenVectorXd inverted_sbn_prior)
     : site_pattern_(std::move(site_pattern)),
-      plv_count_(plv_count),
       rescaling_threshold_(rescaling_threshold),
       log_rescaling_threshold_(log(rescaling_threshold)),
+      plv_count_(plv_count),
       mmapped_master_plv_(mmap_file_path, plv_count_ * site_pattern_.PatternCount()),
       plvs_(mmapped_master_plv_.Subdivide(plv_count_)),
+      gpcsp_count_(gpcsp_count),
       q_(std::move(sbn_prior)),
       unconditional_node_probabilities_(std::move(unconditional_node_probabilities)),
       inverted_sbn_prior_(std::move(inverted_sbn_prior)) {
@@ -24,6 +25,7 @@ GPEngine::GPEngine(SitePattern site_pattern, size_t plv_count, size_t gpcsp_coun
              plvs_.back().cols() ==
                  static_cast<Eigen::Index>(site_pattern_.PatternCount()),
          "Didn't get the right shape of PLVs out of Subdivide.");
+  // per-edge data
   rescaling_counts_.resize(plv_count_);
   rescaling_counts_.setZero();
   branch_lengths_.resize(gpcsp_count);
@@ -31,17 +33,19 @@ GPEngine::GPEngine(SitePattern site_pattern, size_t plv_count, size_t gpcsp_coun
   log_marginal_likelihood_.resize(site_pattern_.PatternCount());
   log_marginal_likelihood_.setConstant(DOUBLE_NEG_INF);
   log_likelihoods_.resize(gpcsp_count, site_pattern_.PatternCount());
+  hybrid_marginal_log_likelihoods_.resize(gpcsp_count);
+  hybrid_marginal_log_likelihoods_.setConstant(DOUBLE_NEG_INF);
 
+  // site pattern
   auto weights = site_pattern_.GetWeights();
   site_pattern_weights_ = EigenVectorXdOfStdVectorDouble(weights);
 
+  // per-node data
   quartet_root_plv_ = plvs_.at(0);
   quartet_root_plv_.setZero();
   quartet_r_s_plv_ = quartet_root_plv_;
   quartet_q_s_plv_ = quartet_root_plv_;
   quartet_r_sorted_plv_ = quartet_root_plv_;
-  hybrid_marginal_log_likelihoods_.resize(gpcsp_count);
-  hybrid_marginal_log_likelihoods_.setConstant(DOUBLE_NEG_INF);
 
   InitializePLVsWithSitePatterns();
 }

--- a/src/gp_engine.hpp
+++ b/src/gp_engine.hpp
@@ -11,6 +11,7 @@
 #include "mmapped_plv.hpp"
 #include "numerical_utils.hpp"
 #include "quartet_hybrid_request.hpp"
+#include "reindexer.hpp"
 #include "rooted_tree_collection.hpp"
 #include "sbn_maps.hpp"
 #include "site_pattern.hpp"
@@ -22,6 +23,11 @@ class GPEngine {
            const std::string& mmap_file_path, double rescaling_threshold,
            EigenVectorXd sbn_prior, EigenVectorXd unconditional_node_probabilities,
            EigenVectorXd inverted_sbn_prior);
+
+  // Make copy of engine, resize to contain
+  GPEngine CopyEngine(const std::string& new_mmap_file_path,
+                      const std::optional<size_t> plv_count = std::nullopt,
+                      const std::optional<size_t> gpcsp_count = std::nullopt);
 
   // These operators mean that we can invoke this class on each of the operations.
   void operator()(const GPOperations::ZeroPLV& op);
@@ -35,17 +41,18 @@ class GPEngine {
   void operator()(const GPOperations::UpdateSBNProbabilities& op);
   void operator()(const GPOperations::PrepForMarginalization& op);
 
+  // Apply all operations in vector in order from beginning to end.
   void ProcessOperations(GPOperationVector operations);
-
   void SetTransitionMatrixToHaveBranchLength(double branch_length);
   void SetTransitionAndDerivativeMatricesToHaveBranchLength(double branch_length);
   void SetTransitionMatrixToHaveBranchLengthAndTranspose(double branch_length);
   const Eigen::Matrix4d& GetTransitionMatrix() { return transition_matrix_; };
-
+  //
   void SetBranchLengths(EigenVectorXd branch_lengths);
   void SetBranchLengthsToConstant(double branch_length);
   void ResetLogMarginalLikelihood();
   double GetLogMarginalLikelihood() const;
+
   EigenVectorXd GetBranchLengths() const;
   // This function returns a vector indexed by GPCSP such that the i-th entry
   // stores the log of the across-sites product of
@@ -68,104 +75,30 @@ class GPEngine {
   EigenConstVectorXdRef GetHybridMarginals() const;
   EigenConstVectorXdRef GetSBNParameters() const;
 
+  size_t GetSitePatternCount() const { return site_pattern_.PatternCount(); };
   // Calculate a vector of likelihoods, one for each summand of the hybrid marginal.
   EigenVectorXd CalculateQuartetHybridLikelihoods(const QuartetHybridRequest& request);
   // Calculate the actual hybrid marginal and store it in the corresponding entry of
   // hybrid_marginal_log_likelihoods_.
   void ProcessQuartetHybridRequest(const QuartetHybridRequest& request);
-
   void PrintPLV(size_t plv_idx);
-
   // Use branch lengths from loaded sample as a starting point for optimization.
   void HotStartBranchLengths(const RootedTreeCollection& tree_collection,
                              const BitsetSizeMap& indexer);
   // Gather branch lengths from loaded sample with their corresponding pcsp.
   SizeDoubleVectorMap GatherBranchLengths(const RootedTreeCollection& tree_collection,
                                           const BitsetSizeMap& indexer);
+  void FunctionOverRootedTreeCollection(
+      std::function<void(size_t, const RootedTree&, const Node*)>
+          function_on_tree_node_by_gpcsp,
+      const RootedTreeCollection& tree_collection, const BitsetSizeMap& indexer);
 
   DoublePair LogLikelihoodAndDerivative(const GPOperations::OptimizeBranchLength& op);
-
-  static constexpr double default_rescaling_threshold_ = 1e-40;
-  static constexpr double default_branch_length_ = 0.1;
 
   double PLVByteCount() const { return mmapped_master_plv_.ByteCount(); };
 
  private:
-  static constexpr double min_log_branch_length_ = -13.9;
-  static constexpr double max_log_branch_length_ = 1.1;
-
-  int significant_digits_for_optimization_ = 6;
-  double relative_tolerance_for_optimization_ = 1e-2;
-  double step_size_for_optimization_ = 5e-4;
-  size_t max_iter_for_optimization_ = 1000;
-
-  // The length of this vector is equal to the number of site patterns.
-  // Entry j stores the marginal log likelihood over all trees at site pattern
-  // j.
-  EigenVectorXd log_marginal_likelihood_;
-
-  // This vector is indexed by the GPCSPs and stores the hybrid marginals if they are
-  // available.
-  EigenVectorXd hybrid_marginal_log_likelihoods_;
-
-  SitePattern site_pattern_;
-  size_t plv_count_;
-  const double rescaling_threshold_;
-  const double log_rescaling_threshold_;
-  MmappedNucleotidePLV mmapped_master_plv_;
-  // plvs_ store the following (see GPDAG::GetPLVIndexStatic):
-  // [0, num_nodes): p(s).
-  // [num_nodes, 2*num_nodes): phat(s).
-  // [2*num_nodes, 3*num_nodes): phat(s_tilde).
-  // [3*num_nodes, 4*num_nodes): rhat(s) = rhat(s_tilde).
-  // [4*num_nodes, 5*num_nodes): r(s).
-  // [5*num_nodes, 6*num_nodes): r(s_tilde).
-  NucleotidePLVRefVector plvs_;
-  EigenVectorXi rescaling_counts_;
-  // branch_lengths_, q_, etc. are indexed in the same way as sbn_parameters_ in
-  // gp_instance.
-  EigenVectorXd branch_lengths_;
-  EigenVectorXd q_;
-  EigenVectorXd unconditional_node_probabilities_;
-  EigenVectorXd inverted_sbn_prior_;
-
-  // The number of rows is equal to the number of GPCSPs.
-  // The number of columns is equal to the number of site patterns.
-  // The rows are indexed in the same way as branch_lengths_ and q_.
-  // Entry (i,j) stores the marginal log likelihood over all trees that include
-  // a GPCSP corresponding to index i at site j.
-  EigenMatrixXd log_likelihoods_;
-
-  // Internal "temporaries" useful for likelihood and derivative calculation.
-  EigenVectorXd per_pattern_log_likelihoods_;
-  EigenVectorXd per_pattern_likelihoods_;
-  EigenVectorXd per_pattern_likelihood_derivatives_;
-  EigenVectorXd per_pattern_likelihood_derivative_ratios_;
-
-  // When we change from JC69Model, check that we are actually doing transpose in
-  // leafward calculations.
-  JC69Model substitution_model_;
-  Eigen::Matrix4d eigenmatrix_ = substitution_model_.GetEigenvectors().reshaped(4, 4);
-  Eigen::Matrix4d inverse_eigenmatrix_ =
-      substitution_model_.GetInverseEigenvectors().reshaped(4, 4);
-  Eigen::Vector4d eigenvalues_ = substitution_model_.GetEigenvalues();
-  Eigen::Vector4d diagonal_vector_;
-  Eigen::DiagonalMatrix<double, 4> diagonal_matrix_;
-  Eigen::Matrix4d transition_matrix_;
-  Eigen::Matrix4d derivative_matrix_;
-  Eigen::Vector4d stationary_distribution_ = substitution_model_.GetFrequencies();
-  EigenVectorXd site_pattern_weights_;
-
-  // For hybrid marginal calculations. #328
-  // The PLV coming down from the root.
-  EigenMatrixXd quartet_root_plv_;
-  // The R-PLV pointing leafward from s.
-  EigenMatrixXd quartet_r_s_plv_;
-  // The Q-PLV pointing leafward from s.
-  EigenMatrixXd quartet_q_s_plv_;
-  // The R-PLV pointing leafward from t.
-  EigenMatrixXd quartet_r_sorted_plv_;
-
+  //
   void InitializePLVsWithSitePatterns();
 
   void RescalePLV(size_t plv_idx, int amount);
@@ -178,11 +111,6 @@ class GPEngine {
 
   void BrentOptimization(const GPOperations::OptimizeBranchLength& op);
   void GradientAscentOptimization(const GPOperations::OptimizeBranchLength& op);
-
-  void FunctionOverRootedTreeCollection(
-      std::function<void(size_t, const RootedTree&, const Node*)>
-          function_on_tree_node_by_gpcsp,
-      const RootedTreeCollection& tree_collection, const BitsetSizeMap& indexer);
 
   inline void PrepareUnrescaledPerPatternLikelihoodDerivatives(size_t src1_idx,
                                                                size_t src2_idx) {
@@ -211,6 +139,113 @@ class GPEngine {
             .log() +
         LogRescalingFor(src1_idx) + LogRescalingFor(src2_idx);
   }
+
+ public:
+  static constexpr double default_rescaling_threshold_ = 1e-40;
+  // Initial branch length during first branch length opimization.
+  static constexpr double default_branch_length_ = 0.1;
+
+ private:
+  // Absolute lower bound for possible branch lengths during optimization (in log
+  // space).
+  static constexpr double min_log_branch_length_ = -13.9;
+  // Absolute upper bound for possible branch lengths during optimization (in log
+  // space).
+  static constexpr double max_log_branch_length_ = 1.1;
+  // Precision used for checking convergence of branch length optimization.
+  int significant_digits_for_optimization_ = 6;
+  //
+  double relative_tolerance_for_optimization_ = 1e-2;
+  // Step size used for gradient-based branch length optimization.
+  double step_size_for_optimization_ = 5e-4;
+  // Number of iterations allowed for branch length optimization.
+  size_t max_iter_for_optimization_ = 1000;
+
+  // Descriptor containing all taxons and sequence alignments.
+  SitePattern site_pattern_;
+  // Rescaling threshold factor to prevent under/overflow errors.
+  const double rescaling_threshold_;
+  // Rescaling threshold in log space.
+  const double log_rescaling_threshold_;
+
+  // ** Per-Node Data
+
+  // Total number of PLVs across entire DAG. Proportional to the number of nodes in DAG.
+  // plv_count_ = node_count_without_root * plv_per_node.
+  const size_t plv_count_per_node_ = 6;
+  size_t plv_count_;
+  // Master PLV: Large data block of virtual memory for Partial Likelihood Vectors.
+  // Subdivided into sections for plvs_.
+  std::unique_ptr<MmappedNucleotidePLV> mmapped_master_plv_ptr_ = nullptr;
+  MmappedNucleotidePLV mmapped_master_plv_;
+  // Partial Likelihood Vectors.
+  // plvs_ store the following (see GPDAG::GetPLVIndexStatic):
+  // [0, num_nodes): p(s).
+  // [num_nodes, 2*num_nodes): phat(s).
+  // [2*num_nodes, 3*num_nodes): phat(s_tilde).
+  // [3*num_nodes, 4*num_nodes): rhat(s) = rhat(s_tilde).
+  // [4*num_nodes, 5*num_nodes): r(s).
+  // [5*num_nodes, 6*num_nodes): r(s_tilde).
+  NucleotidePLVRefVector plvs_;
+  // Rescaling count for each plv.
+  EigenVectorXi rescaling_counts_;
+  // For hybrid marginal calculations. #328
+  // The PLV coming down from the root to s.
+  EigenMatrixXd quartet_root_plv_;
+  // The R-PLV pointing leafward from s.
+  EigenMatrixXd quartet_r_s_plv_;
+  // The Q-PLV pointing leafward from s.
+  EigenMatrixXd quartet_q_s_plv_;
+  // The R-PLV pointing leafward from t.
+  EigenMatrixXd quartet_r_sorted_plv_;
+
+  // ** Per-Edge Data
+
+  // Total number of edges in DAG.
+  size_t gpcsp_count_;
+  // branch_lengths_, q_, etc. are indexed in the same way as sbn_parameters_ in
+  // gp_instance.
+  EigenVectorXd branch_lengths_;
+  // During initialization, stores the SBN prior.
+  // After UpdateSBNProbabilities(), stores the SBN probabilities.
+  // Stored in log space.
+  EigenVectorXd q_;
+  EigenVectorXd unconditional_node_probabilities_;
+  EigenVectorXd inverted_sbn_prior_;
+  // The number of rows is equal to the number of GPCSPs.
+  // The number of columns is equal to the number of site patterns.
+  // The rows are indexed in the same way as branch_lengths_ and q_.
+  // Entry (i,j) stores the marginal log likelihood over all trees that include
+  // a GPCSP corresponding to index i at site j.
+  EigenMatrixXd log_likelihoods_;
+  // The length of this vector is equal to the number of site patterns.
+  // Entry j stores the marginal log likelihood over all trees at site pattern
+  // j.
+  EigenVectorXd log_marginal_likelihood_;
+  // This vector is indexed by the GPCSPs and stores the hybrid marginals if they are
+  // available.
+  EigenVectorXd hybrid_marginal_log_likelihoods_;
+  // Internal "temporaries" useful for likelihood and derivative calculation.
+  EigenVectorXd per_pattern_log_likelihoods_;
+  EigenVectorXd per_pattern_likelihoods_;
+  EigenVectorXd per_pattern_likelihood_derivatives_;
+  EigenVectorXd per_pattern_likelihood_derivative_ratios_;
+
+  // ** Model
+
+  // When we change from JC69Model, check that we are actually doing transpose in
+  // leafward calculations.
+  JC69Model substitution_model_;
+  Eigen::Matrix4d eigenmatrix_ = substitution_model_.GetEigenvectors().reshaped(4, 4);
+  Eigen::Matrix4d inverse_eigenmatrix_ =
+      substitution_model_.GetInverseEigenvectors().reshaped(4, 4);
+  Eigen::Vector4d eigenvalues_ = substitution_model_.GetEigenvalues();
+  Eigen::Vector4d diagonal_vector_;
+  Eigen::DiagonalMatrix<double, 4> diagonal_matrix_;
+  Eigen::Matrix4d transition_matrix_;
+  Eigen::Matrix4d derivative_matrix_;
+  Eigen::Vector4d stationary_distribution_ = substitution_model_.GetFrequencies();
+  EigenVectorXd site_pattern_weights_;
 };
 
 #ifdef DOCTEST_LIBRARY_INCLUDED

--- a/src/gp_engine.hpp
+++ b/src/gp_engine.hpp
@@ -154,7 +154,7 @@ class GPEngine {
   // Number of iterations allowed for branch length optimization.
   size_t max_iter_for_optimization_ = 1000;
 
-  // Descriptor containing all taxons and sequence alignments.
+  // Descriptor containing all taxa and sequence alignments.
   SitePattern site_pattern_;
   // Rescaling threshold factor to prevent under/overflow errors.
   const double rescaling_threshold_;

--- a/src/gp_engine.hpp
+++ b/src/gp_engine.hpp
@@ -24,11 +24,6 @@ class GPEngine {
            EigenVectorXd sbn_prior, EigenVectorXd unconditional_node_probabilities,
            EigenVectorXd inverted_sbn_prior);
 
-  // Make copy of engine, resize to contain
-  GPEngine CopyEngine(const std::string& new_mmap_file_path,
-                      const std::optional<size_t> plv_count = std::nullopt,
-                      const std::optional<size_t> gpcsp_count = std::nullopt);
-
   // These operators mean that we can invoke this class on each of the operations.
   void operator()(const GPOperations::ZeroPLV& op);
   void operator()(const GPOperations::SetToStationaryDistribution& op);
@@ -47,7 +42,6 @@ class GPEngine {
   void SetTransitionAndDerivativeMatricesToHaveBranchLength(double branch_length);
   void SetTransitionMatrixToHaveBranchLengthAndTranspose(double branch_length);
   const Eigen::Matrix4d& GetTransitionMatrix() { return transition_matrix_; };
-  //
   void SetBranchLengths(EigenVectorXd branch_lengths);
   void SetBranchLengthsToConstant(double branch_length);
   void ResetLogMarginalLikelihood();

--- a/src/gp_instance.cpp
+++ b/src/gp_instance.cpp
@@ -276,6 +276,7 @@ RootedTreeCollection GPInstance::GenerateCompleteRootedTreeCollection() {
 
 StringVector GPInstance::PrettyIndexer() const {
   StringVector pretty_representation(dag_.BuildEdgeIndexer().size());
+  // #350 consider use of edge vs pcsp here.
   for (const auto &[edge, idx] : dag_.BuildEdgeIndexer()) {
     pretty_representation[idx] = edge.PCSPToString();
   }

--- a/src/gp_instance.cpp
+++ b/src/gp_instance.cpp
@@ -277,7 +277,7 @@ RootedTreeCollection GPInstance::GenerateCompleteRootedTreeCollection() {
 StringVector GPInstance::PrettyIndexer() const {
   StringVector pretty_representation(dag_.BuildEdgeIndexer().size());
   for (const auto &[edge, idx] : dag_.BuildEdgeIndexer()) {
-    pretty_representation[idx] = edge.EdgeToString();
+    pretty_representation[idx] = edge.PCSPToString();
   }
   return pretty_representation;
 }

--- a/src/gp_instance.hpp
+++ b/src/gp_instance.hpp
@@ -31,7 +31,7 @@ class GPInstance {
   void MakeEngine(double rescaling_threshold = GPEngine::default_rescaling_threshold_);
   GPEngine *GetEngine() const;
   bool HasEngine() const;
-  void PrintGPCSPIndexer();
+  void PrintEdgeIndexer();
   void ProcessOperations(const GPOperationVector &operations);
   void HotStartBranchLengths();
   SizeDoubleVectorMap GatherBranchLengths();
@@ -94,8 +94,8 @@ class GPInstance {
   void CheckSequencesLoaded() const;
   void CheckTreesLoaded() const;
 
-  size_t GetGPCSPIndexForLeafNode(const Bitset &parent_subsplit,
-                                  const Node *leaf_node) const;
+  size_t GetEdgeIndexForLeafNode(const Bitset &parent_subsplit,
+                                 const Node *leaf_node) const;
   RootedTreeCollection TreesWithGPBranchLengthsOfTopologies(
       Node::NodePtrVec &&topologies) const;
   StringDoubleVector PrettyIndexedVector(EigenConstVectorXdRef v);

--- a/src/node.hpp
+++ b/src/node.hpp
@@ -190,13 +190,18 @@ class Node {
   static size_t SORotate(size_t n, uint32_t c);
 
  private:
+  // Vector of direct child descendents of node in tree topology.
   NodePtrVec children_;
-  // See beginning of file for notes about the id and the leaves.
+  // NOTE: See beginning of file for notes about the id and the leaves.
+  // Unique identifier in tree containing node.
   size_t id_;
+  // Bitset of all leaves below node (alternatively can view a leaf as a member of the
+  // taxon set in the tree).
   Bitset leaves_;
   // The tag_ is a pair of packed integers representing (1) the maximum leaf ID
   // of the leaves below this node, and (2) the number of leaves below the node.
   uint64_t tag_;
+  // Hashkey for node maps.
   size_t hash_;
 
   // Make copy constructors private to eliminate copying.

--- a/src/psp_indexer.cpp
+++ b/src/psp_indexer.cpp
@@ -21,8 +21,8 @@ PSPIndexer::PSPIndexer(BitsetVector rootsplits, BitsetSizeMap in_indexer) {
     // The first condition allows us to skip the rootsplits. We only want the
     // PCSPs here. The second condition is because the "primary" part of Primary
     // Subsplit Pair means that the parent split is a rootsplit.
-    if (iter.second >= rootsplits.size() && pcsp.EdgeIsParentRootsplit()) {
-      SafeInsert(indexer_, pcsp.EdgeGetChildSubsplit(), index);
+    if (iter.second >= rootsplits.size() && pcsp.PCSPIsParentRootsplit()) {
+      SafeInsert(indexer_, pcsp.PCSPGetChildSubsplit(), index);
       index++;
     }
   }
@@ -45,7 +45,7 @@ SizeVectorVector PSPIndexer::RepresentationOf(const Node::NodePtr& topology) con
   SizeVector psp_result_down(topology->Id(), first_empty_index_);
   SizeVector psp_result_up(topology->Id(), first_empty_index_);
   auto rootsplit_index = [&indexer = this->indexer_](const Node* node) {
-    return indexer.at(Bitset::RootsplitOfClade(node->Leaves()));
+    return indexer.at(Bitset::RootsplitSubsplitOfClade(node->Leaves()));
   };
   // Here we use the terminology in the 2019 ICLR paper (screenshotted in
   // https://github.com/phylovi/bito/issues/95) looking at the right-hand case

--- a/src/psp_indexer.cpp
+++ b/src/psp_indexer.cpp
@@ -21,8 +21,8 @@ PSPIndexer::PSPIndexer(BitsetVector rootsplits, BitsetSizeMap in_indexer) {
     // The first condition allows us to skip the rootsplits. We only want the
     // PCSPs here. The second condition is because the "primary" part of Primary
     // Subsplit Pair means that the parent split is a rootsplit.
-    if (iter.second >= rootsplits.size() && pcsp.PCSPIsParentRootsplit()) {
-      SafeInsert(indexer_, pcsp.PCSPGetChildSubsplit(), index);
+    if (iter.second >= rootsplits.size() && pcsp.EdgeIsParentRootsplit()) {
+      SafeInsert(indexer_, pcsp.EdgeGetChildSubsplit(), index);
       index++;
     }
   }
@@ -45,7 +45,7 @@ SizeVectorVector PSPIndexer::RepresentationOf(const Node::NodePtr& topology) con
   SizeVector psp_result_down(topology->Id(), first_empty_index_);
   SizeVector psp_result_up(topology->Id(), first_empty_index_);
   auto rootsplit_index = [&indexer = this->indexer_](const Node* node) {
-    return indexer.at(Bitset::RootsplitOfHalf(node->Leaves()));
+    return indexer.at(Bitset::RootsplitOfClade(node->Leaves()));
   };
   // Here we use the terminology in the 2019 ICLR paper (screenshotted in
   // https://github.com/phylovi/bito/issues/95) looking at the right-hand case

--- a/src/reindexer.hpp
+++ b/src/reindexer.hpp
@@ -1,5 +1,17 @@
 // Copyright 2019-2022 bito project contributors.
 // bito is free software under the GPLv3; see LICENSE file for details.
+//
+// Reindexers are argsorted index arrays that describe reordering of data due to
+// modifications of data vectors, such as when adding NNI pairs to the SubsplitDAG.
+// These reindexers can then be used to reorder associated data arrays whose indices
+// correspond the ordering of SubsplitDAG data arrays, such as with the node or edge
+// arrays.
+//
+// A reindexer is a SizeVector that can be thought of as a one-to-one function that maps
+// from an old indexing scheme to a new indexing scheme. In other words, if old index
+// `i` maps to new index `j`, then reindexer[`i`] = `j`. For example, if old_vector =
+// [A, B, C] and reindexer = [1, 2, 0], then new_vector = [C, A, B]. Note that
+// old_vector and reindexer must have the same size.
 
 #pragma once
 
@@ -8,13 +20,8 @@
 #include "eigen_sugar.hpp"
 #include "sugar.hpp"
 
-namespace Reindexer {
 // These operations are for working with reindexers.
-// A reindexer is a SizeVector that can be thought of as a function that maps from an
-// old indexing scheme to a new indexing scheme. In other words, if index `i` maps to
-// index `j`, then reindexer[`i`] = `j`. For example, if old_vector = [A, B, C] and
-// reindexer = [1, 2, 0], then new_vector = [C, A, B]. Note that old_vector and
-// reindexer must have the same size.
+namespace Reindexer {
 
 // For each position in a identity reindexer, reindexer[`i`] = `i`.
 // E.g. for size = 5, reindexer = [0, 1, 2, 3, 4].

--- a/src/rooted_sbn_instance.cpp
+++ b/src/rooted_sbn_instance.cpp
@@ -26,11 +26,10 @@ BitsetDoubleMap RootedSBNInstance::UnconditionalSubsplitProbabilities() const {
   const SubsplitDAG dag(tree_collection_);
   EigenVectorXd sbn_parameters = NormalizedSBNParameters();
   // Expand sbn_parameters to include fake subsplits.
-  Assert(sbn_parameters.size() == static_cast<Eigen::Index>(dag.GPCSPCount()),
-         "GPCSP count mismatch.");
-  sbn_parameters.conservativeResize(dag.GPCSPCountWithFakeSubsplits());
+  Assert(size_t(sbn_parameters.size()) == dag.EdgeCount(), "GPCSP count mismatch.");
+  sbn_parameters.conservativeResize(dag.EdgeCountWithLeafSubsplits());
   sbn_parameters
-      .segment(dag.GPCSPCount(), dag.GPCSPCountWithFakeSubsplits() - dag.GPCSPCount())
+      .segment(dag.EdgeCount(), dag.EdgeCountWithLeafSubsplits() - dag.EdgeCount())
       .setOnes();
   return dag.UnconditionalSubsplitProbabilities(sbn_parameters);
 }

--- a/src/rooted_sbn_support.hpp
+++ b/src/rooted_sbn_support.hpp
@@ -11,7 +11,8 @@ class RootedSBNSupport : public SBNSupport {
   explicit RootedSBNSupport(const Node::TopologyCounter &topologies,
                             StringVector taxon_names)
       : SBNSupport(std::move(taxon_names)) {
-    std::tie(rootsplits_, indexer_, index_to_child_, parent_to_range_, gpcsp_count_) =
+    std::tie(rootsplits_, indexer_, index_to_child_, parent_to_child_range_,
+             gpcsp_count_) =
         SBNMaps::BuildIndexerBundle(RootedSBNMaps::RootsplitCounterOf(topologies),
                                     RootedSBNMaps::PCSPCounterOf(topologies));
   }

--- a/src/sbn_maps.cpp
+++ b/src/sbn_maps.cpp
@@ -93,7 +93,7 @@ IndexerBundle SBNMaps::BuildIndexerBundle(const BitsetSizeDict& rootsplit_counte
   size_t index = 0;
   // Start by adding the rootsplit PCSPs.
   size_t taxon_count((rootsplit_counter.begin()->first).size() / 2);
-  Bitset dag_root(Bitset::RootSubsplitOfTaxonCount(taxon_count));
+  Bitset dag_root(Bitset::UCASubsplitOfTaxonCount(taxon_count));
   // Note: dag_root is rotated before being inserted into parent_to_range
   // because the rootsplits are connected to the DAG root via rotated edges.
   SafeInsert(parent_to_range, dag_root.SubsplitRotate(),

--- a/src/sbn_maps.cpp
+++ b/src/sbn_maps.cpp
@@ -93,10 +93,10 @@ IndexerBundle SBNMaps::BuildIndexerBundle(const BitsetSizeDict& rootsplit_counte
   size_t index = 0;
   // Start by adding the rootsplit PCSPs.
   size_t taxon_count((rootsplit_counter.begin()->first).size() / 2);
-  Bitset dag_root(Bitset::UCASubsplitOfTaxonCount(taxon_count));
-  // Note: dag_root is rotated before being inserted into parent_to_range
+  Bitset uca_root(Bitset::UCASubsplitOfTaxonCount(taxon_count));
+  // Note: uca_root is rotated before being inserted into parent_to_range
   // because the rootsplits are connected to the DAG root via rotated edges.
-  SafeInsert(parent_to_range, dag_root.SubsplitRotate(),
+  SafeInsert(parent_to_range, uca_root.SubsplitRotate(),
              {index, index + rootsplit_counter.size()});
   for (const auto& iter : rootsplit_counter) {
     rootsplits.push_back(iter.first);

--- a/src/sbn_maps.cpp
+++ b/src/sbn_maps.cpp
@@ -34,7 +34,7 @@ SizeVector SBNMaps::SplitIndicesOf(const BitsetSizeMap& indexer,
     // Skip the root.
     if (node != topology.get()) {
       const Bitset rootsplit_pcsp =
-          Bitset::PCSPOfRootsplit(Bitset::RootsplitOfHalf(node->Leaves()));
+          Bitset::EdgeToRootsplit(Bitset::RootsplitOfClade(node->Leaves()));
       split_result[node->Id()] = indexer.at(rootsplit_pcsp);
     }
   });
@@ -93,14 +93,14 @@ IndexerBundle SBNMaps::BuildIndexerBundle(const BitsetSizeDict& rootsplit_counte
   size_t index = 0;
   // Start by adding the rootsplit PCSPs.
   size_t taxon_count((rootsplit_counter.begin()->first).size() / 2);
-  Bitset dag_root(Bitset::DAGRootSubsplitOfTaxonCount(taxon_count));
+  Bitset dag_root(Bitset::RootSubsplitOfTaxonCount(taxon_count));
   // Note: dag_root is rotated before being inserted into parent_to_range
   // because the rootsplits are connected to the DAG root via rotated edges.
   SafeInsert(parent_to_range, dag_root.SubsplitRotate(),
              {index, index + rootsplit_counter.size()});
   for (const auto& iter : rootsplit_counter) {
     rootsplits.push_back(iter.first);
-    SafeInsert(indexer, Bitset::PCSPOfRootsplit(iter.first), index);
+    SafeInsert(indexer, Bitset::EdgeToRootsplit(iter.first), index);
     SafeInsert(index_to_child, index, iter.first);
     index++;
   }
@@ -110,7 +110,7 @@ IndexerBundle SBNMaps::BuildIndexerBundle(const BitsetSizeDict& rootsplit_counte
     for (const auto& child_iter : child_counter) {
       const auto& pcsp = parent + child_iter.first;
       SafeInsert(indexer, pcsp, index);
-      SafeInsert(index_to_child, index, pcsp.PCSPGetChildSubsplit());
+      SafeInsert(index_to_child, index, pcsp.EdgeGetChildSubsplit());
       index++;
     }
   }
@@ -123,7 +123,7 @@ BitsetSizeDict UnrootedSBNMaps::RootsplitCounterOf(
   for (const auto& [topology, topology_count] : topologies) {
     auto Aux = [&rootsplit_counter,
                 &topology_count = topology_count](const Node* node) {
-      const Bitset rootsplit = Bitset::RootsplitOfHalf(node->Leaves());
+      const Bitset rootsplit = Bitset::RootsplitOfClade(node->Leaves());
       rootsplit_counter.increment(std::move(rootsplit), topology_count);
     };
     for (const auto& child : topology->Children()) {
@@ -194,7 +194,7 @@ PCSPCounter UnrootedSBNMaps::PCSPCounterOf(const Node::TopologyCounter& topologi
 Bitset Rootsplit(const Node* rooted_topology) {
   const auto children = rooted_topology->Children();
   Assert(children.size() == 2, "Rootsplit expects a bifurcating tree.");
-  return Bitset::RootsplitOfHalf(children[0]->Leaves());
+  return Bitset::RootsplitOfClade(children[0]->Leaves());
 }
 
 UnrootedIndexerRepresentation UnrootedSBNMaps::IndexerRepresentationOf(
@@ -315,7 +315,7 @@ SizeVector RootedSBNMaps::IndexerRepresentationOf(const BitsetSizeMap& indexer,
   const auto leaf_count = topology->LeafCount();
   SizeVector result;
   // First, add the rootsplit PCSPs.
-  const Bitset rootsplit_pcsp = Bitset::PCSPOfRootsplit(Rootsplit(topology.get()));
+  const Bitset rootsplit_pcsp = Bitset::EdgeToRootsplit(Rootsplit(topology.get()));
   result.push_back(AtWithDefault(indexer, rootsplit_pcsp, default_index));
   // Now add the PCSPs.
   topology->RootedPCSPPreorder(

--- a/src/sbn_maps.cpp
+++ b/src/sbn_maps.cpp
@@ -34,7 +34,7 @@ SizeVector SBNMaps::SplitIndicesOf(const BitsetSizeMap& indexer,
     // Skip the root.
     if (node != topology.get()) {
       const Bitset rootsplit_pcsp =
-          Bitset::EdgeToRootsplit(Bitset::RootsplitOfClade(node->Leaves()));
+          Bitset::PCSPFromUCAToRootsplit(Bitset::RootsplitSubsplitOfClade(node->Leaves()));
       split_result[node->Id()] = indexer.at(rootsplit_pcsp);
     }
   });
@@ -100,7 +100,7 @@ IndexerBundle SBNMaps::BuildIndexerBundle(const BitsetSizeDict& rootsplit_counte
              {index, index + rootsplit_counter.size()});
   for (const auto& iter : rootsplit_counter) {
     rootsplits.push_back(iter.first);
-    SafeInsert(indexer, Bitset::EdgeToRootsplit(iter.first), index);
+    SafeInsert(indexer, Bitset::PCSPFromUCAToRootsplit(iter.first), index);
     SafeInsert(index_to_child, index, iter.first);
     index++;
   }
@@ -110,7 +110,7 @@ IndexerBundle SBNMaps::BuildIndexerBundle(const BitsetSizeDict& rootsplit_counte
     for (const auto& child_iter : child_counter) {
       const auto& pcsp = parent + child_iter.first;
       SafeInsert(indexer, pcsp, index);
-      SafeInsert(index_to_child, index, pcsp.EdgeGetChildSubsplit());
+      SafeInsert(index_to_child, index, pcsp.PCSPGetChildSubsplit());
       index++;
     }
   }
@@ -123,7 +123,7 @@ BitsetSizeDict UnrootedSBNMaps::RootsplitCounterOf(
   for (const auto& [topology, topology_count] : topologies) {
     auto Aux = [&rootsplit_counter,
                 &topology_count = topology_count](const Node* node) {
-      const Bitset rootsplit = Bitset::RootsplitOfClade(node->Leaves());
+      const Bitset rootsplit = Bitset::RootsplitSubsplitOfClade(node->Leaves());
       rootsplit_counter.increment(std::move(rootsplit), topology_count);
     };
     for (const auto& child : topology->Children()) {
@@ -194,7 +194,7 @@ PCSPCounter UnrootedSBNMaps::PCSPCounterOf(const Node::TopologyCounter& topologi
 Bitset Rootsplit(const Node* rooted_topology) {
   const auto children = rooted_topology->Children();
   Assert(children.size() == 2, "Rootsplit expects a bifurcating tree.");
-  return Bitset::RootsplitOfClade(children[0]->Leaves());
+  return Bitset::RootsplitSubsplitOfClade(children[0]->Leaves());
 }
 
 UnrootedIndexerRepresentation UnrootedSBNMaps::IndexerRepresentationOf(
@@ -315,7 +315,7 @@ SizeVector RootedSBNMaps::IndexerRepresentationOf(const BitsetSizeMap& indexer,
   const auto leaf_count = topology->LeafCount();
   SizeVector result;
   // First, add the rootsplit PCSPs.
-  const Bitset rootsplit_pcsp = Bitset::EdgeToRootsplit(Rootsplit(topology.get()));
+  const Bitset rootsplit_pcsp = Bitset::PCSPFromUCAToRootsplit(Rootsplit(topology.get()));
   result.push_back(AtWithDefault(indexer, rootsplit_pcsp, default_index));
   // Now add the PCSPs.
   topology->RootedPCSPPreorder(

--- a/src/sbn_maps.cpp
+++ b/src/sbn_maps.cpp
@@ -33,8 +33,8 @@ SizeVector SBNMaps::SplitIndicesOf(const BitsetSizeMap& indexer,
   topology->Preorder([&topology, &split_result, &indexer](const Node* node) {
     // Skip the root.
     if (node != topology.get()) {
-      const Bitset rootsplit_pcsp =
-          Bitset::PCSPFromUCAToRootsplit(Bitset::RootsplitSubsplitOfClade(node->Leaves()));
+      const Bitset rootsplit_pcsp = Bitset::PCSPFromUCAToRootsplit(
+          Bitset::RootsplitSubsplitOfClade(node->Leaves()));
       split_result[node->Id()] = indexer.at(rootsplit_pcsp);
     }
   });
@@ -315,7 +315,8 @@ SizeVector RootedSBNMaps::IndexerRepresentationOf(const BitsetSizeMap& indexer,
   const auto leaf_count = topology->LeafCount();
   SizeVector result;
   // First, add the rootsplit PCSPs.
-  const Bitset rootsplit_pcsp = Bitset::PCSPFromUCAToRootsplit(Rootsplit(topology.get()));
+  const Bitset rootsplit_pcsp =
+      Bitset::PCSPFromUCAToRootsplit(Rootsplit(topology.get()));
   result.push_back(AtWithDefault(indexer, rootsplit_pcsp, default_index));
   // Now add the PCSPs.
   topology->RootedPCSPPreorder(

--- a/src/sbn_support.cpp
+++ b/src/sbn_support.cpp
@@ -6,7 +6,7 @@
 StringVector SBNSupport::PrettyIndexer() const {
   StringVector pretty_representation(indexer_.size());
   for (const auto& [key, idx] : indexer_) {
-    pretty_representation[idx] = key.EdgeToString();
+    pretty_representation[idx] = key.PCSPToString();
   }
   return pretty_representation;
 }
@@ -32,7 +32,7 @@ std::tuple<StringSizeMap, StringSizePairMap> SBNSupport::GetIndexers() const {
 StringVector SBNSupport::StringReversedIndexer() const {
   StringVector reversed_indexer(indexer_.size());
   for (const auto& [key, idx] : indexer_) {
-    reversed_indexer[idx] = key.EdgeToString();
+    reversed_indexer[idx] = key.PCSPToString();
   }
   return reversed_indexer;
 }

--- a/src/sbn_support.cpp
+++ b/src/sbn_support.cpp
@@ -6,7 +6,7 @@
 StringVector SBNSupport::PrettyIndexer() const {
   StringVector pretty_representation(indexer_.size());
   for (const auto& [key, idx] : indexer_) {
-    pretty_representation[idx] = key.PCSPToString();
+    pretty_representation[idx] = key.EdgeToString();
   }
   return pretty_representation;
 }
@@ -18,10 +18,10 @@ void SBNSupport::PrettyPrintIndexer() const {
   }
 }
 
-// Return indexer_ and parent_to_range_ converted into string-keyed maps.
+// Return indexer_ and parent_to_child_range_ converted into string-keyed maps.
 std::tuple<StringSizeMap, StringSizePairMap> SBNSupport::GetIndexers() const {
   auto str_indexer = StringifyMap(indexer_);
-  auto str_parent_to_range = StringifyMap(parent_to_range_);
+  auto str_parent_to_range = StringifyMap(parent_to_child_range_);
   std::string rootsplit("DAG Root Node");
   SafeInsert(str_parent_to_range, rootsplit, {0, rootsplits_.size()});
   return {str_indexer, str_parent_to_range};
@@ -32,7 +32,7 @@ std::tuple<StringSizeMap, StringSizePairMap> SBNSupport::GetIndexers() const {
 StringVector SBNSupport::StringReversedIndexer() const {
   StringVector reversed_indexer(indexer_.size());
   for (const auto& [key, idx] : indexer_) {
-    reversed_indexer[idx] = key.PCSPToString();
+    reversed_indexer[idx] = key.EdgeToString();
   }
   return reversed_indexer;
 }
@@ -40,5 +40,5 @@ StringVector SBNSupport::StringReversedIndexer() const {
 void SBNSupport::ProbabilityNormalizeSBNParametersInLog(
     EigenVectorXdRef sbn_parameters) const {
   SBNProbability::ProbabilityNormalizeParamsInLog(sbn_parameters, rootsplits_.size(),
-                                                  parent_to_range_);
+                                                  parent_to_child_range_);
 }

--- a/src/sbn_support.hpp
+++ b/src/sbn_support.hpp
@@ -32,16 +32,16 @@ class SBNSupport {
   }
   const size_t &IndexerAt(const Bitset &bitset) const { return indexer_.at(bitset); }
   inline bool ParentInSupport(const Bitset &parent) const {
-    return parent_to_range_.count(parent) > 0;
+    return parent_to_child_range_.count(parent) > 0;
   }
   inline const SizePair &ParentToRangeAt(const Bitset &parent) const {
-    return parent_to_range_.at(parent);
+    return parent_to_child_range_.at(parent);
   }
   inline const Bitset &IndexToChildAt(size_t child_idx) const {
     return index_to_child_.at(child_idx);
   }
 
-  const BitsetSizePairMap &ParentToRange() const { return parent_to_range_; }
+  const BitsetSizePairMap &ParentToRange() const { return parent_to_child_range_; }
   const BitsetSizeMap &Indexer() const { return indexer_; }
 
   PSPIndexer BuildPSPIndexer() const { return PSPIndexer(rootsplits_, indexer_); }
@@ -50,7 +50,7 @@ class SBNSupport {
   StringVector PrettyIndexer() const;
   void PrettyPrintIndexer() const;
 
-  // Return indexer_ and parent_to_range_ converted into string-keyed maps.
+  // Return indexer_ and parent_to_child_range_ converted into string-keyed maps.
   std::tuple<StringSizeMap, StringSizePairMap> GetIndexers() const;
 
   // Get the indexer, but reversed and with bitsets appropriately converted to
@@ -73,5 +73,5 @@ class SBNSupport {
   // A map going from a parent subsplit to the range of indices in
   // sbn_parameters_ with its children. See the definition of Range for the indexing
   // convention.
-  BitsetSizePairMap parent_to_range_;
+  BitsetSizePairMap parent_to_child_range_;
 };

--- a/src/site_pattern.hpp
+++ b/src/site_pattern.hpp
@@ -40,7 +40,10 @@ class SitePattern {
   }
 
  private:
+  // The multiple sequence alignments represented by the site pattern, as a collection
+  // of taxon names and sequences.
   Alignment alignment_;
+  // A map from a unique tag to the taxon name.
   TagStringMap tag_taxon_map_;
   // The first index of patterns_ is across sequences, and the second is across site
   // patterns.

--- a/src/subsplit_dag.cpp
+++ b/src/subsplit_dag.cpp
@@ -7,31 +7,93 @@
 #include "numerical_utils.hpp"
 #include "sbn_probability.hpp"
 
+// ** Constructor methods:
+
 SubsplitDAG::SubsplitDAG()
-    : taxon_count_(0), gpcsp_count_without_fake_subsplits_(0), topology_count_(0.) {}
+    : taxon_count_(0), edge_count_without_leaf_subsplits_(0), topology_count_(0.) {}
 
 SubsplitDAG::SubsplitDAG(size_t taxon_count,
-                         const Node::TopologyCounter &topology_counter)
+                         const Node::TopologyCounter &topology_counter,
+                         const TagStringMap &tag_taxon_map)
     : taxon_count_(taxon_count) {
   Assert(topology_counter.size() > 0, "Empty topology counter given to SubsplitDAG.");
   Assert(topology_counter.begin()->first->LeafCount() == taxon_count,
          "Taxon count mismatch in SubsplitDAG constructor.");
-  auto [gpcsp_indexer, index_to_child, rootsplits] =
+  auto [edge_indexer, index_to_child, rootsplits] =
       ProcessTopologyCounter(topology_counter);
   BuildNodes(index_to_child, rootsplits);
   BuildEdges(index_to_child);
-  BuildDAGEdgesFromGPCSPIndexer(gpcsp_indexer);
-  AddFakeSubsplitsToDAGEdgesAndParentToRange();
+  BuildDAGEdgesFromEdgeIndexer(edge_indexer);
+  AddLeafSubsplitsToDAGEdgesAndParentToRange();
   CountTopologies();
+
+  dag_taxons_ = std::map<std::string, size_t>();
+  // Insert all taxons from tree_collections's map to SubsplitDAG map.
+  for (const auto &[tag, name] : tag_taxon_map) {
+    // The "tag" key of the tree_collection's taxon_map is 2 bitpacked ints: [id,
+    // topology count]. We only care about the id.
+    size_t id = static_cast<size_t>(UnpackFirstInt(tag));
+    dag_taxons_.insert(std::make_pair(name, id));
+  }
 }
 
 SubsplitDAG::SubsplitDAG(const RootedTreeCollection &tree_collection)
-    : SubsplitDAG(tree_collection.TaxonCount(), tree_collection.TopologyCounter()) {}
+    : SubsplitDAG(tree_collection.TaxonCount(), tree_collection.TopologyCounter(),
+                  tree_collection.TagTaxonMap()) {}
+
+// ** Comparator methods:
+
+int SubsplitDAG::Compare(const SubsplitDAG &lhs, const SubsplitDAG &rhs) {
+  // (1) Compare Taxon Sizes.
+  if (lhs.TaxonCount() != rhs.TaxonCount()) {
+    return -100;
+  }
+  // Create translation map (lhs->rhs) for bitset clades.
+  auto taxon_map = SubsplitDAG::BuildTaxonTranslationMap(lhs, rhs);
+  // (2) Compare Subsplit Nodes.
+  auto lhs_nodes = lhs.GetSortedVectorOfNodeBitsets();
+  auto rhs_nodes = rhs.GetSortedVectorOfNodeBitsets();
+  // Translate to account for different Taxon mappings and sort output.
+  for (size_t i = 0; i < lhs_nodes.size(); i++) {
+    lhs_nodes[i] =
+        SubsplitDAG::BitsetTranslateViaTaxonTranslationMap(lhs_nodes[i], taxon_map);
+    // Verify subsplit clades are in 'sorted' order.
+    lhs_nodes[i] = lhs_nodes[i].SubsplitSortClades();
+  }
+  std::sort(lhs_nodes.begin(), lhs_nodes.end());
+  if (lhs_nodes != rhs_nodes) {
+    return -200;
+  }
+  // (3) Compare PCSP Edges.
+  auto lhs_edges = lhs.GetSortedVectorOfEdgeBitsets();
+  auto rhs_edges = rhs.GetSortedVectorOfEdgeBitsets();
+  // Translate to account for different Taxon mappings and sort output.
+  for (size_t i = 0; i < lhs_edges.size(); i++) {
+    lhs_edges[i] =
+        SubsplitDAG::BitsetTranslateViaTaxonTranslationMap(lhs_edges[i], taxon_map);
+    lhs_edges[i] = lhs_edges[i].EdgeSortClades();
+  }
+  std::sort(lhs_edges.begin(), lhs_edges.end());
+  if (lhs_edges != rhs_edges) {
+    return -300;
+  }
+  return 0;
+}
+
+bool operator==(const SubsplitDAG &lhs, const SubsplitDAG &rhs) {
+  return (SubsplitDAG::Compare(lhs, rhs) == 0);
+}
+
+bool operator!=(const SubsplitDAG &lhs, const SubsplitDAG &rhs) {
+  return (SubsplitDAG::Compare(lhs, rhs) != 0);
+}
+
+// ** Count methods:
 
 void SubsplitDAG::CountTopologies() {
   topology_count_below_ = EigenVectorXd::Ones(NodeCount());
 
-  for (const auto &node_id : RootwardPassTraversal(true)) {
+  for (const auto &node_id : RootwardEdgeTraversalTrace(true)) {
     const auto &node = GetDAGNode(node_id);
     for (const bool rotated : {true, false}) {
       // When there are no leafward nodes in the `rotated` direction, we set the number
@@ -49,6 +111,8 @@ void SubsplitDAG::CountTopologies() {
   topology_count_ = topology_count_below_[DAGRootNodeId()];
 }
 
+size_t SubsplitDAG::TaxonCount() const { return dag_taxons_.size(); }
+
 size_t SubsplitDAG::NodeCount() const { return dag_nodes_.size(); }
 
 size_t SubsplitDAG::NodeCountWithoutDAGRoot() const { return NodeCount() - 1; }
@@ -57,12 +121,14 @@ double SubsplitDAG::TopologyCount() const { return topology_count_; }
 
 size_t SubsplitDAG::RootsplitCount() const { return RootsplitIds().size(); }
 
-size_t SubsplitDAG::GPCSPCount() const { return gpcsp_count_without_fake_subsplits_; }
+size_t SubsplitDAG::EdgeCount() const { return edge_count_without_leaf_subsplits_; }
 
-size_t SubsplitDAG::GPCSPCountWithFakeSubsplits() const { return dag_edges_.size(); }
+size_t SubsplitDAG::EdgeCountWithLeafSubsplits() const { return dag_edges_.size(); }
+
+// ** Output methods:
 
 StringSizeMap SubsplitDAG::SummaryStatistics() const {
-  return {{"node_count", NodeCount()}, {"edge_count", GPCSPCountWithFakeSubsplits()}};
+  return {{"node_count", NodeCount()}, {"edge_count", EdgeCountWithLeafSubsplits()}};
 }
 
 void SubsplitDAG::Print() const {
@@ -71,24 +137,30 @@ void SubsplitDAG::Print() const {
   }
 }
 
-void SubsplitDAG::PrintGPCSPIndexer() const {
-  for (const auto &[pcsp, idx] : BuildGPCSPIndexer()) {
-    std::cout << pcsp.PCSPToString() << ", " << idx << std::endl;
-  }
-}
-
-void SubsplitDAG::PrintDAGEdges() const {
-  for (const auto &[parent_child_id, gpcsp_idx] : dag_edges_) {
-    const auto &[parent_id, child_id] = parent_child_id;
-    std::cout << "[" << parent_id << ", " << child_id << "], " << gpcsp_idx
+void SubsplitDAG::PrintNodes() const {
+  for (const auto &dag_node : dag_nodes_) {
+    std::cout << dag_node->Id() << ": " << dag_node->GetBitset().SubsplitToString()
               << std::endl;
   }
 }
 
+void SubsplitDAG::PrintEdgeIndexer() const {
+  for (const auto &[edge, idx] : BuildEdgeIndexer()) {
+    std::cout << idx << ": " << edge.EdgeToString() << std::endl;
+  }
+}
+
+void SubsplitDAG::PrintDAGEdges() const {
+  for (const auto &[parent_child_id, edge_idx] : dag_edges_) {
+    const auto &[parent_id, child_id] = parent_child_id;
+    std::cout << "[" << parent_id << ", " << child_id << "], " << edge_idx << std::endl;
+  }
+}
+
 void SubsplitDAG::PrintParentToRange() const {
-  for (const auto &[subsplit, pcsp_range] : parent_to_range_) {
-    std::cout << subsplit.SubsplitToString() << ": [" << pcsp_range.first << ", "
-              << pcsp_range.second << "]" << std::endl;
+  for (const auto &[subsplit, edge_range] : parent_to_child_range_) {
+    std::cout << subsplit.SubsplitToString() << ": [" << edge_range.first << ", "
+              << edge_range.second << "]" << std::endl;
   }
 }
 
@@ -115,13 +187,15 @@ std::string SubsplitDAG::ToDot(bool show_index_labels) const {
             }
             auto bs = node->GetBitset();
             string_stream << node_id << " [label=\"<f0>"
-                          << bs.SubsplitGetClade(0).ToVectorOfSetBitsAsString()
+                          << bs.SubsplitGetClade(Bitset::SubsplitClade::LEFT)
+                                 .ToVectorOfSetBitsAsString()
                           << "|<f1>";
             if (show_index_labels) {
               string_stream << node_id;
             }
             string_stream << "|<f2>"
-                          << bs.SubsplitGetClade(1).ToVectorOfSetBitsAsString()
+                          << bs.SubsplitGetClade(Bitset::SubsplitClade::RIGHT)
+                                 .ToVectorOfSetBitsAsString()
                           << "\"]\n";
           },
           // AfterNode
@@ -139,7 +213,7 @@ std::string SubsplitDAG::ToDot(bool show_index_labels) const {
             string_stream << "->\"";
             string_stream << child_id << "\":f1";
             if (show_index_labels) {
-              string_stream << " [label=\"" << GPCSPIndexOfIds(node_id, child_id);
+              string_stream << " [label=\"" << GetEdgeIdx(node_id, child_id);
               if (rotated) {
                 string_stream << "\", color=1, fontcolor=1";
               } else {
@@ -161,55 +235,97 @@ std::string SubsplitDAG::ToDot(bool show_index_labels) const {
   return string_stream.str();
 }
 
-BitsetSizeMap SubsplitDAG::BuildGPCSPIndexer() const {
-  auto gpcsp_indexer = BitsetSizeMap();
-  ReversePostorderIndexTraversal([this, &gpcsp_indexer](size_t parent_id, bool rotated,
-                                                        size_t child_id,
-                                                        size_t gpcsp_idx) {
+// ** Build output indexes/vectors methods:
+
+BitsetSizeMap SubsplitDAG::BuildEdgeIndexer() const {
+  auto edge_indexer = BitsetSizeMap();
+  TopologicalEdgeTraversal([this, &edge_indexer](size_t parent_id, bool rotated,
+                                                 size_t child_id, size_t edge_idx) {
     const auto parent_subsplit = GetDAGNode(parent_id)->GetBitset(rotated);
     const auto child_subsplit = GetDAGNode(child_id)->GetBitset();
-    SafeInsert(gpcsp_indexer, Bitset::PCSP(parent_subsplit, child_subsplit), gpcsp_idx);
+    SafeInsert(edge_indexer, Bitset::Edge(parent_subsplit, child_subsplit), edge_idx);
   });
-  return gpcsp_indexer;
+  return edge_indexer;
+}
+
+size_t SubsplitDAG::GetTaxonId(const std::string &name) const {
+  Assert(
+      ContainsTaxon(name),
+      "SubsplitDAG::GetTaxonId(): Taxon with given name is not contained in the DAG.");
+  return dag_taxons_.find(name)->second;
 }
 
 SubsplitDAGNode *SubsplitDAG::GetDAGNode(const size_t node_id) const {
   Assert(ContainsNode(node_id),
-         "Node with the given node_id does not exist in SubsplitDAG::GetDAGNode.");
+         "Node with the given node_id does not exist in SubsplitDAG::GetDAGNode().");
   return dag_nodes_.at(node_id).get();
 }
 
 size_t SubsplitDAG::GetDAGNodeId(const Bitset &subsplit) const {
   Assert(ContainsNode(subsplit),
-         "Node with the given subsplit does not exist in SubsplitDAG::GetDAGNodeId.");
+         "Node with the given subsplit does not exist in SubsplitDAG::GetDAGNodeId().");
   return subsplit_to_id_.at(subsplit);
 }
 
 size_t SubsplitDAG::DAGRootNodeId() const { return NodeCount() - 1; }
 
 const SizeVector &SubsplitDAG::RootsplitIds() const {
-  return GetDAGNode(DAGRootNodeId())->GetLeafwardRotated();
+  return GetDAGNode(DAGRootNodeId())->GetLeafwardLeftward();
 }
 
-size_t SubsplitDAG::GetGPCSPIndex(const Bitset &parent_subsplit,
-                                  const Bitset &child_subsplit) const {
-  return GPCSPIndexOfIds(GetDAGNodeId(parent_subsplit), GetDAGNodeId(child_subsplit));
+size_t SubsplitDAG::GetEdgeIdx(const Bitset &parent_subsplit,
+                               const Bitset &child_subsplit) const {
+  return GetEdgeIdx(GetDAGNodeId(parent_subsplit), GetDAGNodeId(child_subsplit));
 }
 
-size_t SubsplitDAG::GPCSPIndexOfIds(size_t parent_id, size_t child_id) const {
+size_t SubsplitDAG::GetEdgeIdx(size_t parent_id, size_t child_id) const {
   return dag_edges_.at({parent_id, child_id});
 }
 
 SizePair SubsplitDAG::GetEdgeRange(const Bitset &subsplit, const bool rotated) const {
   Assert(ContainsNode(subsplit),
          "Node with the given subsplit does not exist in SubsplitDAG::GetEdgeRange.");
-  return parent_to_range_.at(PerhapsSubsplitRotate(subsplit, rotated));
+  return parent_to_child_range_.at(SubsplitToSortedOrder(subsplit, rotated));
 }
 
-EigenVectorXd SubsplitDAG::BuildUniformOnTopologicalSupportPrior() const {
-  EigenVectorXd q = EigenVectorXd::Ones(GPCSPCountWithFakeSubsplits());
+std::vector<std::string> SubsplitDAG::GetSortedVectorOfTaxonNames() const {
+  std::vector<std::string> taxons;
+  for (const auto &name_id : dag_taxons_) {
+    taxons.push_back(name_id.first);
+  }
+  std::sort(taxons.begin(), taxons.end());
+  return taxons;
+}
 
-  for (const auto &node_id : RootwardPassTraversal(true)) {
+std::vector<Bitset> SubsplitDAG::GetSortedVectorOfNodeBitsets() const {
+  std::vector<Bitset> nodes;
+  for (size_t i = 0; i < NodeCount(); i++) {
+    Bitset node_bitset = GetDAGNode(i)->GetBitset();
+    nodes.push_back(node_bitset);
+  }
+  std::sort(nodes.begin(), nodes.end());
+  return nodes;
+}
+
+std::vector<Bitset> SubsplitDAG::GetSortedVectorOfEdgeBitsets() const {
+  std::vector<Bitset> edges;
+  for (const auto &key_value_pair : dag_edges_) {
+    auto id_pair = key_value_pair.first;
+    auto parent_bitset = GetDAGNode(id_pair.first)->GetBitset();
+    auto child_bitset = GetDAGNode(id_pair.second)->GetBitset();
+    Bitset edge_bitset = Bitset::Edge(parent_bitset, child_bitset);
+    edges.push_back(edge_bitset);
+  }
+  std::sort(edges.begin(), edges.end());
+  return edges;
+}
+
+std::map<std::string, size_t> &SubsplitDAG::GetTaxonMap() { return dag_taxons_; }
+
+EigenVectorXd SubsplitDAG::BuildUniformOnTopologicalSupportPrior() const {
+  EigenVectorXd q = EigenVectorXd::Ones(EdgeCountWithLeafSubsplits());
+
+  for (const auto &node_id : RootwardEdgeTraversalTrace(true)) {
     const auto &node = GetDAGNode(node_id);
     for (const bool rotated : {false, true}) {
       if (!node->GetLeafward(rotated).empty()) {
@@ -218,8 +334,8 @@ EigenVectorXd SubsplitDAG::BuildUniformOnTopologicalSupportPrior() const {
           per_rotated_count += topology_count_below_[child_id];
         }
         for (const auto &child_id : node->GetLeafward(rotated)) {
-          size_t gpcsp_idx = GPCSPIndexOfIds(node->Id(), child_id);
-          q(gpcsp_idx) = topology_count_below_(child_id) / per_rotated_count;
+          size_t edge_idx = GetEdgeIdx(node->Id(), child_id);
+          q(edge_idx) = topology_count_below_(child_id) / per_rotated_count;
         }
       }
     }
@@ -261,7 +377,7 @@ Node::NodePtrVec SubsplitDAG::GenerateAllTopologies() const {
     return topologies;
   };
 
-  for (const auto &node_id : RootwardPassTraversal(true)) {
+  for (const auto &node_id : RootwardEdgeTraversalTrace(true)) {
     const auto &node = GetDAGNode(node_id);
     if (node->IsLeaf()) {
       topology_below.at(node_id).push_back(Node::Leaf(node_id));
@@ -278,7 +394,7 @@ Node::NodePtrVec SubsplitDAG::GenerateAllTopologies() const {
 
   // We return a deep copy of every Polished topology to avoid loops in the pointer
   // structure. Such loops can create problems when we Polish the topologies one at a
-  // time: polishing a second topology can change the numbering of a previous topology.
+  // time: polishing a second topology can change the numbering of a} previous topology.
   // This is checked for in the "GPInstance: GenerateCompleteRootedTreeCollection" test.
   Node::NodePtrVec final_topologies;
   final_topologies.reserve(topologies.size());
@@ -291,21 +407,24 @@ Node::NodePtrVec SubsplitDAG::GenerateAllTopologies() const {
 }
 
 EigenVectorXd SubsplitDAG::BuildUniformOnAllTopologiesPrior() const {
-  EigenVectorXd result = EigenVectorXd::Zero(GPCSPCountWithFakeSubsplits());
-  for (const auto &[parent_child_id, gpcsp_idx] : dag_edges_) {
+  EigenVectorXd result = EigenVectorXd::Zero(EdgeCountWithLeafSubsplits());
+  for (const auto &[parent_child_id, edge_idx] : dag_edges_) {
     const auto &[parent_id, child_id] = parent_child_id;
     std::ignore = parent_id;
     size_t child0_taxon_count =
-        GetDAGNode(child_id)->GetBitset().SubsplitGetCladeByBinaryOrder(0).Count();
+        GetDAGNode(child_id)->GetBitset().SubsplitGetClade(0).Count();
     size_t child1_taxon_count =
-        GetDAGNode(child_id)->GetBitset().SubsplitGetCladeByBinaryOrder(1).Count();
-    //
-    result(gpcsp_idx) = Combinatorics::LogChildSubsplitCountRatio(child0_taxon_count,
-                                                                  child1_taxon_count);
+        GetDAGNode(child_id)->GetBitset().SubsplitGetClade(1).Count();
+    // The ordering of this subsplit is flipped so that this ratio will be non-zero in
+    // the denominator in the case of root & leaves.
+    result(edge_idx) = Combinatorics::LogChildSubsplitCountRatio(child1_taxon_count,
+                                                                 child0_taxon_count);
   }
   NumericalUtils::Exponentiate(result);
   return result;
 }
+
+// ** DAG Lambda Iterator methods:
 
 void SubsplitDAG::IterateOverRealNodes(const NodeLambda &f) const {
   Assert(taxon_count_ < NodeCount(), "No real DAG nodes!");
@@ -334,7 +453,7 @@ void SubsplitDAG::IterateOverLeafwardEdgesAndChildren(
     const SubsplitDAGNode *node, const EdgeAndNodeLambda &f) const {
   IterateOverLeafwardEdges(
       node, [this, &node, &f](bool rotated, const SubsplitDAGNode *child) {
-        f(GPCSPIndexOfIds(node->Id(), child->Id()), rotated, child->Id());
+        f(GetEdgeIdx(node->Id(), child->Id()), rotated, child->Id());
       });
 }
 
@@ -353,7 +472,7 @@ void SubsplitDAG::IterateOverRootwardEdgesAndParents(const SubsplitDAGNode *node
                                                      const EdgeAndNodeLambda &f) const {
   IterateOverRootwardEdges(
       node, [this, &node, &f](bool rotated, const SubsplitDAGNode *parent) {
-        f(GPCSPIndexOfIds(parent->Id(), node->Id()), rotated, parent->Id());
+        f(GetEdgeIdx(parent->Id(), node->Id()), rotated, parent->Id());
       });
 }
 
@@ -361,7 +480,7 @@ void SubsplitDAG::IterateOverParentAndChildAndLeafwardEdges(
     const SubsplitDAGNode *node, const ParentRotationChildEdgeLambda &f) const {
   IterateOverLeafwardEdges(
       node, [this, &node, &f](bool rotated, const SubsplitDAGNode *child) {
-        f(node->Id(), rotated, child->Id(), GPCSPIndexOfIds(node->Id(), child->Id()));
+        f(node->Id(), rotated, child->Id(), GetEdgeIdx(node->Id(), child->Id()));
       });
 }
 
@@ -377,10 +496,10 @@ EigenVectorXd SubsplitDAG::UnconditionalNodeProbabilities(
   node_probabilities.setZero();
   node_probabilities[DAGRootNodeId()] = 1.;
 
-  ReversePostorderIndexTraversal([&node_probabilities, &normalized_sbn_parameters](
-                                     const size_t parent_id, const bool,
-                                     const size_t child_id, const size_t gpcsp_idx) {
-    const double child_probability_given_parent = normalized_sbn_parameters[gpcsp_idx];
+  TopologicalEdgeTraversal([this, &node_probabilities, &normalized_sbn_parameters](
+                               const size_t parent_id, const bool,
+                               const size_t child_id, const size_t edge_idx) {
+    const double child_probability_given_parent = normalized_sbn_parameters[edge_idx];
     Assert(child_probability_given_parent >= 0. && child_probability_given_parent <= 1.,
            "UnconditionalNodeProbabilities: got an out-of-range probability. Are these "
            "normalized and in linear space?");
@@ -412,56 +531,59 @@ EigenVectorXd SubsplitDAG::InvertedGPCSPProbabilities(
   EigenVectorXd inverted_probabilities =
       EigenVectorXd(normalized_sbn_parameters.size());
   inverted_probabilities.setOnes();
-  ReversePostorderIndexTraversal(
-      [this, &node_probabilities, &normalized_sbn_parameters, &inverted_probabilities](
-          const size_t parent_id, const bool, const size_t child_id,
-          const size_t gpcsp_idx) {
-        // The traversal doesn't set the rootsplit probabilities, but those are always 1
-        // (there is only one "parent" of a rootsplit).
-        if (parent_id != DAGRootNodeId()) {
-          // For a PCSP t -> s:
-          inverted_probabilities[gpcsp_idx] =         // P(t|s)
-              node_probabilities[parent_id] *         // P(t)
-              normalized_sbn_parameters[gpcsp_idx] /  // P(s|t)
-              node_probabilities[child_id];           // P(s)
-        }
-      });
+  TopologicalEdgeTraversal([this, &node_probabilities, &normalized_sbn_parameters,
+                            &inverted_probabilities](const size_t parent_id, const bool,
+                                                     const size_t child_id,
+                                                     const size_t edge_idx) {
+    // The traversal doesn't set the rootsplit probabilities, but those are always 1
+    // (there is only one "parent" of a rootsplit).
+    if (parent_id != DAGRootNodeId()) {
+      // For a PCSP t -> s:
+      inverted_probabilities[edge_idx] =         // P(t|s)
+          node_probabilities[parent_id] *        // P(t)
+          normalized_sbn_parameters[edge_idx] /  // P(s|t)
+          node_probabilities[child_id];          // P(s)
+    }
+  });
   return inverted_probabilities;
 }
 
 std::vector<Bitset> SubsplitDAG::GetChildSubsplits(const SizeBitsetMap &index_to_child,
-                                                   const Bitset &subsplit,
-                                                   bool include_fake_subsplits) {
+                                                   const Bitset &parent_subsplit,
+                                                   bool include_leaf_subsplits) {
   std::vector<Bitset> children_subsplits;
-  if (parent_to_range_.count(subsplit) > 0) {
-    const auto [start, stop] = parent_to_range_.at(subsplit);
+  // Add all child subsplit bitsets to vector.
+  if (parent_to_child_range_.count(parent_subsplit) > 0) {
+    const auto [start, stop] = parent_to_child_range_.at(parent_subsplit);
     for (auto idx = start; idx < stop; idx++) {
       children_subsplits.push_back(index_to_child.at(idx));
     }
-  } else if (include_fake_subsplits) {
+  } else if (include_leaf_subsplits) {
     // This method is designed to be called before calling
-    // AddFakeSubsplitsToDAGEdgesAndParentToRange. In that case, if the second clade
+    // AddLeafSubsplitsToDAGEdgesAndParentToRange. In that case, if the second clade
     // of the subsplit is just a single taxon, the subsplit will not map to any value in
-    // parent_to_range_.
+    // parent_to_child_range_.
     //
-    // But we still need to create and connect to fake subsplits in the DAG. So, here we
-    // make a fake child subsplit.
-    children_subsplits.push_back(Bitset::FakeChildSubsplit(subsplit));
+    // But we still need to create and connect to leaf subsplits in the DAG. So, here we
+    // make a leaf child subsplit.
+    children_subsplits.push_back(Bitset::LeafSubsplitOfParentSubsplit(parent_subsplit));
   }
 
   return children_subsplits;
 }
 
+// ** Modify DAG methods:
+
 std::tuple<BitsetSizeMap, SizeBitsetMap, BitsetVector>
 SubsplitDAG::ProcessTopologyCounter(const Node::TopologyCounter &topology_counter) {
-  BitsetSizeMap gpcsp_indexer;
+  BitsetSizeMap edge_indexer;
   SizeBitsetMap index_to_child;
   BitsetVector rootsplits;
-  std::tie(rootsplits, gpcsp_indexer, index_to_child, parent_to_range_,
-           gpcsp_count_without_fake_subsplits_) =
+  std::tie(rootsplits, edge_indexer, index_to_child, parent_to_child_range_,
+           edge_count_without_leaf_subsplits_) =
       SBNMaps::BuildIndexerBundle(RootedSBNMaps::RootsplitCounterOf(topology_counter),
                                   RootedSBNMaps::PCSPCounterOf(topology_counter));
-  return {gpcsp_indexer, index_to_child, rootsplits};
+  return {edge_indexer, index_to_child, rootsplits};
 }
 
 void SubsplitDAG::CreateAndInsertNode(const Bitset &subsplit) {
@@ -474,28 +596,45 @@ void SubsplitDAG::CreateAndInsertEdge(const size_t parent_id, const size_t child
                                       bool rotated) {
   Assert(ContainsNode(parent_id), "Node with the given parent_id does not exist.");
   Assert(ContainsNode(child_id), "Node with the given child_id does not exist.");
+  // Insert edge between parent and child.
   ConnectGivenNodes(parent_id, child_id, rotated);
-  SafeInsert(dag_edges_, {parent_id, child_id}, GPCSPCountWithFakeSubsplits());
+  SafeInsert(dag_edges_, {parent_id, child_id}, EdgeCountWithLeafSubsplits());
+}
+
+void SubsplitDAG::DeleteNode(const Bitset &node_subsplit) {
+  Failwith("SubsplitDAG::DeleteNode() is not implemented.");
+  Assert(ContainsNode(node_subsplit),
+         "SubsplitDAG::DeleteNode(): Given edge does not exist");
+}
+
+void SubsplitDAG::DeleteEdge(const size_t parent_id, const size_t child_id,
+                             bool rotated) {
+  Failwith("SubsplitDAG::DeleteNode() is not implemented.");
+  Assert(ContainsEdge(parent_id, child_id),
+         "SubsplitDAG::DeleteEdge(): Given edge does not exist.");
 }
 
 void SubsplitDAG::ConnectGivenNodes(const size_t parent_id, const size_t child_id,
                                     bool rotated) {
   const auto parent_node = GetDAGNode(parent_id);
   const auto child_node = GetDAGNode(child_id);
-  if (rotated) {
-    parent_node->AddLeafwardRotated(child_node->Id());
-    child_node->AddRootwardRotated(parent_node->Id());
-  } else {
-    parent_node->AddLeafwardSorted(child_node->Id());
-    child_node->AddRootwardSorted(parent_node->Id());
-  }
+
+  SubsplitDAGNode::ParentClade parent_clade =
+      (rotated ? SubsplitDAGNode::ParentClade::LEFTSIDE
+               : SubsplitDAGNode::ParentClade::RIGHTSIDE);
+  parent_node->AddEdge(child_node->Id(), SubsplitDAGNode::Direction::LEAFWARD,
+                       parent_clade);
+  child_node->AddEdge(parent_node->Id(), SubsplitDAGNode::Direction::ROOTWARD,
+                      parent_clade);
 }
 
 void SubsplitDAG::ConnectNodes(const SizeBitsetMap &index_to_child, size_t node_id,
                                bool rotated) {
-  // Retrieve children subsplits, set edge relation.
+  // Get bitset of parent node according to its rotation.
   const Bitset subsplit = GetDAGNode(node_id)->GetBitset(rotated);
+  // Build vector of child node's subsplits.
   const auto children = GetChildSubsplits(index_to_child, subsplit, true);
+  // Connect parent node to all child nodes.
   for (const auto &child_subsplit : children) {
     ConnectGivenNodes(node_id, GetDAGNodeId(child_subsplit), rotated);
   }
@@ -507,7 +646,7 @@ void SubsplitDAG::BuildNodesDepthFirst(const SizeBitsetMap &index_to_child,
   visited_subsplits.insert(subsplit);
   for (bool rotated : {false, true}) {
     for (const auto &child_subsplit : GetChildSubsplits(
-             index_to_child, PerhapsSubsplitRotate(subsplit, rotated), false)) {
+             index_to_child, SubsplitToSortedOrder(subsplit, rotated), false)) {
       if (visited_subsplits.count(child_subsplit) == 0) {
         BuildNodesDepthFirst(index_to_child, child_subsplit, visited_subsplits);
       }
@@ -519,20 +658,19 @@ void SubsplitDAG::BuildNodesDepthFirst(const SizeBitsetMap &index_to_child,
 void SubsplitDAG::BuildNodes(const SizeBitsetMap &index_to_child,
                              const BitsetVector &rootsplits) {
   std::unordered_set<Bitset> visited_subsplits;
-  // We will create fake subsplits and insert to dag_nodes_.
-  // Fake subsplits (i.e. leaf nodes) will take IDs in [0, taxon_count_).
+  // We will create leaf subsplits and insert to dag_nodes_.
+  // Leaf subsplits (i.e. leaf nodes) will take IDs in [0, taxon_count_).
   for (size_t taxon_idx = 0; taxon_idx < taxon_count_; taxon_idx++) {
-    CreateAndInsertNode(
-        Bitset::FakeSubsplit(Bitset::Singleton(taxon_count_, taxon_idx)));
+    CreateAndInsertNode(Bitset::LeafSubsplitOfNonemptyClade(
+        Bitset::Singleton(taxon_count_, taxon_idx)));
   }
   // Then we add the remaining nodes.
   // The root splits will take on the higher IDs compared to the non-rootsplits.
   for (const auto &rootsplit : rootsplits) {
     BuildNodesDepthFirst(index_to_child, rootsplit, visited_subsplits);
   }
-
   // Finally, we add the DAG root node.
-  CreateAndInsertNode(Bitset::DAGRootSubsplitOfTaxonCount(taxon_count_));
+  CreateAndInsertNode(Bitset::RootSubsplitOfTaxonCount(taxon_count_));
 }
 
 void SubsplitDAG::BuildEdges(const SizeBitsetMap &index_to_child) {
@@ -545,64 +683,72 @@ void SubsplitDAG::BuildEdges(const SizeBitsetMap &index_to_child) {
   ConnectNodes(index_to_child, DAGRootNodeId(), true);
 }
 
-void SubsplitDAG::BuildDAGEdgesFromGPCSPIndexer(BitsetSizeMap &gpcsp_indexer) {
-  for (const auto &[gpcsp, index] : gpcsp_indexer) {
-    Assert(gpcsp.size() == 3 * taxon_count_,
+void SubsplitDAG::BuildDAGEdgesFromEdgeIndexer(BitsetSizeMap &edge_indexer) {
+  for (const auto &[edge, index] : edge_indexer) {
+    Assert(edge.size() == 3 * taxon_count_,
            "All edges should be bitsets with size 3 times taxon_count_.");
-    const auto parent_id = GetDAGNodeId(gpcsp.PCSPGetParentSubsplit());
-    const auto child_id = GetDAGNodeId(gpcsp.PCSPGetChildSubsplit());
+    const auto parent_id = GetDAGNodeId(edge.EdgeGetParentSubsplit());
+    const auto child_id = GetDAGNodeId(edge.EdgeGetChildSubsplit());
     SafeInsert(dag_edges_, {parent_id, child_id}, index);
   }
 }
 
-void SubsplitDAG::AddFakeSubsplitsToDAGEdgesAndParentToRange() {
+void SubsplitDAG::AddLeafSubsplitsToDAGEdgesAndParentToRange() {
   for (size_t node_id = 0; node_id < taxon_count_; node_id++) {
     const auto current_bitset(GetDAGNode(node_id)->GetBitset());
-    IterateOverRootwardEdges(GetDAGNode(node_id), [this, current_bitset](
-                                                      const bool rotated,
-                                                      const SubsplitDAGNode *node) {
-      SafeInsert(parent_to_range_, node->GetBitset(rotated),
-                 {GPCSPCountWithFakeSubsplits(), GPCSPCountWithFakeSubsplits() + 1});
-      SafeInsert(dag_edges_, {node->Id(), GetDAGNodeId(current_bitset)},
-                 GPCSPCountWithFakeSubsplits());
-    });
+    IterateOverRootwardEdges(
+        GetDAGNode(node_id),
+        [this, current_bitset](const bool rotated, const SubsplitDAGNode *node) {
+          SafeInsert(parent_to_child_range_, node->GetBitset(rotated),
+                     {EdgeCountWithLeafSubsplits(), EdgeCountWithLeafSubsplits() + 1});
+          SafeInsert(dag_edges_, {node->Id(), GetDAGNodeId(current_bitset)},
+                     EdgeCountWithLeafSubsplits());
+        });
   }
 }
 
 void SubsplitDAG::RootwardDepthFirst(size_t node_id, SizeVector &visit_order,
                                      std::unordered_set<size_t> &visited_nodes) const {
+  // Add to set of all visited nodes.
   SafeInsert(visited_nodes, node_id);
+  // Recurse on sorted children.
   const auto &node = GetDAGNode(node_id);
-  for (size_t parent_id : node->GetRootwardSorted()) {
+  for (size_t parent_id : node->GetRootwardRightward()) {
     if (visited_nodes.count(parent_id) == 0) {
       RootwardDepthFirst(parent_id, visit_order, visited_nodes);
     }
   }
-  for (size_t parent_id : node->GetRootwardRotated()) {
+  // Recurse on rotated children.
+  for (size_t parent_id : node->GetRootwardLeftward()) {
     if (visited_nodes.count(parent_id) == 0) {
       RootwardDepthFirst(parent_id, visit_order, visited_nodes);
     }
   }
+  // Append to vector post-order (after all children have been visited).
   visit_order.push_back(node_id);
 }
 
 void SubsplitDAG::LeafwardDepthFirst(size_t node_id, SizeVector &visit_order,
                                      std::unordered_set<size_t> &visited_nodes) const {
+  // Add to set of all visited nodes.
   SafeInsert(visited_nodes, node_id);
-  for (size_t child_id : GetDAGNode(node_id)->GetLeafwardSorted()) {
+  // Recurse on right/sorted children.
+  for (size_t child_id : GetDAGNode(node_id)->GetLeafwardRightward()) {
     if (visited_nodes.count(child_id) == 0) {
       LeafwardDepthFirst(child_id, visit_order, visited_nodes);
     }
   }
-  for (size_t child_id : GetDAGNode(node_id)->GetLeafwardRotated()) {
+  // Recurse on left/rotated children.
+  for (size_t child_id : GetDAGNode(node_id)->GetLeafwardLeftward()) {
     if (visited_nodes.count(child_id) == 0) {
       LeafwardDepthFirst(child_id, visit_order, visited_nodes);
     }
   }
+  // Append to vector post-order (after all children have been visited).
   visit_order.push_back(node_id);
 }
 
-SizeVector SubsplitDAG::LeafwardPassTraversal(bool include_dag_root_node) const {
+SizeVector SubsplitDAG::LeafwardEdgeTraversalTrace(bool include_dag_root_node) const {
   SizeVector visit_order;
   std::unordered_set<size_t> visited_nodes;
   if (!include_dag_root_node) {
@@ -614,7 +760,7 @@ SizeVector SubsplitDAG::LeafwardPassTraversal(bool include_dag_root_node) const 
   return visit_order;
 }
 
-SizeVector SubsplitDAG::RootwardPassTraversal(bool include_dag_root_node) const {
+SizeVector SubsplitDAG::RootwardEdgeTraversalTrace(bool include_dag_root_node) const {
   SizeVector visit_order;
   std::unordered_set<size_t> visited_nodes;
   for (const auto &rootsplit_id : RootsplitIds()) {
@@ -626,25 +772,77 @@ SizeVector SubsplitDAG::RootwardPassTraversal(bool include_dag_root_node) const 
   return visit_order;
 }
 
-SizeVector SubsplitDAG::ReversePostorderTraversal() const {
-  auto visit_order = RootwardPassTraversal(true);
+SizeVector SubsplitDAG::TopologicalEdgeTraversalTrace() const {
+  auto visit_order = RootwardEdgeTraversalTrace(true);
   std::reverse(visit_order.begin(), visit_order.end());
   return visit_order;
 }
 
-void SubsplitDAG::ReversePostorderIndexTraversal(
-    ParentRotationChildEdgeLambda f) const {
-  for (const auto node_id : ReversePostorderTraversal()) {
+void SubsplitDAG::TopologicalEdgeTraversal(ParentRotationChildEdgeLambda f) const {
+  for (const auto node_id : TopologicalEdgeTraversalTrace()) {
     IterateOverLeafwardEdgesAndChildren(
-        GetDAGNode(node_id), [&f, &node_id](const size_t gpcsp_idx, const bool rotated,
+        GetDAGNode(node_id), [&f, &node_id](const size_t edge_idx, const bool rotated,
                                             const size_t child_id) {
-          f(node_id, rotated, child_id, gpcsp_idx);
+          f(node_id, rotated, child_id, edge_idx);
         });
   }
 }
 
-Bitset SubsplitDAG::PerhapsSubsplitRotate(const Bitset &subsplit, bool rotated) const {
+// ** Miscellaneous methods:
+
+Bitset SubsplitDAG::SubsplitToSortedOrder(const Bitset &subsplit, bool rotated) const {
   return rotated ? subsplit.SubsplitRotate() : subsplit;
+}
+
+SizeVector SubsplitDAG::BuildTaxonTranslationMap(const SubsplitDAG &dag_a,
+                                                 const SubsplitDAG &dag_b) {
+  auto names_a = dag_a.GetSortedVectorOfTaxonNames();
+  auto names_b = dag_b.GetSortedVectorOfTaxonNames();
+  Assert(names_a == names_b,
+         "SubsplitDAG::BuildTaxonTranslationMap(): SubsplitDAGs do not cover the same "
+         "taxon set.");
+  Assert(names_a.size() == dag_a.TaxonCount(),
+         "SubsplitDAG::BuildTaxonTranslationMap(): Number of taxon names does not "
+         "match the number of taxons in the DAG.");
+
+  SizeVector taxon_map(names_a.size());
+  for (const auto &name : names_a) {
+    taxon_map[dag_a.GetTaxonId(name)] = dag_b.GetTaxonId(name);
+  }
+  return taxon_map;
+}
+
+int SubsplitDAG::BitsetCompareViaTaxonTranslationMap(const Bitset &bitset_a,
+                                                     const Bitset &bitset_b,
+                                                     const SizeVector &taxon_map) {
+  Bitset bitset_a_translated_to_b =
+      BitsetTranslateViaTaxonTranslationMap(bitset_a, taxon_map);
+  return Bitset::Compare(bitset_a_translated_to_b, bitset_b);
+}
+
+Bitset SubsplitDAG::BitsetTranslateViaTaxonTranslationMap(
+    const Bitset &bitset, const SizeVector &taxon_map, const bool forward_translate) {
+  Bitset translated_bitset(bitset.size());
+  size_t clade_size = taxon_map.size();
+  size_t clade_count = bitset.size() / taxon_map.size();
+  // Remap each clade individually.
+  for (size_t i = 0; i < clade_count; i++) {
+    // Remap each bit in clade according to a new position according to the taxon map.
+    for (size_t j = 0; j < clade_size; j++) {
+      size_t input_offset = (i * clade_size) + j;
+      size_t output_offset = (i * clade_size) + taxon_map[j];
+      if (forward_translate) {
+        translated_bitset.set(input_offset, bitset[output_offset]);
+      } else {
+        translated_bitset.set(output_offset, bitset[input_offset]);
+      }
+    }
+  }
+  return translated_bitset;
+}
+
+bool SubsplitDAG::ContainsTaxon(const std::string &name) const {
+  return dag_taxons_.find(name) != dag_taxons_.end();
 }
 
 bool SubsplitDAG::ContainsNode(const Bitset &subsplit) const {
@@ -661,60 +859,49 @@ bool SubsplitDAG::ContainsEdge(const size_t parent_id, const size_t child_id) co
 
 std::pair<SizeVector, SizeVector> SubsplitDAG::BuildParentIdVector(
     const Bitset &subsplit) const {
-  SizeVector rotated_parents, sorted_parents;
+  SizeVector left_parents, right_parents;
+  // Linear search for all parents.
   for (const auto &[potential_parent_subsplit, node_id] : subsplit_to_id_) {
-    if (subsplit.SubsplitIsRotatedChildOf(potential_parent_subsplit)) {
-      rotated_parents.push_back(node_id);
-    } else if (subsplit.SubsplitIsSortedChildOf(potential_parent_subsplit)) {
-      sorted_parents.push_back(node_id);
+    if (subsplit.SubsplitIsLeftChildOf(potential_parent_subsplit)) {
+      left_parents.push_back(node_id);
+    } else if (subsplit.SubsplitIsRightChildOf(potential_parent_subsplit)) {
+      right_parents.push_back(node_id);
     }
   }
-  return {rotated_parents, sorted_parents};
+  return {left_parents, right_parents};
 }
 
 std::pair<SizeVector, SizeVector> SubsplitDAG::BuildChildIdVector(
     const Bitset &subsplit) const {
-  SizeVector rotated_children, sorted_children;
+  SizeVector left_children, right_children;
+  // Linear search for all children.
   for (const auto &[potential_child_subsplit, node_id] : subsplit_to_id_) {
-    if (potential_child_subsplit.SubsplitIsRotatedChildOf(subsplit)) {
-      rotated_children.push_back(node_id);
-    } else if (potential_child_subsplit.SubsplitIsSortedChildOf(subsplit)) {
-      sorted_children.push_back(node_id);
+    if (potential_child_subsplit.SubsplitIsLeftChildOf(subsplit)) {
+      left_children.push_back(node_id);
+    } else if (potential_child_subsplit.SubsplitIsRightChildOf(subsplit)) {
+      right_children.push_back(node_id);
     }
   }
-  return {rotated_children, sorted_children};
-}
-
-bool SubsplitDAG::IsValidNewNodePair(const Bitset &parent_subsplit,
-                                     const Bitset &child_subsplit) const {
-  const auto [rotated_parents_of_parent, sorted_parents_of_parent] =
-      BuildParentIdVector(parent_subsplit);
-  const auto [rotated_children_of_parent, sorted_children_of_parent] =
-      BuildChildIdVector(parent_subsplit);
-  const auto [rotated_children_of_child, sorted_children_of_child] =
-      BuildChildIdVector(child_subsplit);
-  return parent_subsplit.size() == 2 * taxon_count_ &&
-         child_subsplit.size() == 2 * taxon_count_ &&
-         !(rotated_parents_of_parent.empty() && sorted_parents_of_parent.empty()) &&
-         ((child_subsplit.SubsplitIsRotatedChildOf(parent_subsplit) &&
-           !sorted_children_of_parent.empty()) ||
-          (child_subsplit.SubsplitIsSortedChildOf(parent_subsplit) &&
-           !rotated_children_of_parent.empty())) &&
-         !rotated_children_of_child.empty() && !sorted_children_of_child.empty();
+  return {left_children, right_children};
 }
 
 void SubsplitDAG::ConnectChildToAllChildren(const Bitset &child_subsplit,
-                                            SizeVector &new_edge_idxs) {
-  const auto [rotated_children_of_child, sorted_children_of_child] =
+                                            SizeVector &added_edge_idxs) {
+  // Get all children of new subsplit.
+  const auto [left_children_of_child, right_children_of_child] =
       BuildChildIdVector(child_subsplit);
+
+  // Iterate over sorted and rotated children of subsplit.
   for (const auto &[children_of_child, rotated] :
-       std::vector<std::pair<SizeVector, bool>>{{rotated_children_of_child, true},
-                                                {sorted_children_of_child, false}}) {
-    SafeInsert(parent_to_range_, PerhapsSubsplitRotate(child_subsplit, rotated),
-               {GPCSPCountWithFakeSubsplits(),
-                GPCSPCountWithFakeSubsplits() + children_of_child.size()});
+       std::vector<std::pair<SizeVector, bool>>{{left_children_of_child, true},
+                                                {right_children_of_child, false}}) {
+    // Add child nodes in range to parent->child_range map.
+    SafeInsert(parent_to_child_range_, SubsplitToSortedOrder(child_subsplit, rotated),
+               {EdgeCountWithLeafSubsplits(),
+                EdgeCountWithLeafSubsplits() + children_of_child.size()});
+    // Add all child_ids
     for (const size_t child_of_child_id : children_of_child) {
-      new_edge_idxs.push_back(GPCSPCountWithFakeSubsplits());
+      added_edge_idxs.push_back(EdgeCountWithLeafSubsplits());
       CreateAndInsertEdge(GetDAGNodeId(child_subsplit), child_of_child_id, rotated);
     }
   }
@@ -722,18 +909,19 @@ void SubsplitDAG::ConnectChildToAllChildren(const Bitset &child_subsplit,
 
 void SubsplitDAG::ConnectParentToAllChildrenExcept(const Bitset &parent_subsplit,
                                                    const Bitset &child_subsplit,
-                                                   SizeVector &new_edge_idxs) {
-  const auto [rotated_children_of_parent, sorted_children_of_parent] =
+                                                   SizeVector &added_edge_idxs) {
+  const auto [left_children_of_parent, right_children_of_parent] =
       BuildChildIdVector(parent_subsplit);
   for (const auto &[children_of_parent, rotated] :
-       std::vector<std::pair<SizeVector, bool>>{{rotated_children_of_parent, true},
-                                                {sorted_children_of_parent, false}}) {
-    SafeInsert(parent_to_range_, PerhapsSubsplitRotate(parent_subsplit, rotated),
-               {GPCSPCountWithFakeSubsplits(),
-                GPCSPCountWithFakeSubsplits() + children_of_parent.size()});
+       std::vector<std::pair<SizeVector, bool>>{{left_children_of_parent, true},
+                                                {right_children_of_parent, false}}) {
+    SafeInsert(parent_to_child_range_, SubsplitToSortedOrder(parent_subsplit, rotated),
+               {EdgeCountWithLeafSubsplits(),
+                EdgeCountWithLeafSubsplits() + children_of_parent.size()});
     for (const size_t child_of_parent_id : children_of_parent) {
+      //
       if (child_of_parent_id != GetDAGNodeId(child_subsplit)) {
-        new_edge_idxs.push_back(GPCSPCountWithFakeSubsplits());
+        added_edge_idxs.push_back(EdgeCountWithLeafSubsplits());
         CreateAndInsertEdge(GetDAGNodeId(parent_subsplit), child_of_parent_id, rotated);
       }
     }
@@ -742,15 +930,16 @@ void SubsplitDAG::ConnectParentToAllChildrenExcept(const Bitset &parent_subsplit
 
 void SubsplitDAG::ConnectChildToAllParentsExcept(const Bitset &parent_subsplit,
                                                  const Bitset &child_subsplit,
-                                                 SizeVector &new_edge_idxs) {
-  const auto [rotated_parents_of_child, sorted_parents_of_child] =
+                                                 SizeVector &added_edge_idxs) {
+  const auto [left_parents_of_child, right_parents_of_child] =
       BuildParentIdVector(child_subsplit);
   for (const auto &[parents_of_child, rotated] :
-       std::vector<std::pair<SizeVector, bool>>{{rotated_parents_of_child, true},
-                                                {sorted_parents_of_child, false}}) {
+       std::vector<std::pair<SizeVector, bool>>{{left_parents_of_child, true},
+                                                {right_parents_of_child, false}}) {
     for (const size_t parent_of_child_id : parents_of_child) {
+      // if parent_of_child is the same
       if (parent_of_child_id != GetDAGNodeId(parent_subsplit)) {
-        new_edge_idxs.push_back(GPCSPCountWithFakeSubsplits());
+        added_edge_idxs.push_back(EdgeCountWithLeafSubsplits());
         CreateAndInsertEdge(parent_of_child_id, GetDAGNodeId(child_subsplit), rotated);
       }
     }
@@ -758,128 +947,224 @@ void SubsplitDAG::ConnectChildToAllParentsExcept(const Bitset &parent_subsplit,
 }
 
 void SubsplitDAG::ConnectParentToAllParents(const Bitset &parent_subsplit,
-                                            SizeVector &new_edge_idxs) {
-  const auto [rotated_parents_of_parent, sorted_parents_of_parent] =
+                                            SizeVector &added_edge_idxs) {
+  const auto [left_parents_of_parent, right_parents_of_parent] =
       BuildParentIdVector(parent_subsplit);
   for (const auto &[parents_of_parent, rotated] :
-       std::vector<std::pair<SizeVector, bool>>{{rotated_parents_of_parent, true},
-                                                {sorted_parents_of_parent, false}}) {
+       std::vector<std::pair<SizeVector, bool>>{{left_parents_of_parent, true},
+                                                {right_parents_of_parent, false}}) {
     for (const size_t parent_of_parent_id : parents_of_parent) {
-      new_edge_idxs.push_back(GPCSPCountWithFakeSubsplits());
+      added_edge_idxs.push_back(EdgeCountWithLeafSubsplits());
       CreateAndInsertEdge(parent_of_parent_id, GetDAGNodeId(parent_subsplit), rotated);
     }
   }
 }
 
-SubsplitDAG::NodeAdditionResult SubsplitDAG::AddNodePair(const Bitset &parent_subsplit,
+SubsplitDAG::ModificationResult SubsplitDAG::AddNodePair(const Bitset &parent_subsplit,
                                                          const Bitset &child_subsplit) {
+  // Check that node pair will create a valid SubsplitDAG.
   Assert(
-      IsValidNewNodePair(parent_subsplit, child_subsplit),
+      IsValidAddNodePair(parent_subsplit, child_subsplit),
       "The given pair of nodes is incompatible with DAG in SubsplitDAG::AddNodePair.");
-  SizeVector new_node_ids, new_edge_idxs, node_reindexer, edge_reindexer;
+  // Initialize output vectors.
+  SizeVector added_node_ids, added_edge_idxs, node_reindexer, edge_reindexer;
+  // Check if either parent or child don't already exist in the DAG.
   const bool parent_is_new = !ContainsNode(parent_subsplit);
   const bool child_is_new = !ContainsNode(child_subsplit);
-  // If both the parent and child exists, return new_node_ids and  new_edge_idxs as
-  // empty, and node_reindexer and edge_reindexer as default reindexers.
+  // Soft assert: This allows for parent-child pair to exist in the DAG, but no work is
+  // done. If both the parent and child already exist in DAG, return added_node_ids and
+  // added_edge_idxs as empty, and node_reindexer and edge_reindexer as identity
+  // reindexers.
   if (!parent_is_new && !child_is_new) {
     // Return default reindexers if both nodes already exist.
     node_reindexer = Reindexer::IdentityReindexer(NodeCount());
-    edge_reindexer = Reindexer::IdentityReindexer(GPCSPCountWithFakeSubsplits());
-    return {new_node_ids, new_edge_idxs, node_reindexer, edge_reindexer};
+    edge_reindexer = Reindexer::IdentityReindexer(EdgeCountWithLeafSubsplits());
+    return {added_node_ids, added_edge_idxs, node_reindexer, edge_reindexer};
   }
-  // Note: `prev_node_count` is a marker so that we know what the DAG root node id is
+
+  // Note: `prev_node_count` acts as a place marker. We know what the DAG root node id
+  // is
   // (`prev_node_count - 1`).
   const size_t prev_node_count = NodeCount();
+
+  // Add parent/child nodes and connect them to their children
+  // If child node is new, add node and connect it to all its children.
   if (child_is_new) {
     CreateAndInsertNode(child_subsplit);
-    new_node_ids.push_back(GetDAGNodeId(child_subsplit));
+    added_node_ids.push_back(GetDAGNodeId(child_subsplit));
     // Don't reindex these edges.
-    ConnectChildToAllChildren(child_subsplit, new_edge_idxs);
+    ConnectChildToAllChildren(child_subsplit, added_edge_idxs);
   }
+  // If parent node is new, add node it to all its children (except )
   if (parent_is_new) {
     CreateAndInsertNode(parent_subsplit);
-    new_node_ids.push_back(GetDAGNodeId(parent_subsplit));
+    added_node_ids.push_back(GetDAGNodeId(parent_subsplit));
     // Don't reindex these edges.
-    ConnectParentToAllChildrenExcept(parent_subsplit, child_subsplit, new_edge_idxs);
+    ConnectParentToAllChildrenExcept(parent_subsplit, child_subsplit, added_edge_idxs);
   }
   // Note: `prev_edge_count` is a marker conveying where we need to start
   // reindexing edge idxs.
   // Edges are only reindexed if the parent node already existed in the DAG
   // (so as to ensure that edges descending from the same node clade have
   // contiguous idxs).
-  size_t prev_edge_count = GPCSPCountWithFakeSubsplits();
+  size_t prev_edge_count = EdgeCountWithLeafSubsplits();
   // Connect the given parent node to the given child node.
-  new_edge_idxs.push_back(GPCSPCountWithFakeSubsplits());
+  added_edge_idxs.push_back(EdgeCountWithLeafSubsplits());
   CreateAndInsertEdge(GetDAGNodeId(parent_subsplit), GetDAGNodeId(child_subsplit),
-                      child_subsplit.SubsplitIsRotatedChildOf(parent_subsplit));
+                      child_subsplit.SubsplitIsLeftChildOf(parent_subsplit));
   // Don't reindex the edge between the given parent and child if the parent is new.
   if (parent_is_new) {
-    prev_edge_count = GPCSPCountWithFakeSubsplits();
+    prev_edge_count = EdgeCountWithLeafSubsplits();
   }
   if (child_is_new) {
     // Reindex these edges.
-    ConnectChildToAllParentsExcept(parent_subsplit, child_subsplit, new_edge_idxs);
+    ConnectChildToAllParentsExcept(parent_subsplit, child_subsplit, added_edge_idxs);
   }
   if (parent_is_new) {
     // Reindex these edges.
-    ConnectParentToAllParents(parent_subsplit, new_edge_idxs);
+    ConnectParentToAllParents(parent_subsplit, added_edge_idxs);
   }
   // Create reindexers.
   node_reindexer = BuildNodeReindexer(prev_node_count);
   edge_reindexer = BuildEdgeReindexer(prev_edge_count);
-  // Update the ids in new_node_ids and new_edge_idxs according to the reindexers.
-  Reindexer::RemapIdVector(new_node_ids, node_reindexer);
-  Reindexer::RemapIdVector(new_edge_idxs, edge_reindexer);
+  // Update the ids in added_node_ids and added_edge_idxs according to the reindexers.
+  Reindexer::RemapIdVector(added_node_ids, node_reindexer);
+  Reindexer::RemapIdVector(added_edge_idxs, edge_reindexer);
   // Update fields in the Subsplit DAG according to the reindexers.
   RemapNodeIds(node_reindexer);
   RemapEdgeIdxs(edge_reindexer);
   // Recount topologies to update `topology_count_below_`.
   CountTopologies();
-  return {new_node_ids, new_edge_idxs, node_reindexer, edge_reindexer};
+
+  return {added_node_ids, added_edge_idxs, node_reindexer, edge_reindexer};
 }
 
+// ** Validation Test methods:
+
+bool SubsplitDAG::IsConsistent() const {
+  Failwith("SubsplitDAG::IsConsistent() is not yet implemented.");
+  return false;
+}
+
+bool SubsplitDAG::IsValid() const {
+  bool has_invalid_node = false;
+  IterateOverRealNodes([this, &has_invalid_node](const SubsplitDAGNode *node) {
+    if (has_invalid_node == false) {
+      if (node->IsValid() == false) {
+        has_invalid_node = true;
+      }
+    }
+  });
+  return has_invalid_node;
+}
+
+bool SubsplitDAG::IsValidAddNodePair(const Bitset &parent_subsplit,
+                                     const Bitset &child_subsplit) const {
+  auto GetParentNodeCounts = [this](Bitset subsplit) {
+    const auto [left_parents, right_parents] = BuildParentIdVector(subsplit);
+    SizePair parents = {left_parents.size(), right_parents.size()};
+    return parents;
+  };
+  auto GetChildNodeCounts = [this](Bitset subsplit) {
+    const auto [left_children, right_children] = BuildChildIdVector(subsplit);
+    SizePair children = {left_children.size(), right_children.size()};
+    return children;
+  };
+
+  // Get all adjacent nodes, not including parent and child.
+  auto [left_parents_of_parent, right_parents_of_parent] =
+      GetParentNodeCounts(parent_subsplit);
+  auto [left_children_of_parent, right_children_of_parent] =
+      GetChildNodeCounts(parent_subsplit);
+  auto [left_children_of_child, right_children_of_child] =
+      GetChildNodeCounts(child_subsplit);
+  // Add child to parent's adjacent nodes.
+  const bool is_left_child = child_subsplit.SubsplitIsLeftChildOf(parent_subsplit);
+  if (is_left_child) {
+    left_children_of_parent++;
+  } else {
+    right_children_of_child++;
+  }
+
+  // (1) Added nodes are parent/child pair.
+  if (Bitset::SubsplitIsParentChildPair(parent_subsplit, child_subsplit) == false) {
+    return false;
+  }
+  // (2) Nodes do not add or remove taxa.
+  if ((parent_subsplit.size() != 2 * taxon_count_) ||
+      (child_subsplit.size() != 2 * taxon_count_)) {
+    return false;
+  }
+  // (3) The parent node has at least one parent, and at least one rotated and sorted
+  // child (including the added child node).
+  const bool parent_has_parent =
+      (left_parents_of_parent > 0) || (right_parents_of_parent > 0);
+  const bool parent_has_children =
+      (left_children_of_parent > 0) && (right_children_of_parent > 0);
+  if ((parent_has_parent && parent_has_children) == false) {
+    return false;
+  }
+  // (4) The child node has at least one parent, and at least one rotated and sorted
+  // child.
+  // (* we know child node has a parent node, so only need to check children)
+  const bool child_has_children =
+      (left_children_of_child > 0) && (right_children_of_child > 0);
+  if (child_has_children == false) {
+    return false;
+  }
+  return true;
+}
+
+// ** Reindexer methods:
+
+// NOTE: To be performed *after* DAG modification.
 SizeVector SubsplitDAG::BuildNodeReindexer(const size_t prev_node_count) {
   SizeVector node_reindexer = Reindexer::IdentityReindexer(NodeCount());
+  // Begin reindex values at taxon count to account for ...leaves?
   size_t running_traversal_idx = taxon_count_;
   size_t dag_root_node_id = prev_node_count - 1;
-  // Build node_reindexer by traversing entire DAG and assigning new ids after child ids
-  // are assigned.
-  DepthFirstWithAction({dag_root_node_id},
-                       SubsplitDAGTraversalAction(
-                           // BeforeNode
-                           [](size_t node_id) {},
-                           // AfterNode
-                           [&node_reindexer, &running_traversal_idx](size_t node_id) {
-                             node_reindexer.at(node_id) = running_traversal_idx;
-                             running_traversal_idx++;
-                           },
-                           // BeforeNodeClade
-                           [](size_t node_id, bool rotated) {},
-                           // VisitEdge
-                           [](size_t node_id, size_t child_id, bool rotated) {}));
+  // Build node_reindexer by using post-order traversal (topological sort) of entire DAG
+  // to assign new ids, where the index is the "before" node_id (stored in the node
+  // object), and the value is the "after" node_id.
+  DepthFirstWithAction(
+      {dag_root_node_id},
+      SubsplitDAGTraversalAction(
+          // BeforeNode
+          [this](size_t node_id) {},
+          // AfterNode
+          [this, &node_reindexer, &running_traversal_idx](size_t node_id) {
+            node_reindexer.at(node_id) = running_traversal_idx;
+            running_traversal_idx++;
+          },
+          // BeforeNodeClade
+          [this](size_t node_id, bool rotated) {},
+          // VisitEdge
+          [this](size_t node_id, size_t child_id, bool rotated) {}));
   return node_reindexer;
 }
 
 SizeVector SubsplitDAG::BuildEdgeReindexer(const size_t prev_edge_count) {
   SizeVector edge_reindexer =
-      Reindexer::IdentityReindexer(GPCSPCountWithFakeSubsplits());
+      Reindexer::IdentityReindexer(EdgeCountWithLeafSubsplits());
   // Only edges from an existing parent node to a new child node need to be reindexed.
   // See SubsplitDAG::AddNodePair().
-  for (size_t edge_idx = prev_edge_count; edge_idx < GPCSPCountWithFakeSubsplits();
+  for (size_t edge_idx = prev_edge_count; edge_idx < EdgeCountWithLeafSubsplits();
        edge_idx++) {
+    // Find edge with given idx.
     const auto &element =
         std::find_if(dag_edges_.begin(), dag_edges_.end(),
                      [edge_idx](auto pair) { return pair.second == edge_idx; });
     Assert(element != dag_edges_.end(),
            "An edge with given edge_idx did not exist in "
            "SubsplitDAG::BuildEdgeReindexer.");
+    //
     const auto &[node_pair, idx] = *element;
     std::ignore = idx;
     const auto &[parent_id, child_id] = node_pair;
     const Bitset parent_subsplit = GetDAGNode(parent_id)->GetBitset();
     const Bitset child_subsplit = GetDAGNode(child_id)->GetBitset();
     const auto idx_range = GetEdgeRange(
-        parent_subsplit, child_subsplit.SubsplitIsRotatedChildOf(parent_subsplit));
+        parent_subsplit, child_subsplit.SubsplitIsLeftChildOf(parent_subsplit));
     // New edge is added to the end of the range.
     const size_t new_idx = edge_reindexer.at(idx_range.second);
     Reindexer::ReassignAndShift(edge_reindexer, edge_idx, new_idx);
@@ -915,9 +1200,9 @@ void SubsplitDAG::RemapEdgeIdxs(const SizeVector &edge_reindexer) {
   for (const auto &[node_pair, edge_idx] : dag_edges_) {
     dag_edges_.at(node_pair) = edge_reindexer.at(edge_idx);
   }
-  // Update `parent_to_range_`.
-  for (const auto &[subsplit, idx_range] : parent_to_range_) {
-    parent_to_range_.at(subsplit) = {edge_reindexer.at(idx_range.first),
-                                     edge_reindexer.at(idx_range.second)};
+  // Update `parent_to_child_range_`.
+  for (const auto &[subsplit, idx_range] : parent_to_child_range_) {
+    parent_to_child_range_.at(subsplit) = {edge_reindexer.at(idx_range.first),
+                                           edge_reindexer.at(idx_range.second)};
   }
 }

--- a/src/subsplit_dag.cpp
+++ b/src/subsplit_dag.cpp
@@ -187,14 +187,14 @@ std::string SubsplitDAG::ToDot(bool show_index_labels) const {
             }
             auto bs = node->GetBitset();
             string_stream << node_id << " [label=\"<f0>"
-                          << bs.SubsplitGetClade(Bitset::SubsplitClade::LEFT)
+                          << bs.SubsplitGetClade(Bitset::SubsplitClade::Left)
                                  .ToVectorOfSetBitsAsString()
                           << "|<f1>";
             if (show_index_labels) {
               string_stream << node_id;
             }
             string_stream << "|<f2>"
-                          << bs.SubsplitGetClade(Bitset::SubsplitClade::RIGHT)
+                          << bs.SubsplitGetClade(Bitset::SubsplitClade::Right)
                                  .ToVectorOfSetBitsAsString()
                           << "\"]\n";
           },
@@ -413,10 +413,10 @@ EigenVectorXd SubsplitDAG::BuildUniformOnAllTopologiesPrior() const {
     std::ignore = parent_id;
     // If child is a leaf and subsplit is sorted, then child0 will have a zero taxon count.
     size_t child0_taxon_count =
-        GetDAGNode(child_id)->GetBitset().SubsplitGetClade(Bitset::SubsplitClade::LEFT).Count();
+        GetDAGNode(child_id)->GetBitset().SubsplitGetClade(Bitset::SubsplitClade::Left).Count();
     // As long as subsplit is sorted and nonempty, then child1 will have a nonzero taxon count.
     size_t child1_taxon_count =
-        GetDAGNode(child_id)->GetBitset().SubsplitGetClade(Bitset::SubsplitClade::RIGHT).Count();
+        GetDAGNode(child_id)->GetBitset().SubsplitGetClade(Bitset::SubsplitClade::Right).Count();
     // The ordering of this subsplit is flipped so that this ratio will be nonzero in
     // the denominator in the case of root & leaves.
     result(edge_idx) = Combinatorics::LogChildSubsplitCountRatio(child1_taxon_count,
@@ -622,11 +622,11 @@ void SubsplitDAG::ConnectGivenNodes(const size_t parent_id, const size_t child_i
   const auto child_node = GetDAGNode(child_id);
 
   SubsplitDAGNode::ParentClade parent_clade =
-      (rotated ? SubsplitDAGNode::ParentClade::LEFTSIDE
-               : SubsplitDAGNode::ParentClade::RIGHTSIDE);
-  parent_node->AddEdge(child_node->Id(), SubsplitDAGNode::Direction::LEAFWARD,
+      (rotated ? SubsplitDAGNode::ParentClade::Left
+               : SubsplitDAGNode::ParentClade::Right);
+  parent_node->AddEdge(child_node->Id(), SubsplitDAGNode::Direction::Leafward,
                        parent_clade);
-  child_node->AddEdge(parent_node->Id(), SubsplitDAGNode::Direction::ROOTWARD,
+  child_node->AddEdge(parent_node->Id(), SubsplitDAGNode::Direction::Rootward,
                       parent_clade);
 }
 
@@ -672,7 +672,7 @@ void SubsplitDAG::BuildNodes(const SizeBitsetMap &index_to_child,
     BuildNodesDepthFirst(index_to_child, rootsplit, visited_subsplits);
   }
   // Finally, we add the DAG root node.
-  CreateAndInsertNode(Bitset::RootSubsplitOfTaxonCount(taxon_count_));
+  CreateAndInsertNode(Bitset::UCASubsplitOfTaxonCount(taxon_count_));
 }
 
 void SubsplitDAG::BuildEdges(const SizeBitsetMap &index_to_child) {

--- a/src/subsplit_dag.cpp
+++ b/src/subsplit_dag.cpp
@@ -411,11 +411,13 @@ EigenVectorXd SubsplitDAG::BuildUniformOnAllTopologiesPrior() const {
   for (const auto &[parent_child_id, edge_idx] : dag_edges_) {
     const auto &[parent_id, child_id] = parent_child_id;
     std::ignore = parent_id;
+    // If child is a leaf and subsplit is sorted, then child0 will have a zero taxon count.
     size_t child0_taxon_count =
-        GetDAGNode(child_id)->GetBitset().SubsplitGetClade(0).Count();
+        GetDAGNode(child_id)->GetBitset().SubsplitGetClade(Bitset::SubsplitClade::LEFT).Count();
+    // As long as subsplit is sorted and nonempty, then child1 will have a nonzero taxon count.
     size_t child1_taxon_count =
-        GetDAGNode(child_id)->GetBitset().SubsplitGetClade(1).Count();
-    // The ordering of this subsplit is flipped so that this ratio will be non-zero in
+        GetDAGNode(child_id)->GetBitset().SubsplitGetClade(Bitset::SubsplitClade::RIGHT).Count();
+    // The ordering of this subsplit is flipped so that this ratio will be nonzero in
     // the denominator in the case of root & leaves.
     result(edge_idx) = Combinatorics::LogChildSubsplitCountRatio(child1_taxon_count,
                                                                  child0_taxon_count);

--- a/src/subsplit_dag.cpp
+++ b/src/subsplit_dag.cpp
@@ -901,7 +901,8 @@ void SubsplitDAG::ConnectChildToAllChildren(const Bitset &child_subsplit,
                 EdgeCountWithLeafSubsplits() + children_of_child.size()});
 
     for (const size_t child_of_child_id : children_of_child) {
-      const auto new_edge_idx = CreateAndInsertEdge(GetDAGNodeId(child_subsplit), child_of_child_id, rotated);
+      const auto new_edge_idx =
+          CreateAndInsertEdge(GetDAGNodeId(child_subsplit), child_of_child_id, rotated);
       added_edge_idxs.push_back(new_edge_idx);
     }
   }
@@ -922,7 +923,8 @@ void SubsplitDAG::ConnectParentToAllChildrenExcept(const Bitset &parent_subsplit
 
     for (const size_t child_of_parent_id : children_of_parent) {
       if (child_of_parent_id != GetDAGNodeId(child_subsplit)) {
-        const auto new_edge_idx = CreateAndInsertEdge(GetDAGNodeId(parent_subsplit), child_of_parent_id, rotated);
+        const auto new_edge_idx = CreateAndInsertEdge(GetDAGNodeId(parent_subsplit),
+                                                      child_of_parent_id, rotated);
         added_edge_idxs.push_back(new_edge_idx);
       }
     }
@@ -940,7 +942,8 @@ void SubsplitDAG::ConnectChildToAllParentsExcept(const Bitset &parent_subsplit,
                                                 {right_parents_of_child, false}}) {
     for (const size_t parent_of_child_id : parents_of_child) {
       if (parent_of_child_id != GetDAGNodeId(parent_subsplit)) {
-        const auto new_edge_idx = CreateAndInsertEdge(parent_of_child_id, GetDAGNodeId(child_subsplit), rotated);
+        const auto new_edge_idx = CreateAndInsertEdge(
+            parent_of_child_id, GetDAGNodeId(child_subsplit), rotated);
         added_edge_idxs.push_back(new_edge_idx);
       }
     }
@@ -956,7 +959,8 @@ void SubsplitDAG::ConnectParentToAllParents(const Bitset &parent_subsplit,
        std::vector<std::pair<SizeVector, bool>>{{left_parents_of_parent, true},
                                                 {right_parents_of_parent, false}}) {
     for (const size_t parent_of_parent_id : parents_of_parent) {
-      const auto new_edge_idx = CreateAndInsertEdge(parent_of_parent_id, GetDAGNodeId(parent_subsplit), rotated);
+      const auto new_edge_idx = CreateAndInsertEdge(
+          parent_of_parent_id, GetDAGNodeId(parent_subsplit), rotated);
       added_edge_idxs.push_back(new_edge_idx);
     }
   }

--- a/src/subsplit_dag.cpp
+++ b/src/subsplit_dag.cpp
@@ -27,13 +27,13 @@ SubsplitDAG::SubsplitDAG(size_t taxon_count,
   AddLeafSubsplitsToDAGEdgesAndParentToRange();
   CountTopologies();
 
-  dag_taxons_ = std::map<std::string, size_t>();
+  dag_taxa_ = std::map<std::string, size_t>();
   // Insert all taxons from tree_collections's map to SubsplitDAG map.
   for (const auto &[tag, name] : tag_taxon_map) {
     // The "tag" key of the tree_collection's taxon_map is 2 bitpacked ints: [id,
     // topology count]. We only care about the id.
     size_t id = static_cast<size_t>(UnpackFirstInt(tag));
-    dag_taxons_.insert(std::make_pair(name, id));
+    dag_taxa_.insert(std::make_pair(name, id));
   }
 }
 
@@ -111,7 +111,7 @@ void SubsplitDAG::CountTopologies() {
   topology_count_ = topology_count_below_[DAGRootNodeId()];
 }
 
-size_t SubsplitDAG::TaxonCount() const { return dag_taxons_.size(); }
+size_t SubsplitDAG::TaxonCount() const { return dag_taxa_.size(); }
 
 size_t SubsplitDAG::NodeCount() const { return dag_nodes_.size(); }
 
@@ -252,7 +252,7 @@ size_t SubsplitDAG::GetTaxonId(const std::string &name) const {
   Assert(
       ContainsTaxon(name),
       "SubsplitDAG::GetTaxonId(): Taxon with given name is not contained in the DAG.");
-  return dag_taxons_.find(name)->second;
+  return dag_taxa_.find(name)->second;
 }
 
 SubsplitDAGNode *SubsplitDAG::GetDAGNode(const size_t node_id) const {
@@ -290,7 +290,7 @@ SizePair SubsplitDAG::GetEdgeRange(const Bitset &subsplit, const bool rotated) c
 
 std::vector<std::string> SubsplitDAG::GetSortedVectorOfTaxonNames() const {
   std::vector<std::string> taxons;
-  for (const auto &name_id : dag_taxons_) {
+  for (const auto &name_id : dag_taxa_) {
     taxons.push_back(name_id.first);
   }
   std::sort(taxons.begin(), taxons.end());
@@ -320,7 +320,7 @@ std::vector<Bitset> SubsplitDAG::GetSortedVectorOfEdgeBitsets() const {
   return edges;
 }
 
-std::map<std::string, size_t> &SubsplitDAG::GetTaxonMap() { return dag_taxons_; }
+std::map<std::string, size_t> &SubsplitDAG::GetTaxonMap() { return dag_taxa_; }
 
 EigenVectorXd SubsplitDAG::BuildUniformOnTopologicalSupportPrior() const {
   EigenVectorXd q = EigenVectorXd::Ones(EdgeCountWithLeafSubsplits());
@@ -609,19 +609,6 @@ void SubsplitDAG::CreateAndInsertEdge(const size_t parent_id, const size_t child
   SafeInsert(dag_edges_, {parent_id, child_id}, EdgeCountWithLeafSubsplits());
 }
 
-void SubsplitDAG::DeleteNode(const Bitset &node_subsplit) {
-  Failwith("SubsplitDAG::DeleteNode() is not implemented.");
-  Assert(ContainsNode(node_subsplit),
-         "SubsplitDAG::DeleteNode(): Given edge does not exist");
-}
-
-void SubsplitDAG::DeleteEdge(const size_t parent_id, const size_t child_id,
-                             bool rotated) {
-  Failwith("SubsplitDAG::DeleteNode() is not implemented.");
-  Assert(ContainsEdge(parent_id, child_id),
-         "SubsplitDAG::DeleteEdge(): Given edge does not exist.");
-}
-
 void SubsplitDAG::ConnectGivenNodes(const size_t parent_id, const size_t child_id,
                                     bool rotated) {
   const auto parent_node = GetDAGNode(parent_id);
@@ -850,7 +837,7 @@ Bitset SubsplitDAG::BitsetTranslateViaTaxonTranslationMap(
 }
 
 bool SubsplitDAG::ContainsTaxon(const std::string &name) const {
-  return dag_taxons_.find(name) != dag_taxons_.end();
+  return dag_taxa_.find(name) != dag_taxa_.end();
 }
 
 bool SubsplitDAG::ContainsNode(const Bitset &subsplit) const {

--- a/src/subsplit_dag.hpp
+++ b/src/subsplit_dag.hpp
@@ -4,25 +4,26 @@
 // The purpose of this class is to hold a DAG built from the parent-child relationships
 // of the subsplits. We wish to have information associated with both the nodes and
 // edges of the DAG. Our strategy for doing that is via non-negative integer indices:
-// nodes have a unique size_t `Id`, and each edge has a unique `gpcsp_idx`. We can then
+// nodes have a unique size_t `Id`, and each edge has a unique `edge_idx`. We can then
 // store arbitrary associated information in other data structures associated with these
 // indices.
 //
 // The DAG has a well-defined notion of rootward and leafward.
 //
 // The data structure for this DAG is as follows:
-// - The nodes of the DAG have vectors of indices representing their edges to other
+// - The nodes of the DAG are vectors of indices representing their edges to other
 // nodes. These include edges to the children (leafward edges) and also the edges that
 // are connecting to that node (rootward edges). Furthermore, these sets of edges are
-// separated into two classes: those that split apart the left component of the subsplit
-// ("rotated" edges) and those that split apart the right component of the subsplit
-// ("sorted" edges). The nodes of the DAG also include bitsets describing the subsplit
-// that they represent.
+// separated into two subsets: those that descend from the left component of the
+// subsplit
+// ("rotated" edges) and those that descend from the right component of the subsplit
+// ("sorted" edges). The nodes of the DAG also include bitsets describing the taxa they
+// contain.
 // - The edges of the DAG are indexed separately, and there is a map (`dag_edges_`)
-// which maps from pairs of node Ids to this edge index. These DAG edges are indexed
+// which maps from pairs of node Ids to its edge index. These DAG edges are indexed
 // such that all of the sorted edges descending from a given node have a contiguous set
 // of indices, as do all of the rotated indices. The range of indices for such a set of
-// edges is given by the `parent_to_range_` map.
+// edges is given by the `parent_to_child_range_` map.
 // There is also a `subsplit_to_id_` map that maps from the subsplit bitset of the DAG
 // node (and its rotated version) to the node Id.
 // - To clarify terminology, the "DAG root node" refers to the universal ancestor and is
@@ -42,64 +43,133 @@
 
 class SubsplitDAG {
  public:
+  // ** Constructor methods:
+
+  // Build empty Subsplit DAG with no topologies and no taxa.
+  SubsplitDAG();
+  // Build a Subsplit DAG expressing all tree topologies from tree_collection.
+  explicit SubsplitDAG(const RootedTreeCollection &tree_collection);
+  // Build a Subsplit DAG from
+  // SubsplitDAG();
+
+  // ** Comparator methods:
+
+  // This compare ensures that both DAGs have the same topology according to their
+  // set of node and edge bitsets.  However, it does ensure that DAGs have the same id
+  // and idxs for their respective nodes and edges, only that they contain the
+  // same set of nodes and edges (as long as taxon positions in the
+  // clades have the same mapping). Additionally, this compare does not give a proper
+  // ordering.  It only returns zero for equal, nonzero otherwise.
+  static int Compare(const SubsplitDAG &lhs, const SubsplitDAG &rhs);
+  friend bool operator==(const SubsplitDAG &lhs, const SubsplitDAG &rhs);
+  friend bool operator!=(const SubsplitDAG &lhs, const SubsplitDAG &rhs);
+
+  // ** Count methods:
+
+  // The total number of individual taxa in the
+  size_t TaxonCount() const;
+  // The total number of nodes in the DAG (including the root and leaves).
+  size_t NodeCount() const;
+  // The total number of nodes in the DAG (excluding the root, but including the
+  // leaves).
+  size_t NodeCountWithoutDAGRoot() const;
+  // The total number of rootsplits in DAG. These count all direct descendents of the
+  // root (also, the union of each rootsplits clades cover the set of all taxa in the
+  // DAG).
+  size_t RootsplitCount() const;
+  // The total number of edges in the DAG (excluding edges which terminate at a root or
+  // leaf node).
+  size_t EdgeCount() const;
+  // The total number of edges in the DAG (including edges which terminat at a root of
+  // leaf node).
+  size_t EdgeCountWithLeafSubsplits() const;
+  // The total number of tree topologies expressable by the DAG.
+  double TopologyCount() const;
+
+  // ** Print
+
+  // Print all nodes:
+  // - One line is given for (node_id | subsplit_bitset).
+  // - One line is given for each combination of leafward/rootward, sorted/rotated, for
+  // all adjacent node_ids.
+  void Print() const;
+  // Print all nodes as (node_id | node_bitsets) pairs, one-per-line.
+  void PrintNodes() const;
+  // Print all edges/PCSP, as (pcsp_bitset | edge_idx) pairs, one-per-line.
+  void PrintEdgeIndexer() const;
+  // Print all edges/PCSP, as (parent_node_id | child_node_id) pairs, one-per-line.
+  void PrintDAGEdges() const;
+  // Print all nodes, as (bitset | range_begin | range_end)
+  void PrintParentToRange() const;
+  // Output DOT format graph of DAG to file.
+  void ToDot(const std::string file_path, bool show_index_labels = true) const;
+  // Output DOT format graph of DAG to a string.
+  std::string ToDot(bool show_index_labels = true) const;
+
+  // ** Build output indexes/vectors
+
+  // Create a EdgeIndexer representing the DAG.
+  // The EdgeIndexer is a map (edge/PCSP bitset -> edge/PCSP index).
+  // The edge/PCSP indexer is "expanded", meaning it contains leafs and rootsplits.
+  BitsetSizeMap BuildEdgeIndexer() const;
+  // Get the rotated and sorted parents of the node with the given subsplit.
+  std::pair<SizeVector, SizeVector> BuildParentIdVector(const Bitset &subsplit) const;
+  // Get the rotated and sorted children of the node with the given subsplit.
+  std::pair<SizeVector, SizeVector> BuildChildIdVector(const Bitset &subsplit) const;
+  // Output RootedIndexerRepresentation of DAG (from RootedSBNMaps).
+  // RootedIndexerRepresentation is a vector of edge idxs in topological preorder.
+  RootedIndexerRepresentation IndexerRepresentationOf(const BitsetSizeMap &indexer,
+                                                      const Node::NodePtr &topology,
+                                                      size_t default_index) const;
+  // Each node in a topology is constructed with SubsplitDAGNode ID as Node ID.
+  Node::NodePtrVec GenerateAllTopologies() const;
+
+  // ** Getter methods:
+
+  // Get Taxon's bitset clade positional id.
+  size_t GetTaxonId(const std::string &name) const;
+  // Get node based on node id.
+  SubsplitDAGNode *GetDAGNode(const size_t node_id) const;
+  // Get the node id based on the subsplit bitset.
+  size_t GetDAGNodeId(const Bitset &subsplit) const;
+  // Gets the node id of the DAG root.
+  size_t DAGRootNodeId() const;
+  // Return the node ids corresponding to the rootsplits.
+  const SizeVector &RootsplitIds() const;
+  // Get the PCSP edge index by its parent-child pair subsplits from the DAG nodes.
+  size_t GetEdgeIdx(const Bitset &parent_subsplit, const Bitset &child_subsplit) const;
+  // Get the PCSP edge index by its parent-child pair id from the DAG nodes.
+  size_t GetEdgeIdx(size_t parent_id, size_t child_id) const;
+  // Get the range of outgoing idxs from the given clade of a subsplit.
+  SizePair GetEdgeRange(const Bitset &subsplit, const bool rotated) const;
+  // Get set of all taxon names.
+  std::vector<std::string> GetSortedVectorOfTaxonNames() const;
+  // Get set of all node Subsplit bitsets.
+  std::vector<Bitset> GetSortedVectorOfNodeBitsets() const;
+  // Get set of all edge PCSP bitsets.
+  std::vector<Bitset> GetSortedVectorOfEdgeBitsets() const;
+  // Get reference to taxon map.
+  std::map<std::string, size_t> &GetTaxonMap();
+
+  // ** DAG Lambda Iterator methods:
+  // These methods iterate over the nodes and take lambda functions with arguments
+  // relative to current node.
+
   // NodeLambda is for iterating over nodes.
   using NodeLambda = std::function<void(const SubsplitDAGNode *)>;
   // EdgeDestinationLambda takes in a rotation status (true is rotated, false is not)
   // and a "destination" node. For iterating over DAG edges with a rotation status.
   using EdgeDestinationLambda = std::function<void(bool, const SubsplitDAGNode *)>;
-  // EdgeAndNodeLambda takes a GPCSP index of an edge, its rotation status, and an index
+  // EdgeAndNodeLambda takes a PCSP index of an edge, its rotation status, and an index
   // of the node on the other side of the edge.
   using EdgeAndNodeLambda = std::function<void(const size_t, const bool, const size_t)>;
   // ParentEdgeChildLambda takes: the parent id in the DAG, the rotation status of the
   // edge, the child id, and the GCPSP index of the edge.
   using ParentRotationChildEdgeLambda =
       std::function<void(const size_t, const bool, const size_t, const size_t)>;
-
-  // NodeAdditionResult is the return value of SubsplitDAG::AddNodePair.
-  struct NodeAdditionResult {
-    SizeVector new_node_ids, new_edge_idxs, node_reindexer, edge_reindexer;
-  };
-
-  SubsplitDAG();
-  explicit SubsplitDAG(const RootedTreeCollection &tree_collection);
-
-  // The total node count (including the DAG root node).
-  size_t NodeCount() const;
-  size_t NodeCountWithoutDAGRoot() const;
-  // How many topologies can be expressed by the subsplit DAG? Expressed as a double
-  // because this number can be big.
-  double TopologyCount() const;
-  size_t RootsplitCount() const;
-  size_t GPCSPCount() const;
-  size_t GPCSPCountWithFakeSubsplits() const;
-  StringSizeMap SummaryStatistics() const;
-
-  void Print() const;
-  void PrintGPCSPIndexer() const;
-  void PrintDAGEdges() const;
-  void PrintParentToRange() const;
-  void ToDot(const std::string file_path, bool show_index_labels = true) const;
-  std::string ToDot(bool show_index_labels = true) const;
-
-  // Create a GPCSPIndexer representing the DAG.
-  // The gpcsp indexer is "expanded" meaning it contains fake PCSPs and rootsplit
-  // bitsets are formatted as subsplits: 1110|0001.
-  BitsetSizeMap BuildGPCSPIndexer() const;
-  SubsplitDAGNode *GetDAGNode(size_t node_id) const;
-  size_t GetDAGNodeId(const Bitset &subsplit) const;
-  size_t DAGRootNodeId() const;
-  // Return the node ids corresponding to the rootsplits.
-  const SizeVector &RootsplitIds() const;
-
-  // Access the GPCSP index from a parent-child pair of DAG nodes.
-  size_t GetGPCSPIndex(const Bitset &parent_subsplit,
-                       const Bitset &child_subsplit) const;
-  // Get the GPCSP index from a parent-child pair of DAG nodes using the dag_edges_.
-  size_t GPCSPIndexOfIds(size_t parent_id, size_t child_id) const;
-  // Get the range of outgoing idxs from the given clade of a subsplit.
-  SizePair GetEdgeRange(const Bitset &subsplit, const bool rotated) const;
+  //
   // Iterate over the "real" nodes, i.e. those that do not correspond to
-  // fake subsplits or the DAG root node.
+  // leaf subsplits or the DAG root node.
   void IterateOverRealNodes(const NodeLambda &f) const;
   // Iterate over the all leafward edges, rotated and sorted, of node using an
   // EdgeDestinationLambda.
@@ -108,7 +178,7 @@ class SubsplitDAG {
   // Iterate over only the rotated/sorted leafward edges of node using a NodeLambda.
   void IterateOverLeafwardEdges(const SubsplitDAGNode *node, bool rotated,
                                 const NodeLambda &f) const;
-  // Iterate over the leafward edges, supplying both the a GPCSP index of the edge and
+  // Iterate over the leafward edges, supplying both the a PCSP index of the edge and
   // the SubsplitDAGNode of the corresponding child.
   void IterateOverLeafwardEdgesAndChildren(const SubsplitDAGNode *node,
                                            const EdgeAndNodeLambda &f) const;
@@ -116,27 +186,33 @@ class SubsplitDAG {
   // Excludes edges to the DAG root node.
   void IterateOverRootwardEdges(const SubsplitDAGNode *node,
                                 const EdgeDestinationLambda &f) const;
-  // Iterate over the rootward edges, supplying both the a GPCSP index of the edge and
+  // Iterate over the rootward edges, supplying both the a PCSP index of the edge and
   // the SubsplitDAGNode of the corresponding child.
   void IterateOverRootwardEdgesAndParents(const SubsplitDAGNode *node,
                                           const EdgeAndNodeLambda &f) const;
   // Iterate over the leafward edges, supplying the parent node id, child node id,
-  // rotation of child, and the GPCSP index of the rootward edge connecting the two.
+  // rotation of child, and the PCSP index of the rootward edge connecting the two.
   void IterateOverParentAndChildAndLeafwardEdges(
       const SubsplitDAGNode *node, const ParentRotationChildEdgeLambda &f) const;
 
-  // Each node in a topology is constructed with SubsplitDAGNode ID as Node ID.
-  Node::NodePtrVec GenerateAllTopologies() const;
+  // ** DAG Traversals
+  // These perform a traversal of the DAG and takes an argument TraversalActionT.
+  // TraversalActionT passes four functions of the following form and order:
+  // (1)  void BeforeNode(size_t node_id)
+  // (2)  void AfterNode(size_t node_id)
+  // (3)  void BeforeNodeClade(size_t node_id, bool rotated)
+  // (4)  void VisitEdge(size_t node_id, size_t child_id, bool rotated)
+  // See below for order of usage.
 
-  // Apply an Action via a depth first traversal. Do not visit leaf nodes.
+  // Apply a TraversalAction via a depth first traversal. Do not visit leaf nodes.
   // Applied to a given node, we:
-  // * Apply BeforeNode
-  // * For each of the clades of the node, we:
-  //     * Apply BeforeNodeClade
-  //     * For each edge descending from that clade, we:
-  //         * Recur into the child node of the clade if it is not a leaf
-  //         * Apply VisitEdge to the edge
-  // * Apply AfterNode
+  // - Apply BeforeNode()
+  // - For each of the clades of the node, we:
+  //     - Apply BeforeNodeClade()
+  //     - For each edge descending from that clade, we:
+  //         - Recur into the child node of the clade if it is not a leaf
+  //         - Apply VisitEdge() to the edge
+  // - Apply AfterNode()
   template <typename TraversalActionT>
   void DepthFirstWithAction(const SizeVector &starting_nodes,
                             const TraversalActionT &action) const {
@@ -145,7 +221,6 @@ class SubsplitDAG {
       DepthFirstWithActionForNode(action, node_id, visited_nodes);
     }
   };
-
   // The portion of the traversal that is below a given node.
   template <typename TraversalActionT>
   void DepthFirstWithActionForNode(const TraversalActionT &action, size_t node_id,
@@ -155,9 +230,8 @@ class SubsplitDAG {
     DepthFirstWithActionForNodeClade(action, node_id, true, visited_nodes);
     action.AfterNode(node_id);
   };
-
   // The portion of the traversal that is below a given clade of a given node.
-  // Do not recur into leaf nodes.
+  // Does not recurse into leaf nodes.
   template <typename TraversalActionT>
   void DepthFirstWithActionForNodeClade(
       const TraversalActionT &action, size_t node_id, bool rotated,
@@ -175,16 +249,28 @@ class SubsplitDAG {
     }
   };
 
-  // #288: consider renaming these re leafward and rootward.
-  // Also, note that they could be called "TraversalTrace" to signify that they are
-  // recording the trace of a traversal.
-  [[nodiscard]] SizeVector LeafwardPassTraversal(bool include_dag_root_node) const;
-  [[nodiscard]] SizeVector RootwardPassTraversal(bool include_dag_root_node) const;
-  [[nodiscard]] SizeVector ReversePostorderTraversal() const;
+  // ** DAG Edge Traversal Traces
+  // These function produce a vector of edge indexes representing an ordered traversal
+  // of the DAG.
 
-  // Do a reverse postorder traversal on the edges of the DAG, including edges from the
+  // Creates a vector of edge idxs representing a leafward DFS postorder traversal of
+  // the DAG.
+  [[nodiscard]] SizeVector LeafwardEdgeTraversalTrace(bool include_dag_root_node) const;
+  // Creates a vector of edge idxs representing a rootward DFS postorder traversal of
+  // the DAG.
+  [[nodiscard]] SizeVector RootwardEdgeTraversalTrace(bool include_dag_root_node) const;
+  // Creates a vector of edge idxs representing a reverse DFS postorder, leafward
+  // traversal of the DAG. NOTE: A reverse postorder traversal represents a topological
+  // sort.
+  [[nodiscard]] SizeVector TopologicalEdgeTraversalTrace() const;
+
+  // ** DAG Edge Traversals with Action
+
+  // Do a topological traversal on the edges of the DAG, including edges from the
   // DAG root node to the rootsplits, supplying the relevant indices to a lambda.
-  void ReversePostorderIndexTraversal(ParentRotationChildEdgeLambda f) const;
+  void TopologicalEdgeTraversal(ParentRotationChildEdgeLambda f) const;
+
+  // ** Priors
 
   // Discrete uniform distribution over each subsplit.
   [[nodiscard]] EigenVectorXd BuildUniformQ() const;
@@ -195,58 +281,75 @@ class SubsplitDAG {
   // all topologies are in the support.
   [[nodiscard]] EigenVectorXd BuildUniformOnAllTopologiesPrior() const;
 
-  RootedIndexerRepresentation IndexerRepresentationOf(const BitsetSizeMap &indexer,
-                                                      const Node::NodePtr &topology,
-                                                      size_t default_index) const;
-
   // Get a vector from each DAG node index to the probability of sampling that DAG node
   // with the supplied SBN parameters. These SBN parameters must be indexed in a
   // compatible way as the dag_edges_ of the subsplit DAG.
   EigenVectorXd UnconditionalNodeProbabilities(
       EigenConstVectorXdRef normalized_sbn_parameters) const;
-  // Get a map from each non-fake subsplit to the probability of observing that
+  // Get a map from each non-leaf subsplit to the probability of observing that
   // subsplit with the supplied SBN parameters. See
   // UnconditionalSubsplitProbabilityVector for notes.
   BitsetDoubleMap UnconditionalSubsplitProbabilities(
       EigenConstVectorXdRef normalized_sbn_parameters) const;
-  // Get a vector from each GPCSP index to the Bayes-inverted probability of sampling
+  // Get a vector from each PCSP index to the Bayes-inverted probability of sampling
   // the parent given the child.
   EigenVectorXd InvertedGPCSPProbabilities(
       EigenConstVectorXdRef normalized_sbn_parameters,
       EigenConstVectorXdRef node_probabilities) const;
 
+  // ** Contains
+
+  // Does a taxon with the given name exist?
+  bool ContainsTaxon(const std::string &name) const;
   // Does a node with the given subsplit exist?
   bool ContainsNode(const Bitset &subsplit) const;
   // Does a node with the given id exist?
   bool ContainsNode(const size_t node_id) const;
   // Does an edge that connects the two nodes exist?
   bool ContainsEdge(const size_t parent_id, const size_t child_id) const;
-  // Get the rotated and sorted parents of the node with the given subsplit.
-  std::pair<SizeVector, SizeVector> BuildParentIdVector(const Bitset &subsplit) const;
-  // Get the rotated and sorted children of the node with the given subsplit.
-  std::pair<SizeVector, SizeVector> BuildChildIdVector(const Bitset &subsplit) const;
-  // Check if it is valid to add the node pair. More specifically, check that:
-  // - The nodes are adjacent.
-  // - The nodes do not add/remove any taxa.
-  // - The parent node has at least 1 parent.
-  // - Including the child node, each clade of the parent node has at least 1 child.
-  // - Each clade of the child node has at least 1 child.
-  bool IsValidNewNodePair(const Bitset &parent_subsplit,
-                          const Bitset &child_subsplit) const;
-  // Add an adjacent node pair to the DAG
-  // and maintain the following indexing conventions for nodes and edges:
+
+  // ** Modify DAG
+  // These methods are for directly modifying the DAG by adding or removing nodes and
+  // edges. All these methods promise that all data owned by the SubsplitDAG will be
+  // valid and up-to-date at their conclusion. This includes maintaining the following
+  // DAG invariants:
   // - Tips have ids 0 to taxon_count_.
   // - Parents have higher ids than their children.
   // - The DAG root node has highest id.
   // - Edges descending from the same node clade have contiguous idxs.
   // - There are no gaps in node ids or edge idxs.
-  // Get the new_node_ids, new_edge_idxs, node_reindexer, and edge_reindexer.
-  // Note: if both nodes already existed in the DAG, then new_node_ids and
-  // new_edge_idxs will be empty.
-  NodeAdditionResult AddNodePair(const Bitset &parent_subsplit,
-                                 const Bitset &child_subsplit);
+  // Returned is the ModificationResult, which will specify changes and reordering to
+  // data that occurred during modification.
 
-  // Get the reindexer for node ids.
+  // ModificationResult is the return value of Modification methods.
+  // Contains the output needed to update all related data to reflect modifications to
+  // DAG.
+  struct ModificationResult {
+    // Nodes that were added or removed by modification.
+    SizeVector added_node_ids;
+    // Edges that were added or removed by modification.
+    SizeVector added_edge_idxs;
+    // New ordering of node ids relative to their ordering before DAG modification.
+    SizeVector node_reindexer;
+    // New ordering of edge idxs relative to their ordering before DAG modification.
+    SizeVector edge_reindexer;
+  };
+
+  // Add an adjacent node pair to the DAG.
+  ModificationResult AddNodePair(const Bitset &parent_subsplit,
+                                 const Bitset &child_subsplit);
+  // Add all tree topologies in topology_counter to DAG.
+  std::tuple<BitsetSizeMap, SizeBitsetMap, BitsetVector> ProcessTopologyCounter(
+      const Node::TopologyCounter &topology_counter);
+
+  // ** Reindexers
+  // These methods are for building and applying reindexers.
+  // A reindexer describes a remapping/transform of identifiers (i.e. node ids, edge
+  // idxs) before and after a modification to the DAG. The index is before the
+  // modification, the value is after the modification. Reindexers are used to perform a
+  // transform on data vectors,
+
+  // Uses a depth first DAG traversal to build a reindexer for node_ids.
   SizeVector BuildNodeReindexer(const size_t prev_node_count);
   // Get the reindexer for edges idxs.
   SizeVector BuildEdgeReindexer(const size_t prev_edge_count);
@@ -255,75 +358,173 @@ class SubsplitDAG {
   // Remap all edge idxs according to the edge_reindexer.
   void RemapEdgeIdxs(const SizeVector &edge_reindexer);
 
+  // ** Validation Tests
+  // These methods are used to assert that a DAG is in a valid state or that given
+  // operation will result in a valid DAG.
+
+  // Checks if SubsplitDAG's corresponding data is consistent and up-to-date.
+  // Specifically, checks that:
+  // - subsplit_to_id_ map consistent with nodes in dag_nodes_.
+  // - parent_to_child_range_ map consistent with nodes in dag_nodes_'s (adjacent.
+  // - parent_to_child_range_ map matches each edge in dag_edges_.
+  bool IsConsistent() const;
+  // Checks if SubsplitDAG is in a valid state (assumes that DAG is consistent).
+  // Specifically, checks that:
+  // - Each node is valid. That is, either:
+  //    - Node has zero parents and zero children.
+  //    - Node has 1+ parents, 1+ sorted children, and 1+ rotated children.
+  // -
+  bool IsValid() const;
+  // Check if it is valid to add given node pair. Specifically, check that:
+  // - The nodes are adjacent.
+  // - The nodes do not add/remove any taxa.
+  // - The parent node has at least one parent.
+  // - Including the child node, each clade of the parent node has at least one child.
+  // - Each clade of the child node has at least 1 child.
+  bool IsValidAddNodePair(const Bitset &parent_subsplit,
+                          const Bitset &child_subsplit) const;
+
+  // ** Miscellaneous
+
+  // Creates a dictionary of summary statistics for DAG.
+  // Includes node_count and edge_count.
+  StringSizeMap SummaryStatistics() const;
+  // Rotates Node Subsplit only if it is out of sorted order (rotated).
+  Bitset SubsplitToSortedOrder(const Bitset &subsplit, bool rotated) const;
+  // Fixes Edge PCSP only if child is out of sorted order (rotated).
+  Bitset EdgeToSortedOrder(const Bitset &pcsp) const;
+  // Build vector between from SubsplitDAGs dag_a to dag_b corresponding to their taxon
+  // ids. Can be treated as a "map" with indices representing keys. Requires that both
+  // SubsplitDAGs use the same taxon set.
+  // - Map: [ index: dag_a's taxon_id => value: dag_b's taxon_id ]
+  static SizeVector BuildTaxonTranslationMap(const SubsplitDAG &dag_a,
+                                             const SubsplitDAG &dag_b);
+  // Compare two bitsets (subsplits or PCSPs) from two different DAGs using a taxon
+  // map.
+  static int BitsetCompareViaTaxonTranslationMap(const Bitset &bitset_a,
+                                                 const Bitset &bitset_b,
+                                                 const SizeVector &taxon_map);
+  // Translate bitset using the taxon translation map output positions.
+  // NOTE:  forward_translate uses index in map as input bit locations, values in map as
+  // output bit locations.
+  //        If false, map is used vice versa.
+  static Bitset BitsetTranslateViaTaxonTranslationMap(
+      const Bitset &bitset, const SizeVector &taxon_map,
+      const bool forward_translate = true);
+
  protected:
-  size_t taxon_count_;
-  size_t gpcsp_count_without_fake_subsplits_;
-  // This indexer is an expanded version of parent_to_range_ in sbn_instance:
-  // it includes single element range for fake subsplits.
-  BitsetSizePairMap parent_to_range_;
+  // Build a Subsplit DAG on given number of taxa, expressing all tree topologies from
+  // tree_collection, with trees on the given taxa names/labels.
+  SubsplitDAG(size_t taxon_count, const Node::TopologyCounter &topology_counter,
+              const TagStringMap &tag_taxon_map);
 
-  // A map from node id pairs to gpcsp idxs.
-  std::map<SizePair, size_t> dag_edges_;
-
-  // We will call the index of DAG nodes "ids" to distinguish them from GPCSP indexes.
-  // This corresponds to the analogous concept for topologies.
-  //
-  // A map from Bitset to the corresponding index in dag_nodes_.
-  // The first entries are reserved for fake subsplits.
-  // The last entries are reserved for rootsplits.
-  // The DAG root node has the highest node id.
-  BitsetSizeMap subsplit_to_id_;
-  std::vector<std::unique_ptr<SubsplitDAGNode>> dag_nodes_;
-
-  // Total number of topologies spanned by the DAG.
-  double topology_count_;
-  // Storage for the number of topologies below for each node.
-  EigenVectorXd topology_count_below_;
-
-  SubsplitDAG(size_t taxon_count, const Node::TopologyCounter &topology_counter);
-
-  // Gives the child subsplits of a given parent subsplit, optionally including fake
-  // subsplits.
+  // Builds a vector of subsplits of all children , optionally including leaf nodes.
   std::vector<Bitset> GetChildSubsplits(const SizeBitsetMap &index_to_child,
                                         const Bitset &subsplit,
-                                        bool include_fake_subsplits = false);
+                                        bool include_leaf_subsplits = false);
 
-  std::tuple<BitsetSizeMap, SizeBitsetMap, BitsetVector> ProcessTopologyCounter(
-      const Node::TopologyCounter &topology_counter);
-  void CreateAndInsertNode(const Bitset &subsplit);
-  void CreateAndInsertEdge(const size_t parent_id, const size_t child_id, bool rotated);
-  void ConnectGivenNodes(const size_t parent_id, const size_t child_id, bool rotated);
-  void ConnectNodes(const SizeBitsetMap &index_to_child, size_t node_id, bool rotated);
-  void BuildNodesDepthFirst(const SizeBitsetMap &index_to_child, const Bitset &subsplit,
-                            std::unordered_set<Bitset> &visited_subsplits);
-  void BuildNodes(const SizeBitsetMap &index_to_child, const BitsetVector &rootsplits);
-  void BuildEdges(const SizeBitsetMap &index_to_child);
-  void BuildDAGEdgesFromGPCSPIndexer(BitsetSizeMap &gpcsp_indexer);
+  // ** Count
+
+  // Traverses the DAG and refreshes count of the number of topologies contained in the
+  // DAG. Updates topology_count_ and topology_count_below_, which contains the count of
   void CountTopologies();
-  // Expand dag_edges_ and parent_to_range_ with fake subsplits at the end.
-  void AddFakeSubsplitsToDAGEdgesAndParentToRange();
+
+  // ** DAG Traversal
+  // NOTES: - visit_order is the output vector of node ids in specified traversal order.
+  //        - visited_nodes is a set of all node ids reached by traversal.
+
+  // Creates vector of node ids in leafward depth first post-order traversal of DAG.
   void LeafwardDepthFirst(size_t node_id, SizeVector &visit_order,
                           std::unordered_set<size_t> &visited_nodes) const;
+  // Create vector of node ids in rootward depth first post-order traversal of DAG.
   void RootwardDepthFirst(size_t node_id, SizeVector &visit_order,
                           std::unordered_set<size_t> &visited_nodes) const;
-  // Rotates subsplit only if it is out of sorted order (rotated).
-  Bitset PerhapsSubsplitRotate(const Bitset &subsplit, bool rotated) const;
 
-  // Note: the below methods are helper funcions for AddNodePair.
-  // Connect the child to all of its children and update new_edge_idxs.
+  // ** Modify DAG Helpers
+  // These methods help calling functions to modify the DAG, but do NOT ensure a valid
+  // state at the end of the function. Do not necessarily handle remapping ids and idxs,
+  // removing old references to deleted objects, etc.
+
+  // Create Node and insert it into the DAG.
+  // WARNING: Does not check for redundant nodes.
+  void CreateAndInsertNode(const Bitset &subsplit);
+  // Create Edge between given nodes and insert it into the DAG.
+  // WARNING: Does not check for redundant edges.
+  void CreateAndInsertEdge(const size_t parent_id, const size_t child_id, bool rotated);
+  // Delete Node from the DAG.
+  void DeleteNode(const Bitset &subsplit);
+  // Delete Edge from the DAG.
+  void DeleteEdge(const size_t parent_id, const size_t child_id, bool rotated);
+  // Add edge between given parent and child nodes to the DAG.
+  void ConnectGivenNodes(const size_t parent_id, const size_t child_id, bool rotated);
+  // Add edge between node_id and
+  void ConnectNodes(const SizeBitsetMap &index_to_child, size_t node_id, bool rotated);
+  // TODO
+  //
+  void BuildNodes(const SizeBitsetMap &index_to_child, const BitsetVector &rootsplits);
+  //
+  void BuildNodesDepthFirst(const SizeBitsetMap &index_to_child, const Bitset &subsplit,
+                            std::unordered_set<Bitset> &visited_subsplits);
+  //
+  void BuildEdges(const SizeBitsetMap &index_to_child);
+  //
+  void BuildDAGEdgesFromEdgeIndexer(BitsetSizeMap &edge_indexer);
+  // Connect the child to all of its children. Push all new edges to
+  // added_edge_idxs.
   void ConnectChildToAllChildren(const Bitset &child_subsplit,
-                                 SizeVector &new_edge_idxs);
-  // Connect the parent to all of its children except for the given child node and
-  // update new_edge_idxs.
+                                 SizeVector &added_edge_idxs);
+  // Connect the parent to all of its children except for the given child node. Insert
+  // all new edges to added_edge_idxs vector.
   void ConnectParentToAllChildrenExcept(const Bitset &parent_subsplit,
                                         const Bitset &child_subsplit,
-                                        SizeVector &new_edge_idxs);
-  // Connect the child to all of its parents except for the given parent node and update
-  // new_edge_idxs.
+                                        SizeVector &added_edge_idxs);
+  // Connect the child to all of its parents except for the given parent node. Insert
+  // all new edge to added_edge_idxs vector.
   void ConnectChildToAllParentsExcept(const Bitset &parent_subsplit,
                                       const Bitset &child_subsplit,
-                                      SizeVector &new_edge_idxs);
-  // Connect the parent to all of its parents and update new_edge_idxs.
+                                      SizeVector &added_edge_idxs);
+  // Connect the parent to all of its parents. Insert all new edges to
+  // added_edge_idxs vector.
   void ConnectParentToAllParents(const Bitset &parent_subsplit,
-                                 SizeVector &new_edge_idxs);
+                                 SizeVector &added_edge_idxs);
+  // Expand dag_edges_ and parent_to_child_range_ with leaf subsplits at the end.
+  void AddLeafSubsplitsToDAGEdgesAndParentToRange();
+
+ protected:
+  // NOTE: When using unique identifiers, for DAG nodes (aka Subsplits) we use the term
+  // "ids", and for edges (aka PCSPs) we use the term index or "idx", to more easily
+  // distinguish the two. This corresponds to the analogous concept for topologies.
+
+  // - Map of Taxon Names
+  //    - [ Taxon Name => Taxon Id (Bitset Clade Position) ]
+  std::map<std::string, size_t> dag_taxons_;
+  // - Vector of DAG Nodes: each Node index in the vector corresponds to their Id.
+  // - This can be viewed as a map:
+  //    - [ Node Id => Node data structure ]
+  std::vector<std::unique_ptr<SubsplitDAGNode>> dag_nodes_;
+  // - Map of all DAG Edges:
+  //    - [ (parent_id, child_id) Node Id Pairs => Edge/PCSP Idxs. ]
+  std::map<SizePair, size_t> dag_edges_;
+  // - Map of all DAG Nodes:
+  //    - [ Node Subsplit (Bitset) => Node Id ]
+  // A node's id is equivalent to its index in dag_nodes_. The first entries are
+  // reserved for leaf subsplits. The last entries are reserved for rootsplits. The DAG
+  // root node has the highest node id.
+  BitsetSizeMap subsplit_to_id_;
+  // - Map of all DAG Nodes:
+  //    - [ Node Subsplit (Bitset) => (begin, end) Range of Child Ids ]
+  // This indexer is an expanded version of parent_to_child_range_ in sbn_instance:
+  // It includes single element range for leaf subsplits.
+  BitsetSizePairMap parent_to_child_range_;
+  // The number of taxa in the DAG. This is equivalent to the size of the clades in each
+  // subsplit. Also equivalent to the number of leaf nodes in the DAG.
+  size_t taxon_count_;
+  // Number of internal edges in the DAG (excludes all edges that go to a root or
+  // leaf).
+  size_t edge_count_without_leaf_subsplits_;
+  // Total number of tree topologies spanned by the DAG.
+  double topology_count_;
+  // Storage for the number of topologies below for each node. Each index maps to the
+  // count for the corresponding node_id.
+  EigenVectorXd topology_count_below_;
 };

--- a/src/subsplit_dag.hpp
+++ b/src/subsplit_dag.hpp
@@ -178,7 +178,7 @@ class SubsplitDAG {
   // Iterate over only the rotated/sorted leafward edges of node using a NodeLambda.
   void IterateOverLeafwardEdges(const SubsplitDAGNode *node, bool rotated,
                                 const NodeLambda &f) const;
-  // Iterate over the leafward edges, supplying both the a PCSP index of the edge and
+  // Iterate over the leafward edges, supplying both the index of the edge and
   // the SubsplitDAGNode of the corresponding child.
   void IterateOverLeafwardEdgesAndChildren(const SubsplitDAGNode *node,
                                            const EdgeAndNodeLambda &f) const;
@@ -391,7 +391,7 @@ class SubsplitDAG {
   StringSizeMap SummaryStatistics() const;
   // Rotates Node Subsplit only if it is out of sorted order (rotated).
   Bitset SubsplitToSortedOrder(const Bitset &subsplit, bool rotated) const;
-  // Fixes Edge PCSP only if child is out of sorted order (rotated).
+  // Fixes PCSP only if child is out of sorted order (rotated).
   Bitset EdgeToSortedOrder(const Bitset &pcsp) const;
   // Build vector between from SubsplitDAGs dag_a to dag_b corresponding to their taxon
   // ids. Can be treated as a "map" with indices representing keys. Requires that both

--- a/src/subsplit_dag.hpp
+++ b/src/subsplit_dag.hpp
@@ -457,17 +457,16 @@ class SubsplitDAG {
   void DeleteEdge(const size_t parent_id, const size_t child_id, bool rotated);
   // Add edge between given parent and child nodes to the DAG.
   void ConnectGivenNodes(const size_t parent_id, const size_t child_id, bool rotated);
-  // Add edge between node_id and
+  // Add edges between node_id and all children in map.
   void ConnectNodes(const SizeBitsetMap &index_to_child, size_t node_id, bool rotated);
-  // TODO
-  //
+  // Add nodes for all children in map.
   void BuildNodes(const SizeBitsetMap &index_to_child, const BitsetVector &rootsplits);
-  //
+  // Add nodes in depth first ordering for children in map. 
   void BuildNodesDepthFirst(const SizeBitsetMap &index_to_child, const Bitset &subsplit,
                             std::unordered_set<Bitset> &visited_subsplits);
-  //
+  // Add edges for all nodes according to children in map.
   void BuildEdges(const SizeBitsetMap &index_to_child);
-  //
+  // Add edges to DAG according to node_id pairs in edge indexer.
   void BuildDAGEdgesFromEdgeIndexer(BitsetSizeMap &edge_indexer);
   // Connect the child to all of its children. Push all new edges to
   // added_edge_idxs.

--- a/src/subsplit_dag.hpp
+++ b/src/subsplit_dag.hpp
@@ -449,10 +449,6 @@ class SubsplitDAG {
   void CreateAndInsertNode(const Bitset &subsplit);
   // Create Edge between given nodes and insert it into the DAG.
   void CreateAndInsertEdge(const size_t parent_id, const size_t child_id, bool rotated);
-  // Delete Node from the DAG.
-  void DeleteNode(const Bitset &subsplit);
-  // Delete Edge from the DAG.
-  void DeleteEdge(const size_t parent_id, const size_t child_id, bool rotated);
   // Add edge between given parent and child nodes to the DAG.
   void ConnectGivenNodes(const size_t parent_id, const size_t child_id, bool rotated);
   // Add edges between node_id and all children in map.
@@ -494,13 +490,13 @@ class SubsplitDAG {
 
   // - Map of Taxon Names
   //    - [ Taxon Name => Taxon Id (position of the "on" bit in the clades) ]
-  std::map<std::string, size_t> dag_taxons_;
+  std::map<std::string, size_t> dag_taxa_;
   // - Vector of DAG Nodes: each Node index in the vector corresponds to their Id.
   // - This can be viewed as a map:
   //    - [ Node Id => Node data structure ]
   std::vector<std::unique_ptr<SubsplitDAGNode>> dag_nodes_;
   // - Map of all DAG Edges:
-  //    - [ (parent_id, child_id) Node Id Pairs => Edge/PCSP Idxs. ]
+  //    - [ (parent_id, child_id) Node Id Pairs => Edge Idxs. ]
   std::map<SizePair, size_t> dag_edges_;
   // - Map of all DAG Nodes:
   //    - [ Node Subsplit (Bitset) => Node Id ]

--- a/src/subsplit_dag.hpp
+++ b/src/subsplit_dag.hpp
@@ -446,10 +446,8 @@ class SubsplitDAG {
   // removing old references to deleted objects, etc.
 
   // Create Node and insert it into the DAG.
-  // WARNING: Does not check for redundant nodes.
   void CreateAndInsertNode(const Bitset &subsplit);
   // Create Edge between given nodes and insert it into the DAG.
-  // WARNING: Does not check for redundant edges.
   void CreateAndInsertEdge(const size_t parent_id, const size_t child_id, bool rotated);
   // Delete Node from the DAG.
   void DeleteNode(const Bitset &subsplit);
@@ -495,7 +493,7 @@ class SubsplitDAG {
   // distinguish the two. This corresponds to the analogous concept for topologies.
 
   // - Map of Taxon Names
-  //    - [ Taxon Name => Taxon Id (Bitset Clade Position) ]
+  //    - [ Taxon Name => Taxon Id (position of the "on" bit in the clades) ]
   std::map<std::string, size_t> dag_taxons_;
   // - Vector of DAG Nodes: each Node index in the vector corresponds to their Id.
   // - This can be viewed as a map:

--- a/src/subsplit_dag.hpp
+++ b/src/subsplit_dag.hpp
@@ -459,7 +459,7 @@ class SubsplitDAG {
   void ConnectNodes(const SizeBitsetMap &index_to_child, size_t node_id, bool rotated);
   // Add nodes for all children in map.
   void BuildNodes(const SizeBitsetMap &index_to_child, const BitsetVector &rootsplits);
-  // Add nodes in depth first ordering for children in map. 
+  // Add nodes in depth first ordering for children in map.
   void BuildNodesDepthFirst(const SizeBitsetMap &index_to_child, const Bitset &subsplit,
                             std::unordered_set<Bitset> &visited_subsplits);
   // Add edges for all nodes according to children in map.

--- a/src/subsplit_dag.hpp
+++ b/src/subsplit_dag.hpp
@@ -445,10 +445,14 @@ class SubsplitDAG {
   // state at the end of the function. Do not necessarily handle remapping ids and idxs,
   // removing old references to deleted objects, etc.
 
-  // Create Node and insert it into the DAG.
-  void CreateAndInsertNode(const Bitset &subsplit);
-  // Create Edge between given nodes and insert it into the DAG.
-  void CreateAndInsertEdge(const size_t parent_id, const size_t child_id, bool rotated);
+  // Add taxon map to DAG.
+  void BuildTaxonMap(const TagStringMap &tag_taxon_map);
+  // Create Node and insert it into the DAG.  Returns ID of created node.
+  size_t CreateAndInsertNode(const Bitset &subsplit);
+  // Create Edge between given nodes and insert it into the DAG. Returns ID of created
+  // edge.
+  size_t CreateAndInsertEdge(const size_t parent_id, const size_t child_id,
+                             bool rotated);
   // Add edge between given parent and child nodes to the DAG.
   void ConnectGivenNodes(const size_t parent_id, const size_t child_id, bool rotated);
   // Add edges between node_id and all children in map.

--- a/src/subsplit_dag_nni.cpp
+++ b/src/subsplit_dag_nni.cpp
@@ -95,7 +95,7 @@ void SyncSetOfNNIsWithDAG(SetOfNNIs &set_of_nnis, const SubsplitDAG &dag) {
           // Only internal node pairs are viable NNIs.
           Bitset parent_bitset = dag.GetDAGNode(parent_id)->GetBitset();
           Bitset child_bitset = dag.GetDAGNode(child_id)->GetBitset();
-          if (!(parent_bitset.SubsplitIsRoot() || child_bitset.SubsplitIsLeaf())) {
+          if (!(parent_bitset.SubsplitIsUCA() || child_bitset.SubsplitIsLeaf())) {
             SafeAddOutputNNIsToSetOfNNIs(set_of_nnis, dag, parent_bitset, child_bitset,
                                          is_rotated);
           }
@@ -160,7 +160,7 @@ void SafeAddOutputNNIsToSetOfNNIs(SetOfNNIs &set_of_nnis, const SubsplitDAG &dag
                                   const Bitset &child_bitset,
                                   const bool is_edge_rotated) {
   // Soft assert that parent is not the root and child is not a leaf.
-  if (parent_bitset.SubsplitIsRoot() || child_bitset.SubsplitIsLeaf()) {
+  if (parent_bitset.SubsplitIsUCA() || child_bitset.SubsplitIsLeaf()) {
     return;
   }
   // Input pair is in the DAG, so remove it from the Set if it exists.

--- a/src/subsplit_dag_nni.cpp
+++ b/src/subsplit_dag_nni.cpp
@@ -53,7 +53,7 @@ NNIOperation NNIOperation::NNIOperationFromNeighboringSubsplits(
 NNIOperation NNIOperation::NNIOperationFromNeighboringSubsplits(
     const Bitset parent_in, const Bitset child_in,
     const bool swap_which_child_clade_with_sister) {
-  bool which_clade_of_parent = Bitset::SubsplitIsWhichChildOf(parent_in, child_in);
+  bool which_clade_of_parent = Bitset::SubsplitIsChildOfWhichParentClade(parent_in, child_in);
   return NNIOperationFromNeighboringSubsplits(
       parent_in, child_in, swap_which_child_clade_with_sister, which_clade_of_parent);
 }

--- a/src/subsplit_dag_nni.cpp
+++ b/src/subsplit_dag_nni.cpp
@@ -53,7 +53,8 @@ NNIOperation NNIOperation::NNIOperationFromNeighboringSubsplits(
 NNIOperation NNIOperation::NNIOperationFromNeighboringSubsplits(
     const Bitset parent_in, const Bitset child_in,
     const bool swap_which_child_clade_with_sister) {
-  bool which_clade_of_parent = Bitset::SubsplitIsChildOfWhichParentClade(parent_in, child_in);
+  bool which_clade_of_parent =
+      Bitset::SubsplitIsChildOfWhichParentClade(parent_in, child_in);
   return NNIOperationFromNeighboringSubsplits(
       parent_in, child_in, swap_which_child_clade_with_sister, which_clade_of_parent);
 }

--- a/src/subsplit_dag_node.cpp
+++ b/src/subsplit_dag_node.cpp
@@ -14,23 +14,22 @@ std::string GetNeighborString(SizeVector neighbors) {
 bool SubsplitDAGNode::IsValid() const {
   // If node is a leaf, then a valid node should have no parents.
   if (IsLeaf()) {
-    return (GetLeafwardRightward().size() + GetLeafwardLeftward().size() == 0);
+    return (GetRightLeafward().size() + GetLeftLeafward().size() == 0);
   }
   // If node is a root, then a valid node should have no children.
   else if (IsDAGRootNode()) {
-    return (GetRootwardRightward().size() + GetRootwardLeftward().size() == 0);
+    return (GetRightRootward().size() + GetLeftRootward().size() == 0);
   }
   // If neither, then node should either have:
   // (1) Zero parents and zero children.
   // (2) 1+ parents, 1+ sorted children, and 1+ rotated children.
-  size_t parent_node_count =
-      GetRootwardRightward().size() + GetRootwardLeftward().size();
+  size_t parent_node_count = GetRightRootward().size() + GetLeftRootward().size();
   if (parent_node_count > 0) {
-    if (GetLeafwardRightward().size() == 0 || GetLeafwardRightward().size() == 0) {
+    if (GetRightLeafward().size() == 0 || GetRightLeafward().size() == 0) {
       return false;
     }
   } else {
-    if (GetLeafwardRightward().size() > 0 || GetLeafwardRightward().size() > 0) {
+    if (GetRightLeafward().size() > 0 || GetRightLeafward().size() > 0) {
       return false;
     }
   }

--- a/src/subsplit_dag_node.cpp
+++ b/src/subsplit_dag_node.cpp
@@ -11,11 +11,37 @@ std::string GetNeighborString(SizeVector neighbors) {
   return str;
 }
 
+bool SubsplitDAGNode::IsValid() const {
+  // If node is a leaf, then a valid node should have no parents.
+  if (IsLeaf()) {
+    return (GetLeafwardRightward().size() + GetLeafwardLeftward().size() == 0);
+  }
+  // If node is a root, then a valid node should have no children.
+  else if (IsDAGRootNode()) {
+    return (GetRootwardRightward().size() + GetRootwardLeftward().size() == 0);
+  }
+  // If neither, then node should either have:
+  // (1) Zero parents and zero children.
+  // (2) 1+ parents, 1+ sorted children, and 1+ rotated children.
+  size_t parent_node_count =
+      GetRootwardRightward().size() + GetRootwardLeftward().size();
+  if (parent_node_count > 0) {
+    if (GetLeafwardRightward().size() == 0 || GetLeafwardRightward().size() == 0) {
+      return false;
+    }
+  } else {
+    if (GetLeafwardRightward().size() > 0 || GetLeafwardRightward().size() > 0) {
+      return false;
+    }
+  }
+  return true;
+}
+
 std::string SubsplitDAGNode::ToString() const {
   std::string str = std::to_string(id_) + ": " + GetBitset().SubsplitToString() + "\n";
-  str += "Rootward Sorted: " + GetNeighborString(rootward_sorted_) + "\n";
-  str += "Rootward Rotated: " + GetNeighborString(rootward_rotated_) + "\n";
-  str += "Leafward Sorted: " + GetNeighborString(leafward_sorted_) + "\n";
-  str += "Leafward Rotated: " + GetNeighborString(leafward_rotated_) + "\n";
+  str += "Rootward Rightward: " + GetNeighborString(rootward_rightward_) + "\n";
+  str += "Rootward Leftward: " + GetNeighborString(rootward_leftward_) + "\n";
+  str += "Leafward Rightward: " + GetNeighborString(leafward_rightward_) + "\n";
+  str += "Leafward Leftward: " + GetNeighborString(leafward_leftward_) + "\n";
   return str;
 }

--- a/src/subsplit_dag_node.cpp
+++ b/src/subsplit_dag_node.cpp
@@ -39,9 +39,9 @@ bool SubsplitDAGNode::IsValid() const {
 
 std::string SubsplitDAGNode::ToString() const {
   std::string str = std::to_string(id_) + ": " + GetBitset().SubsplitToString() + "\n";
-  str += "Rootward Rightward: " + GetNeighborString(rootward_rightward_) + "\n";
-  str += "Rootward Leftward: " + GetNeighborString(rootward_leftward_) + "\n";
-  str += "Leafward Rightward: " + GetNeighborString(leafward_rightward_) + "\n";
-  str += "Leafward Leftward: " + GetNeighborString(leafward_leftward_) + "\n";
+  str += "Rootward Rightward: " + GetNeighborString(right_rootward_) + "\n";
+  str += "Rootward Leftward: " + GetNeighborString(left_rootward_) + "\n";
+  str += "Leafward Rightward: " + GetNeighborString(right_leafward_) + "\n";
+  str += "Leafward Leftward: " + GetNeighborString(left_leafward_) + "\n";
   return str;
 }

--- a/src/subsplit_dag_node.cpp
+++ b/src/subsplit_dag_node.cpp
@@ -38,9 +38,9 @@ bool SubsplitDAGNode::IsValid() const {
 
 std::string SubsplitDAGNode::ToString() const {
   std::string str = std::to_string(id_) + ": " + GetBitset().SubsplitToString() + "\n";
-  str += "Rootward Rightward: " + GetNeighborString(right_rootward_) + "\n";
-  str += "Rootward Leftward: " + GetNeighborString(left_rootward_) + "\n";
-  str += "Leafward Rightward: " + GetNeighborString(right_leafward_) + "\n";
-  str += "Leafward Leftward: " + GetNeighborString(left_leafward_) + "\n";
+  str += "Right Rootward: " + GetNeighborString(right_rootward_) + "\n";
+  str += "Left Rootward: " + GetNeighborString(left_rootward_) + "\n";
+  str += "Right Leafward: " + GetNeighborString(right_leafward_) + "\n";
+  str += "Left Leafward: " + GetNeighborString(left_leafward_) + "\n";
   return str;
 }

--- a/src/subsplit_dag_node.hpp
+++ b/src/subsplit_dag_node.hpp
@@ -26,8 +26,8 @@ class SubsplitDAGNode {
     Leafward = 1,
   };
   enum class ParentClade : bool {
-    Left = 0, 
-    Right = 1, 
+    Left = 0,
+    Right = 1,
   };
 
   SubsplitDAGNode(size_t id, Bitset subsplit)
@@ -48,12 +48,10 @@ class SubsplitDAGNode {
   // Is the node a rootsplit (direct descendent of root, dividing entire taxon set)?
   bool IsRootsplit() const { return subsplit_.SubsplitIsRootsplit(); }
   // Is the node a leaf (has no descendents)?
-  bool IsLeaf() const {
-    return left_leafward_.empty() && right_leafward_.empty();
-  }
+  bool IsLeaf() const { return left_leafward_.empty() && right_leafward_.empty(); }
 
-  // ** Edges 
-  
+  // ** Edges
+
   // Add edge from this node to adjacent_node.
   void AddEdge(size_t adjacent_node_id, bool is_leafward, bool is_rotated) {
     if (is_leafward) {
@@ -103,7 +101,7 @@ class SubsplitDAGNode {
     return rotated ? GetRootwardLeftward() : GetRootwardRightward();
   }
 
-  // After modifying parent DAG.  
+  // After modifying parent DAG.
   void RemapNodeIds(const SizeVector node_reindexer) {
     id_ = node_reindexer.at(id_);
     Reindexer::RemapIdVector(left_leafward_, node_reindexer);

--- a/src/subsplit_dag_node.hpp
+++ b/src/subsplit_dag_node.hpp
@@ -27,7 +27,7 @@ class SubsplitDAGNode {
   };
   enum class ParentClade : bool {
     LEFTSIDE = 0, /* ROTATED */
-    RIGHTSIDE = 1 /* SORTED */
+    RIGHTSIDE = 1, /* SORTED */
   };
 
   SubsplitDAGNode(size_t id, Bitset subsplit)
@@ -38,15 +38,22 @@ class SubsplitDAGNode {
   const Bitset GetBitset(bool rotated) const {
     return rotated ? subsplit_.SubsplitRotate() : subsplit_;
   }
+
+  // ** Node Types
+
+  // Is the node the DAG root (universal ancestor of the DAG)?
   bool IsDAGRootNode() const {
     return (rootward_rightward_.empty() && rootward_leftward_.empty());
   }
-  //
+  // Is the node a rootsplit (direct descendent of root, dividing entire taxon set)?
   bool IsRootsplit() const { return subsplit_.SubsplitIsRootsplit(); }
+  // Is the node a leaf (has no descendents)?
   bool IsLeaf() const {
     return leafward_leftward_.empty() && leafward_rightward_.empty();
   }
 
+  // ** Edges 
+  
   // Add edge from this node to adjacent_node.
   void AddEdge(size_t adjacent_node_id, bool is_leafward, bool is_rotated) {
     if (is_leafward) {
@@ -67,7 +74,6 @@ class SubsplitDAGNode {
   void AddRootwardLeftward(size_t node_id) { rootward_leftward_.push_back(node_id); }
   void AddRootwardRightward(size_t node_id) { rootward_rightward_.push_back(node_id); }
 
-  // #350 use enumerated types for rotated?
   // Get vector of all adjacent node vectors along the specified direction.
   void GetEdge(bool is_leafward, bool is_rotated) {
     if (is_leafward) {
@@ -94,6 +100,8 @@ class SubsplitDAGNode {
   const SizeVector &GetRootward(bool rotated) const {
     return rotated ? GetRootwardLeftward() : GetRootwardRightward();
   }
+
+  // After modifying parent DAG.  
   void RemapNodeIds(const SizeVector node_reindexer) {
     id_ = node_reindexer.at(id_);
     Reindexer::RemapIdVector(leafward_leftward_, node_reindexer);

--- a/src/subsplit_dag_node.hpp
+++ b/src/subsplit_dag_node.hpp
@@ -55,30 +55,31 @@ class SubsplitDAGNode {
   // Add edge from this node to adjacent_node.
   void AddEdge(size_t adjacent_node_id, bool is_leafward, bool is_rotated) {
     if (is_leafward) {
-      is_rotated ? AddLeafwardLeftward(adjacent_node_id)
-                 : AddLeafwardRightward(adjacent_node_id);
+      is_rotated ? AddLeftLeafward(adjacent_node_id)
+                 : AddRightLeafward(adjacent_node_id);
     } else {
-      is_rotated ? AddRootwardLeftward(adjacent_node_id)
-                 : AddRootwardRightward(adjacent_node_id);
+      is_rotated ? AddLeftRootward(adjacent_node_id)
+                 : AddRightRootward(adjacent_node_id);
     }
   }
-  void AddEdge(size_t adjacent_node_id, Direction direction, ParentClade clade) {
-    bool is_leafward = (direction == Direction::Leafward);
-    bool is_rotated = (clade == ParentClade::Left);
+  void AddEdge(size_t adjacent_node_id, Direction which_direction,
+               ParentClade which_clade) {
+    bool is_leafward = (which_direction == Direction::Leafward);
+    bool is_rotated = (which_clade == ParentClade::Left);
     AddEdge(adjacent_node_id, is_leafward, is_rotated);
   }
-  void AddLeafwardLeftward(size_t node_id) { left_leafward_.push_back(node_id); }
-  void AddLeafwardRightward(size_t node_id) { right_leafward_.push_back(node_id); }
-  void AddRootwardLeftward(size_t node_id) { left_rootward_.push_back(node_id); }
-  void AddRootwardRightward(size_t node_id) { right_rootward_.push_back(node_id); }
+  void AddLeftLeafward(size_t node_id) { left_leafward_.push_back(node_id); }
+  void AddRightLeafward(size_t node_id) { right_leafward_.push_back(node_id); }
+  void AddLeftRootward(size_t node_id) { left_rootward_.push_back(node_id); }
+  void AddRightRootward(size_t node_id) { right_rootward_.push_back(node_id); }
 
   // Get vector of all adjacent node vectors along the specified direction.
   const SizeVector &GetEdge(bool is_leafward, bool is_rotated) {
     if (is_leafward) {
-      auto &edges = is_rotated ? GetLeafwardLeftward() : GetLeafwardRightward();
+      auto &edges = is_rotated ? GetLeftLeafward() : GetRightLeafward();
       return edges;
     } else {
-      auto &edges = is_rotated ? GetRootwardLeftward() : GetRootwardRightward();
+      auto &edges = is_rotated ? GetLeftRootward() : GetRightRootward();
       return edges;
     }
   }
@@ -90,15 +91,15 @@ class SubsplitDAGNode {
   const SizeVector &GetLeafwardOrRootward(bool leafward, bool rotated) const {
     return leafward ? GetLeafward(rotated) : GetRootward(rotated);
   };
-  const SizeVector &GetLeafwardLeftward() const { return left_leafward_; }
-  const SizeVector &GetLeafwardRightward() const { return right_leafward_; }
+  const SizeVector &GetLeftLeafward() const { return left_leafward_; }
+  const SizeVector &GetRightLeafward() const { return right_leafward_; }
   const SizeVector &GetLeafward(bool rotated) const {
-    return rotated ? GetLeafwardLeftward() : GetLeafwardRightward();
+    return rotated ? GetLeftLeafward() : GetRightLeafward();
   }
-  const SizeVector &GetRootwardLeftward() const { return left_rootward_; }
-  const SizeVector &GetRootwardRightward() const { return right_rootward_; }
+  const SizeVector &GetLeftRootward() const { return left_rootward_; }
+  const SizeVector &GetRightRootward() const { return right_rootward_; }
   const SizeVector &GetRootward(bool rotated) const {
-    return rotated ? GetRootwardLeftward() : GetRootwardRightward();
+    return rotated ? GetLeftRootward() : GetRightRootward();
   }
 
   // After modifying parent DAG.

--- a/src/sugar.hpp
+++ b/src/sugar.hpp
@@ -108,6 +108,8 @@ constexpr void SafeInsert(std::unordered_set<Key, Hash> &set, Key &&k) {
   Assert(set.insert(k).second, "Failed set insertion!");
 }
 
+// Return value associated with key in map.
+// If key does not exist in map, returns default_value.
 template <class Key, class T, class Hash>
 T AtWithDefault(const std::unordered_map<Key, T, Hash> &map, const Key &key,
                 T default_value) {

--- a/src/tidy_subsplit_dag.cpp
+++ b/src/tidy_subsplit_dag.cpp
@@ -6,16 +6,17 @@
 TidySubsplitDAG::TidySubsplitDAG() : SubsplitDAG() {}
 
 TidySubsplitDAG::TidySubsplitDAG(const RootedTreeCollection &tree_collection)
-    : TidySubsplitDAG(tree_collection.TaxonCount(), tree_collection.TopologyCounter()) {
-}
+    : TidySubsplitDAG(tree_collection.TaxonCount(), tree_collection.TopologyCounter(),
+                      tree_collection.TagTaxonMap()) {}
 
 TidySubsplitDAG::TidySubsplitDAG(size_t node_count)
     : above_rotated_(EigenMatrixXb::Identity(node_count, node_count)),
       above_sorted_(EigenMatrixXb::Identity(node_count, node_count)){};
 
 TidySubsplitDAG::TidySubsplitDAG(size_t taxon_count,
-                                 const Node::TopologyCounter &topology_counter)
-    : SubsplitDAG(taxon_count, topology_counter) {
+                                 const Node::TopologyCounter &topology_counter,
+                                 const TagStringMap &tag_taxon_map)
+    : SubsplitDAG(taxon_count, topology_counter, tag_taxon_map) {
   auto node_count = NodeCount();
   above_rotated_ = EigenMatrixXb::Identity(node_count, node_count);
   above_sorted_ = EigenMatrixXb::Identity(node_count, node_count);
@@ -112,9 +113,11 @@ std::string TidySubsplitDAG::AboveMatricesAsString() const {
 
 TidySubsplitDAG TidySubsplitDAG::TrivialExample() {
   // ((0,1),2)
-  auto topology = Node::Join(Node::Join(Node::Leaf(0), Node::Leaf(1)), Node::Leaf(2));
+  Node::NodePtr topology =
+      Node::Join(Node::Join(Node::Leaf(0), Node::Leaf(1)), Node::Leaf(2));
   topology->Polish();
-  return TidySubsplitDAG(3, {{topology, 1}});
+  TagStringMap taxon_map = {{0, "x0"}, {1, "x1"}, {2, "x2"}};
+  return TidySubsplitDAG(3, {{topology, 1}}, taxon_map);
 }
 
 TidySubsplitDAG TidySubsplitDAG::ManualTrivialExample() {
@@ -133,7 +136,7 @@ TidySubsplitDAG TidySubsplitDAG::ManualTrivialExample() {
 
 TidySubsplitDAG TidySubsplitDAG::MotivatingExample() {
   auto topologies = Node::ExampleTopologies();
-  return TidySubsplitDAG(4, {{topologies[3], 1}, {topologies[4], 1}});
+  return TidySubsplitDAG(4, {{topologies[3], 1}, {topologies[4], 1}}, TagStringMap());
 }
 
 std::string TidySubsplitDAG::RecordTraversal() {

--- a/src/tidy_subsplit_dag.hpp
+++ b/src/tidy_subsplit_dag.hpp
@@ -166,7 +166,6 @@ class TidySubsplitDAG : public SubsplitDAG {
   // depth-first traversal.
   void SetBelow(size_t dst_id, bool dst_rotated, size_t src_id);
 
- private:
   // If this is set then we are in an "updating mode", where we are updating below the
   // specified node-clade.
   std::optional<std::pair<size_t, bool>> updating_below_;

--- a/src/tidy_subsplit_dag.hpp
+++ b/src/tidy_subsplit_dag.hpp
@@ -55,15 +55,15 @@ class TidySubsplitDAG : public SubsplitDAG {
   // more details.
   //
   // Applied to a given node, we:
-  // * Apply BeforeNode
-  // * For each of the clades of the node, we:
-  //     * Descend into each clade, cleaning up the sister clade with UpdateEdge as
+  // - Apply BeforeNode
+  // - For each of the clades of the node, we:
+  //     - Descend into each clade, cleaning up the sister clade with UpdateEdge as
   //     needed.
-  //     * Apply BeforeNodeClade
-  //     * For each edge descending from that clade, we:
-  //         * Recur into the child node of the clade if it is not a leaf
-  //         * Apply VisitEdge to the edge
-  // * Apply AfterNode
+  //     - Apply BeforeNodeClade
+  //     - For each edge descending from that clade, we:
+  //         - Recur into the child node of the clade if it is not a leaf
+  //         - Apply VisitEdge to the edge
+  // - Apply AfterNode
   template <typename TidyTraversalActionT>
   void DepthFirstWithTidyAction(const SizeVector &starting_nodes,
                                 const TidyTraversalActionT &action) {
@@ -155,6 +155,18 @@ class TidySubsplitDAG : public SubsplitDAG {
   };
 
  private:
+  // This constructor is really just meant for testing.
+  explicit TidySubsplitDAG(size_t node_count);
+
+  TidySubsplitDAG(size_t taxon_count, const Node::TopologyCounter &topology_counter,
+                  const TagStringMap &tag_taxon_map);
+
+  // Set the below matrix up to have all of the nodes below src_id below the
+  // subsplit-clade described by (dst_rotated, dst_id). Meant to be used as part of a
+  // depth-first traversal.
+  void SetBelow(size_t dst_id, bool dst_rotated, size_t src_id);
+
+ private:
   // If this is set then we are in an "updating mode", where we are updating below the
   // specified node-clade.
   std::optional<std::pair<size_t, bool>> updating_below_;
@@ -170,16 +182,6 @@ class TidySubsplitDAG : public SubsplitDAG {
   // dirty_rotated_(i) is true iff there has been a calculation below i,false that
   // invalidates the p-hat PLV coming up into it.
   EigenArrayXb dirty_sorted_;
-
-  // This constructor is really just meant for testing.
-  explicit TidySubsplitDAG(size_t node_count);
-
-  TidySubsplitDAG(size_t taxon_count, const Node::TopologyCounter &topology_counter);
-
-  // Set the below matrix up to have all of the nodes below src_id below the
-  // subsplit-clade described by (dst_rotated, dst_id). Meant to be used as part of a
-  // depth-first traversal.
-  void SetBelow(size_t dst_id, bool dst_rotated, size_t src_id);
 };
 
 #ifdef DOCTEST_LIBRARY_INCLUDED

--- a/src/unrooted_sbn_support.hpp
+++ b/src/unrooted_sbn_support.hpp
@@ -12,7 +12,8 @@ class UnrootedSBNSupport : public SBNSupport {
   explicit UnrootedSBNSupport(const Node::TopologyCounter &topologies,
                               StringVector taxon_names)
       : SBNSupport(std::move(taxon_names)) {
-    std::tie(rootsplits_, indexer_, index_to_child_, parent_to_range_, gpcsp_count_) =
+    std::tie(rootsplits_, indexer_, index_to_child_, parent_to_child_range_,
+             gpcsp_count_) =
         SBNMaps::BuildIndexerBundle(UnrootedSBNMaps::RootsplitCounterOf(topologies),
                                     UnrootedSBNMaps::PCSPCounterOf(topologies));
   }


### PR DESCRIPTION
## Description

Rename & Refactor of DAG Elements 

- Restructed Bitset in MultiClade, Subsplit, and Edge Sections.
- Renamed Rotated->Left and Sorted->Right in DAG and Bitset.
- Added enumerated types for Subsplit Clades and Edge Clades.
- Added enumerated types for SubsplitDAGNode for Direction (Rootward, Leafward) and ParentClade (Left, Right).
- Removed instances of using different Subsplit orderings (Lexicographical vs Binary).  Now uses lexicographical only.

Additional changes: 
- SubsplitDAG compare function.

Closes #375 


## Tests

## Checklist:

* [x] Code follows our detailed [contribution guidelines](CONTRIBUTING.md)
* [x] `clang-format` has been run
* [x] TODOs have been eliminated from the code
* [x] Comments are up to date, document intent, and there are no commented-out code blocks
