### PR TITLE
More flexible DAG creation; summary stats; writing topologies

### DIFF
--- a/src/generic_tree_collection.hpp
+++ b/src/generic_tree_collection.hpp
@@ -112,7 +112,7 @@ class GenericTreeCollection {
   void ToNewickTopologyFile(const std::string &out_path) const {
     std::ofstream out_stream(out_path);
     for (const auto &tree : trees_) {
-      out_stream << tree.NewickTopology();
+      out_stream << tree.NewickTopology(tag_taxon_map_) << std::endl;
     }
     out_stream.close();
     if (!out_stream) {
@@ -154,12 +154,12 @@ class GenericTreeCollection {
   }
 
   static GenericTreeCollection UnitBranchLengthTreesOf(
-      std::vector<Node::NodePtr> topologies) {
+      std::vector<Node::NodePtr> topologies, TagStringMap tag_taxon_map) {
     std::vector<TTree> tree_vector;
     for (const auto &topology : topologies) {
       tree_vector.push_back(TTree::UnitBranchLengthTreeOf(topology));
     }
-    return GenericTreeCollection(tree_vector);
+    return GenericTreeCollection(tree_vector, tag_taxon_map);
   }
 
   TTreeVector trees_;

--- a/src/generic_tree_collection.hpp
+++ b/src/generic_tree_collection.hpp
@@ -109,6 +109,17 @@ class GenericTreeCollection {
     }
   }
 
+  void ToNewickTopologyFile(const std::string &out_path) const {
+    std::ofstream out_stream(out_path);
+    for (const auto &tree : trees_) {
+      out_stream << tree.NewickTopology();
+    }
+    out_stream.close();
+    if (!out_stream) {
+      Failwith("ToNewickTopologyFile: could not write file to " + out_path);
+    }
+  }
+
   Node::TopologyCounter TopologyCounter() const {
     Node::TopologyCounter counter;
     for (const auto &tree : trees_) {
@@ -140,6 +151,15 @@ class GenericTreeCollection {
                  taxon_labels[index]);
     }
     return taxon_map;
+  }
+
+  static GenericTreeCollection UnitBranchLengthTreesOf(
+      std::vector<Node::NodePtr> topologies) {
+    std::vector<TTree> tree_vector;
+    for (const auto &topology : topologies) {
+      tree_vector.push_back(TTree::UnitBranchLengthTreeOf(topology));
+    }
+    return GenericTreeCollection(tree_vector);
   }
 
   TTreeVector trees_;

--- a/src/gp_doctest.cpp
+++ b/src/gp_doctest.cpp
@@ -77,6 +77,12 @@ GPInstance MakeFluAGPInstance(double rescaling_threshold) {
   return inst;
 }
 
+TEST_CASE("DAGSummaryStatistics") {
+  auto inst = MakeHelloGPInstanceTwoTrees();
+  StringSizeMap summaries = {{"edge_count", 10}, {"node_count", 8}};
+  CHECK(summaries == inst.DAGSummaryStatistics());
+}
+
 EigenVectorXd MakeHelloGPInstanceMarginalLikelihoodTestBranchLengths() {
   EigenVectorXd hello_gp_optimal_branch_lengths(10);
   hello_gp_optimal_branch_lengths << 1, 1, 0.066509261, 0.00119570257, 0.00326456973,

--- a/src/gp_instance.cpp
+++ b/src/gp_instance.cpp
@@ -25,8 +25,9 @@ void GPInstance::PrintStatus() {
     std::cout << "No trees loaded.\n";
   }
   std::cout << alignment_.Data().size() << " sequences loaded.\n";
-  std::cout << dag_.NodeCount() << " DAG nodes representing " << dag_.TopologyCount()
-            << " trees.\n";
+  std::cout << dag_.NodeCount() << " DAG nodes with "
+            << dag_.GPCSPCountWithFakeSubsplits() << " edges representing "
+            << dag_.TopologyCount() << " trees.\n";
   std::cout << dag_.GPCSPCountWithFakeSubsplits() << " continuous parameters.\n";
   if (HasEngine()) {
     std::cout << "Engine available using " << GetEngine()->PLVByteCount() / 1e9
@@ -361,7 +362,8 @@ void GPInstance::ExportAllGeneratedTrees(const std::string &out_path) {
 }
 
 void GPInstance::ExportAllGeneratedTopologies(const std::string &out_path) {
-  TreeCollection::UnitBranchLengthTreesOf(dag_.GenerateAllTopologies())
+  TreeCollection::UnitBranchLengthTreesOf(dag_.GenerateAllTopologies(),
+                                          tree_collection_.TagTaxonMap())
       .ToNewickTopologyFile(out_path);
 }
 

--- a/src/gp_instance.cpp
+++ b/src/gp_instance.cpp
@@ -361,13 +361,8 @@ void GPInstance::ExportAllGeneratedTrees(const std::string &out_path) {
 }
 
 void GPInstance::ExportAllGeneratedTopologies(const std::string &out_path) {
-  auto raw_topologies = dag_.GenerateAllTopologies();
-  std::vector<Tree> tree_vector;
-  for (const auto &raw_topology : raw_topologies) {
-    tree_vector.push_back(Tree::UnitBranchLengthTreeOf(raw_topology));
-  }
-  auto trees = TreeCollection(tree_vector);
-  trees.ToNewickFile(out_path);
+  TreeCollection::UnitBranchLengthTreesOf(dag_.GenerateAllTopologies())
+      .ToNewickTopologyFile(out_path);
 }
 
 void GPInstance::LoadAllGeneratedTrees() {

--- a/src/gp_instance.cpp
+++ b/src/gp_instance.cpp
@@ -36,6 +36,8 @@ void GPInstance::PrintStatus() {
   }
 }
 
+StringSizeMap GPInstance::DAGSummaryStatistics() { return dag_.SummaryStatistics(); }
+
 void GPInstance::ReadFastaFile(const std::string &fname) {
   alignment_ = Alignment::ReadFasta(fname);
 }

--- a/src/gp_instance.cpp
+++ b/src/gp_instance.cpp
@@ -66,24 +66,32 @@ void GPInstance::ReadNexusFileGZ(const std::string &fname) {
       RootedTreeCollection::OfTreeCollection(driver.ParseNexusFileGZ(fname));
 }
 
-void GPInstance::CheckSequencesAndTreesLoaded() const {
+void GPInstance::CheckSequencesLoaded() const {
   if (alignment_.SequenceCount() == 0) {
     Failwith(
-        "Load an alignment into your GPInstance on which you wish to "
-        "calculate phylogenetic likelihoods.");
-  }
-  if (tree_collection_.TreeCount() == 0) {
-    Failwith(
-        "Load some trees into your GPInstance on which you wish to "
+        "Load an alignment into your GPInstance with which you wish to "
         "calculate phylogenetic likelihoods.");
   }
 }
 
+void GPInstance::CheckTreesLoaded() const {
+  if (tree_collection_.TreeCount() == 0) {
+    Failwith(
+        "Load some trees into your GPInstance on which you wish to "
+        "build your subsplit DAG.");
+  }
+}
+
+void GPInstance::MakeDAG() {
+  CheckTreesLoaded();
+  dag_ = GPDAG(tree_collection_);
+}
+
 void GPInstance::MakeEngine(double rescaling_threshold) {
-  CheckSequencesAndTreesLoaded();
+  CheckSequencesLoaded();
   SitePattern site_pattern(alignment_, tree_collection_.TagTaxonMap());
 
-  dag_ = GPDAG(tree_collection_);
+  MakeDAG();
   auto sbn_prior = dag_.BuildUniformOnTopologicalSupportPrior();
   auto unconditional_node_probabilities =
       dag_.UnconditionalNodeProbabilities(sbn_prior);

--- a/src/gp_instance.cpp
+++ b/src/gp_instance.cpp
@@ -221,7 +221,7 @@ size_t GPInstance::GetGPCSPIndexForLeafNode(const Bitset &parent_subsplit,
 
 RootedTreeCollection GPInstance::TreesWithGPBranchLengthsOfTopologies(
     Node::NodePtrVec &&topologies) const {
-  const EigenVectorXd gpcsp_indexed_branch_lengths = engine_->GetBranchLengths();
+  const EigenVectorXd gpcsp_indexed_branch_lengths = GetEngine()->GetBranchLengths();
   RootedTree::RootedTreeVector tree_vector;
 
   for (auto &root_node : topologies) {
@@ -282,7 +282,7 @@ StringDoubleVector GPInstance::PrettyIndexedVector(EigenConstVectorXdRef v) {
 }
 
 EigenConstVectorXdRef GPInstance::GetSBNParameters() {
-  return engine_->GetSBNParameters();
+  return GetEngine()->GetSBNParameters();
 }
 
 StringDoubleVector GPInstance::PrettyIndexedSBNParameters() {
@@ -357,6 +357,16 @@ void GPInstance::ExportTreesWithAPCSP(const std::string &pcsp_string,
 
 void GPInstance::ExportAllGeneratedTrees(const std::string &out_path) {
   auto trees = GenerateCompleteRootedTreeCollection();
+  trees.ToNewickFile(out_path);
+}
+
+void GPInstance::ExportAllGeneratedTopologies(const std::string &out_path) {
+  auto raw_topologies = dag_.GenerateAllTopologies();
+  std::vector<Tree> tree_vector;
+  for (const auto &raw_topology : raw_topologies) {
+    tree_vector.push_back(Tree::UnitBranchLengthTreeOf(raw_topology));
+  }
+  auto trees = TreeCollection(tree_vector);
   trees.ToNewickFile(out_path);
 }
 

--- a/src/gp_instance.hpp
+++ b/src/gp_instance.hpp
@@ -17,6 +17,7 @@ class GPInstance {
     }
   };
   void PrintStatus();
+  StringSizeMap DAGSummaryStatistics();
 
   void ReadFastaFile(const std::string &fname);
   void ReadNewickFile(const std::string &fname);

--- a/src/gp_instance.hpp
+++ b/src/gp_instance.hpp
@@ -69,8 +69,8 @@ class GPInstance {
   // file.
   void ExportTreesWithAPCSP(const std::string &pcsp_string,
                             const std::string &newick_path);
-  // Export all trees in the span of the subsplit DAG to a Newick file. Does not require
-  // an Engine.
+  // Export all topologies in the span of the subsplit DAG to a Newick file. Does not
+  // require an Engine.
   void ExportAllGeneratedTopologies(const std::string &out_path);
   // Export all trees in the span of the subsplit DAG (with GP branch lengths) to a
   // Newick file. Requires an Engine.

--- a/src/gp_instance.hpp
+++ b/src/gp_instance.hpp
@@ -25,11 +25,12 @@ class GPInstance {
   void ReadNexusFile(const std::string &fname);
   void ReadNexusFileGZ(const std::string &fname);
 
+  void MakeDAG();
+  GPDAG &GetDAG();
+  void PrintDAG();
   void MakeEngine(double rescaling_threshold = GPEngine::default_rescaling_threshold_);
   GPEngine *GetEngine() const;
   bool HasEngine() const;
-  GPDAG &GetDAG();
-  void PrintDAG();
   void PrintGPCSPIndexer();
   void ProcessOperations(const GPOperationVector &operations);
   void HotStartBranchLengths();
@@ -87,7 +88,8 @@ class GPInstance {
   static constexpr size_t plv_count_per_node_ = 6;
 
   void ClearTreeCollectionAssociatedState();
-  void CheckSequencesAndTreesLoaded() const;
+  void CheckSequencesLoaded() const;
+  void CheckTreesLoaded() const;
 
   size_t GetGPCSPIndexForLeafNode(const Bitset &parent_subsplit,
                                   const Node *leaf_node) const;

--- a/src/gp_instance.hpp
+++ b/src/gp_instance.hpp
@@ -69,9 +69,11 @@ class GPInstance {
   // file.
   void ExportTreesWithAPCSP(const std::string &pcsp_string,
                             const std::string &newick_path);
-  // Run CurrentlyLoadedTreesWithGPBranchLengths and export to a Newick file.
+  // Export all trees in the span of the subsplit DAG to a Newick file. Does not require
+  // an Engine.
+  void ExportAllGeneratedTopologies(const std::string &out_path);
   // Export all trees in the span of the subsplit DAG (with GP branch lengths) to a
-  // Newick file.
+  // Newick file. Requires an Engine.
   void ExportAllGeneratedTrees(const std::string &out_path);
   // Generate all trees spanned by the DAG and load them into the instance.
   void LoadAllGeneratedTrees();

--- a/src/pybito.cpp
+++ b/src/pybito.cpp
@@ -391,7 +391,8 @@ PYBIND11_MODULE(bito, m) {
            "Print information about the instance.")
       .def("dag_summary_statistics", &GPInstance::DAGSummaryStatistics,
            "Return summary statistics about the DAG.")
-      .def("print_dag", &GPInstance::PrintDAG, "Print the generalized pruning DAG.")
+      .def("make_dag", &GPInstance::MakeDAG, "Build subsplit DAG.")
+      .def("print_dag", &GPInstance::PrintDAG, "Print the subsplit DAG.")
 
       // ** I/O
       .def("read_newick_file", &GPInstance::ReadNewickFile,

--- a/src/pybito.cpp
+++ b/src/pybito.cpp
@@ -415,9 +415,14 @@ PYBIND11_MODULE(bito, m) {
            R"raw(Write out currently loaded trees to a Newick file
           (using current GP branch lengths).)raw",
            py::arg("out_path"))
+      .def(
+          "export_all_generated_topologies", &GPInstance::ExportAllGeneratedTopologies,
+          R"raw(Write out all topologies spanned by the current SBN DAG to a Newick file.
+            Doesn't require an Engine.)raw",
+          py::arg("out_path"))
       .def("export_all_generated_trees", &GPInstance::ExportAllGeneratedTrees,
            R"raw(Write out all trees spanned by the current SBN DAG to a Newick file
-          (using current GP branch lengths).)raw",
+          (using current GP branch lengths). Requires an Engine.)raw",
            py::arg("out_path"))
 
       .def(

--- a/src/pybito.cpp
+++ b/src/pybito.cpp
@@ -389,6 +389,8 @@ PYBIND11_MODULE(bito, m) {
   gp_instance_class.def(py::init<const std::string &>())
       .def("print_status", &GPInstance::PrintStatus,
            "Print information about the instance.")
+      .def("dag_summary_statistics", &GPInstance::DAGSummaryStatistics,
+           "Return summary statistics about the DAG.")
       .def("print_dag", &GPInstance::PrintDAG, "Print the generalized pruning DAG.")
 
       // ** I/O

--- a/src/rooted_tree.cpp
+++ b/src/rooted_tree.cpp
@@ -122,6 +122,11 @@ RootedTree RootedTree::Example() {
   return tree;
 }
 
+RootedTree RootedTree::UnitBranchLengthTreeOf(Node::NodePtr topology) {
+  topology->Polish();
+  return RootedTree(topology, BranchLengthVector(1 + topology->Id(), 1.));
+}
+
 bool RootedTree::operator==(const RootedTree& other) const {
   return (this->Topology() == other.Topology()) &&
          (this->BranchLengths() == other.BranchLengths());

--- a/src/rooted_tree.hpp
+++ b/src/rooted_tree.hpp
@@ -108,6 +108,7 @@ class RootedTree : public Tree {
   // The tree `(0:2,(1:1.5,(2:2,3:1):2.5):2.5):0;` as depicted in
   // https://github.com/phylovi/bito/issues/187#issuecomment-618421183
   static RootedTree Example();
+  static RootedTree UnitBranchLengthTreeOf(Node::NodePtr topology);
 
  private:
   // As for SetTipDates, but only set the node bounds. No constraint on supplied

--- a/src/subsplit_dag.cpp
+++ b/src/subsplit_dag.cpp
@@ -61,6 +61,10 @@ size_t SubsplitDAG::GPCSPCount() const { return gpcsp_count_without_fake_subspli
 
 size_t SubsplitDAG::GPCSPCountWithFakeSubsplits() const { return dag_edges_.size(); }
 
+StringSizeMap SubsplitDAG::SummaryStatistics() const {
+  return {{"node_count", NodeCount()}, {"edge_count", GPCSPCountWithFakeSubsplits()}};
+}
+
 void SubsplitDAG::Print() const {
   for (const auto &dag_node : dag_nodes_) {
     std::cout << dag_node->ToString() << std::endl;

--- a/src/subsplit_dag.hpp
+++ b/src/subsplit_dag.hpp
@@ -327,3 +327,21 @@ class SubsplitDAG {
   void ConnectParentToAllParents(const Bitset &parent_subsplit,
                                  SizeVector &new_edge_idxs);
 };
+
+#ifdef DOCTEST_LIBRARY_INCLUDED
+#include "gp_instance.hpp"
+
+GPInstance GPInstanceOfFiles(const std::string &fasta_path,
+                             const std::string &newick_path) {
+  GPInstance inst("_ignore/mmapped_plv.data");
+  inst.ReadFastaFile(fasta_path);
+  inst.ReadNewickFile(newick_path);
+  inst.MakeEngine();
+  return inst;
+}
+
+TEST_CASE("SubsplitDAG") {
+  auto inst = GPInstanceOfFiles("data/hello.fasta", "data/hello_rooted_two_trees.nwk");
+  auto summaries = inst.DAGSummaryStatistics();
+}
+#endif  // DOCTEST_LIBRARY_INCLUDED

--- a/src/subsplit_dag.hpp
+++ b/src/subsplit_dag.hpp
@@ -327,21 +327,3 @@ class SubsplitDAG {
   void ConnectParentToAllParents(const Bitset &parent_subsplit,
                                  SizeVector &new_edge_idxs);
 };
-
-#ifdef DOCTEST_LIBRARY_INCLUDED
-#include "gp_instance.hpp"
-
-GPInstance GPInstanceOfFiles(const std::string &fasta_path,
-                             const std::string &newick_path) {
-  GPInstance inst("_ignore/mmapped_plv.data");
-  inst.ReadFastaFile(fasta_path);
-  inst.ReadNewickFile(newick_path);
-  inst.MakeEngine();
-  return inst;
-}
-
-TEST_CASE("SubsplitDAG") {
-  auto inst = GPInstanceOfFiles("data/hello.fasta", "data/hello_rooted_two_trees.nwk");
-  auto summaries = inst.DAGSummaryStatistics();
-}
-#endif  // DOCTEST_LIBRARY_INCLUDED

--- a/src/subsplit_dag.hpp
+++ b/src/subsplit_dag.hpp
@@ -72,6 +72,7 @@ class SubsplitDAG {
   size_t RootsplitCount() const;
   size_t GPCSPCount() const;
   size_t GPCSPCountWithFakeSubsplits() const;
+  StringSizeMap SummaryStatistics() const;
 
   void Print() const;
   void PrintGPCSPIndexer() const;

--- a/src/tree.cpp
+++ b/src/tree.cpp
@@ -41,12 +41,12 @@ bool Tree::operator==(const Tree& other) const {
          (this->BranchLengths() == other.BranchLengths());
 }
 
-std::string Tree::Newick(TagStringMapOption node_labels) const {
+std::string Tree::Newick(const TagStringMapOption& node_labels) const {
   return Topology()->Newick(branch_lengths_, node_labels);
 }
 
-std::string Tree::NewickTopology() const {
-  return Topology()->Newick(std::nullopt, std::nullopt);
+std::string Tree::NewickTopology(const TagStringMapOption& node_labels) const {
+  return Topology()->Newick(std::nullopt, node_labels);
 }
 
 double Tree::BranchLength(const Node* node) const {

--- a/src/tree.cpp
+++ b/src/tree.cpp
@@ -45,6 +45,10 @@ std::string Tree::Newick(TagStringMapOption node_labels) const {
   return Topology()->Newick(branch_lengths_, node_labels);
 }
 
+std::string Tree::NewickTopology() const {
+  return Topology()->Newick(std::nullopt, std::nullopt);
+}
+
 double Tree::BranchLength(const Node* node) const {
   Assert(node->Id() < branch_lengths_.size(),
          "Requested id is out of range in Tree::BranchLength.");

--- a/src/tree.hpp
+++ b/src/tree.hpp
@@ -39,6 +39,7 @@ class Tree {
 
   std::string Newick() const { return Newick(std::nullopt); }
   std::string Newick(TagStringMapOption node_labels) const;
+  std::string NewickTopology() const;
 
   double BranchLength(const Node* node) const;
 

--- a/src/tree.hpp
+++ b/src/tree.hpp
@@ -38,8 +38,8 @@ class Tree {
   bool operator==(const Tree& other) const;
 
   std::string Newick() const { return Newick(std::nullopt); }
-  std::string Newick(TagStringMapOption node_labels) const;
-  std::string NewickTopology() const;
+  std::string Newick(const TagStringMapOption& node_labels) const;
+  std::string NewickTopology(const TagStringMapOption& node_labels) const;
 
   double BranchLength(const Node* node) const;
 


### PR DESCRIPTION
## Description

* Can create a subsplit DAG without a fasta file
* Can get summary stats about a subsplit DAG
* Can write out topologies (not trees) from a subsplit DAG

Closes #386 


## Tests

* Added a test that we get the right summary statistics about a subsplit DAG.

## Checklist:

* [x] Code follows our detailed [contribution guidelines](CONTRIBUTING.md)
* [x] `clang-format` has been run
* [x] TODOs have been eliminated from the code
* [x] Comments are up to date, document intent, and there are no commented-out code blocks
