### PR TITLE
Enable loading of duplicates of the first loaded tree.

### DIFF
--- a/src/generic_sbn_instance.hpp
+++ b/src/generic_sbn_instance.hpp
@@ -279,6 +279,11 @@ class GenericSBNInstance {
   void SetAlignment(const Alignment &alignment) { alignment_ = alignment; }
   void SetAlignment(Alignment &&alignment) { alignment_ = alignment; }
 
+  void LoadDuplicatesOfFirstTree(size_t number_of_times) {
+    tree_collection_ =
+        tree_collection_.BuildCollectionByDuplicatingFirst(number_of_times);
+  }
+
  protected:
   // The name of our bito instance.
   std::string name_;

--- a/src/generic_tree_collection.hpp
+++ b/src/generic_tree_collection.hpp
@@ -87,13 +87,16 @@ class GenericTreeCollection {
     Erase(0, end_idx);
   }
 
+  // Build a tree collection by duplicating the first tree loaded.
   GenericTreeCollection<TTree> BuildCollectionByDuplicatingFirst(
       size_t number_of_times) {
     TTreeVector tree_vector;
 
+    Assert(TreeCount() > 0, "Need at least one tree if we are to duplicate the first.");
+
     tree_vector.reserve(number_of_times);
     for (size_t idx = 0; idx < number_of_times; idx++) {
-      tree_vector.push_back(GetTree(0));
+      tree_vector.push_back(GetTree(0).DeepCopy());
     }
 
     return GenericTreeCollection<TTree>(std::move(tree_vector), TagTaxonMap());

--- a/src/generic_tree_collection.hpp
+++ b/src/generic_tree_collection.hpp
@@ -87,6 +87,18 @@ class GenericTreeCollection {
     Erase(0, end_idx);
   }
 
+  GenericTreeCollection<TTree> BuildCollectionByDuplicatingFirst(
+      size_t number_of_times) {
+    TTreeVector tree_vector;
+
+    tree_vector.reserve(number_of_times);
+    for (size_t idx = 0; idx < number_of_times; idx++) {
+      tree_vector.push_back(GetTree(0));
+    }
+
+    return GenericTreeCollection<TTree>(std::move(tree_vector), TagTaxonMap());
+  }
+
   std::string Newick() const {
     std::string str;
     for (const auto &tree : trees_) {

--- a/src/pybito.cpp
+++ b/src/pybito.cpp
@@ -203,6 +203,10 @@ PYBIND11_MODULE(bito, m) {
           py::arg("use_tip_states") = true, py::arg("tree_count_option") = std::nullopt)
       .def("resize_phylo_model_params", &RootedSBNInstance::ResizePhyloModelParams,
            "Resize phylo_model_params.", py::arg("tree_count_option") = std::nullopt)
+      .def("load_duplicates_of_first_tree",
+           &RootedSBNInstance::LoadDuplicatesOfFirstTree,
+           "Replace all of the loaded trees with duplicates of the first tree.",
+           py::arg("number_of_times"))
       .def("read_fasta_file", &RootedSBNInstance::ReadFastaFile,
            "Read a sequence alignment from a FASTA file.")
       .def("taxon_names", &RootedSBNInstance::TaxonNames,
@@ -286,6 +290,10 @@ PYBIND11_MODULE(bito, m) {
           py::arg("use_tip_states") = true, py::arg("tree_count_option") = std::nullopt)
       .def("resize_phylo_model_params", &UnrootedSBNInstance::ResizePhyloModelParams,
            "Resize phylo_model_params.", py::arg("tree_count_option") = std::nullopt)
+      .def("load_duplicates_of_first_tree",
+           &UnrootedSBNInstance::LoadDuplicatesOfFirstTree,
+           "Replace all of the loaded trees with duplicates of the first tree.",
+           py::arg("number_of_times"))
       .def("read_fasta_file", &UnrootedSBNInstance::ReadFastaFile,
            "Read a sequence alignment from a FASTA file.")
       .def("taxon_names", &UnrootedSBNInstance::TaxonNames,

--- a/src/rooted_sbn_instance.hpp
+++ b/src/rooted_sbn_instance.hpp
@@ -462,4 +462,18 @@ TEST_CASE("RootedSBNInstance: SBN parameter round trip") {
                         reloaded_normalized_sbn_parameters, 1e-6);
 }
 
+TEST_CASE("RootedSBNInstance: BuildCollectionByDuplicatingFirst") {
+  auto empty_collection = RootedTreeCollection();
+  CHECK_THROWS(empty_collection.BuildCollectionByDuplicatingFirst(5));
+  auto inst = MakeFiveTaxonRootedInstance();
+  auto trees = inst.tree_collection_.BuildCollectionByDuplicatingFirst(5);
+  CHECK_EQ(trees.GetTree(0), trees.GetTree(1));
+  // Check that the trees don't refer to the same place in memory.
+  CHECK_NE(&trees.GetTree(0), &trees.GetTree(1));
+  inst = MakeFluInstance(true);
+  auto& base_flu_tree = inst.tree_collection_.GetTree(0);
+  trees = inst.tree_collection_.BuildCollectionByDuplicatingFirst(5);
+  CHECK_EQ(base_flu_tree, trees.GetTree(1));
+}
+
 #endif  // DOCTEST_LIBRARY_INCLUDED

--- a/src/rooted_tree.cpp
+++ b/src/rooted_tree.cpp
@@ -8,14 +8,30 @@ constexpr double BRANCH_LENGTH_TOLERANCE = 1e-4;
 
 RootedTree::RootedTree(const Node::NodePtr& topology, BranchLengthVector branch_lengths)
     : Tree(topology, std::move(branch_lengths)) {
-  Assert(
-      Children().size() == 2,
-      "Failed to create a RootedTree out of a topology that isn't bifurcating at the "
-      "root. Perhaps you are trying to parse unrooted trees into a RootedSBNInstance?");
+  AssertTopologyBifurcatingInConstructor(topology);
 }
 
 RootedTree::RootedTree(const Tree& tree)
     : RootedTree(tree.Topology(), tree.BranchLengths()) {}
+
+RootedTree::RootedTree(const Node::NodePtr& topology, BranchLengthVector branch_lengths,
+                       std::vector<double> node_bounds,
+                       std::vector<double> height_ratios,
+                       std::vector<double> node_heights, std::vector<double> rates,
+                       size_t rate_count)
+    : Tree(topology, std::move(branch_lengths)),
+      node_bounds_(std::move(node_bounds)),
+      height_ratios_(std::move(height_ratios)),
+      node_heights_(std::move(node_heights)),
+      rates_(std::move(rates)),
+      rate_count_(rate_count) {
+  AssertTopologyBifurcatingInConstructor(topology);
+}
+
+RootedTree RootedTree::DeepCopy() const {
+  return RootedTree(Topology()->DeepCopy(), branch_lengths_, node_bounds_,
+                    height_ratios_, node_heights_, rates_, rate_count_);
+};
 
 void RootedTree::SetTipDates(const TagDoubleMap& tag_date_map) {
   node_heights_ = std::vector<double>(Topology()->Id() + 1);
@@ -130,4 +146,11 @@ RootedTree RootedTree::UnitBranchLengthTreeOf(Node::NodePtr topology) {
 bool RootedTree::operator==(const RootedTree& other) const {
   return (this->Topology() == other.Topology()) &&
          (this->BranchLengths() == other.BranchLengths());
+}
+
+void RootedTree::AssertTopologyBifurcatingInConstructor(const Node::NodePtr& topology) {
+  Assert(
+      Children().size() == 2,
+      "Failed to create a RootedTree out of a topology that isn't bifurcating at the "
+      "root. Perhaps you are trying to parse unrooted trees into a RootedSBNInstance?");
 }

--- a/src/rooted_tree.hpp
+++ b/src/rooted_tree.hpp
@@ -32,7 +32,14 @@ class RootedTree : public Tree {
   using RootedTreeVector = std::vector<RootedTree>;
 
   RootedTree(const Node::NodePtr& topology, BranchLengthVector branch_lengths);
+  explicit RootedTree(const Node::NodePtr& topology, BranchLengthVector branch_lengths,
+                      std::vector<double> node_bounds,
+                      std::vector<double> height_ratios,
+                      std::vector<double> node_heights, std::vector<double> rates,
+                      size_t rate_count);
   explicit RootedTree(const Tree& tree);
+
+  RootedTree DeepCopy() const;
 
   const std::vector<double>& GetNodeBounds() const {
     EnsureTipDatesHaveBeenSet();
@@ -114,6 +121,8 @@ class RootedTree : public Tree {
   // As for SetTipDates, but only set the node bounds. No constraint on supplied
   // branch lengths.
   void SetNodeBoundsUsingDates(const TagDoubleMap& tag_date_map);
+
+  void AssertTopologyBifurcatingInConstructor(const Node::NodePtr& topology);
 };
 
 inline bool operator!=(const RootedTree& lhs, const RootedTree& rhs) {

--- a/src/rooted_tree_collection.cpp
+++ b/src/rooted_tree_collection.cpp
@@ -6,6 +6,10 @@
 #include "csv.hpp"
 #include "taxon_name_munging.hpp"
 
+RootedTreeCollection::RootedTreeCollection(
+    const PreRootedTreeCollection& pre_collection, const TagDateMap& tag_date_map)
+    : PreRootedTreeCollection(pre_collection), tag_date_map_(tag_date_map){};
+
 RootedTreeCollection RootedTreeCollection::OfTreeCollection(
     const TreeCollection& trees) {
   TTreeVector rooted_trees;
@@ -14,6 +18,13 @@ RootedTreeCollection RootedTreeCollection::OfTreeCollection(
     rooted_trees.emplace_back(tree);
   }
   return RootedTreeCollection(std::move(rooted_trees), trees.TagTaxonMap());
+}
+
+RootedTreeCollection RootedTreeCollection::BuildCollectionByDuplicatingFirst(
+    size_t number_of_times) {
+  return RootedTreeCollection(
+      PreRootedTreeCollection::BuildCollectionByDuplicatingFirst(number_of_times),
+      tag_date_map_);
 }
 
 void RootedTreeCollection::SetDatesToBeConstant(

--- a/src/rooted_tree_collection.hpp
+++ b/src/rooted_tree_collection.hpp
@@ -19,8 +19,12 @@ class RootedTreeCollection : public PreRootedTreeCollection {
  public:
   // Inherit all constructors.
   using PreRootedTreeCollection::PreRootedTreeCollection;
+  RootedTreeCollection(const PreRootedTreeCollection& pre_collection,
+                       const TagDateMap& tag_date_map);
 
   static RootedTreeCollection OfTreeCollection(const TreeCollection& trees);
+  // Build a tree collection by duplicating the first tree.
+  RootedTreeCollection BuildCollectionByDuplicatingFirst(size_t number_of_times);
 
   const TagDateMap& GetTagDateMap() const { return tag_date_map_; };
 

--- a/src/tree.cpp
+++ b/src/tree.cpp
@@ -41,6 +41,8 @@ bool Tree::operator==(const Tree& other) const {
          (this->BranchLengths() == other.BranchLengths());
 }
 
+Tree Tree::DeepCopy() const { return Tree(Topology()->DeepCopy(), BranchLengths()); }
+
 std::string Tree::Newick(const TagStringMapOption& node_labels) const {
   return Topology()->Newick(branch_lengths_, node_labels);
 }

--- a/src/tree.hpp
+++ b/src/tree.hpp
@@ -35,6 +35,7 @@ class Tree {
   size_t Id() const { return Topology()->Id(); }
   std::vector<size_t> ParentIdVector() const { return Topology()->ParentIdVector(); }
 
+  Tree DeepCopy() const;
   bool operator==(const Tree& other) const;
 
   std::string Newick() const { return Newick(std::nullopt); }

--- a/src/unrooted_tree.cpp
+++ b/src/unrooted_tree.cpp
@@ -36,6 +36,10 @@ Tree UnrootedTree::Detrifurcate() const {
   return Tree(rerooted_topology, branch_lengths);
 }
 
+UnrootedTree UnrootedTree::DeepCopy() const {
+  return UnrootedTree(Topology()->DeepCopy(), BranchLengths());
+}
+
 bool UnrootedTree::operator==(const UnrootedTree& other) const {
   return (this->Topology() == other.Topology()) &&
          (this->BranchLengths() == other.BranchLengths());

--- a/src/unrooted_tree.hpp
+++ b/src/unrooted_tree.hpp
@@ -17,6 +17,8 @@ class UnrootedTree : public Tree {
   explicit UnrootedTree(Tree tree)
       : UnrootedTree(tree.Topology(), std::move(tree.branch_lengths_)){};
 
+  UnrootedTree DeepCopy() const;
+
   bool operator==(const Tree& other) const = delete;
   bool operator==(const UnrootedTree& other) const;
 

--- a/src/unrooted_tree_collection.cpp
+++ b/src/unrooted_tree_collection.cpp
@@ -7,6 +7,10 @@
 // https://en.cppreference.com/w/cpp/language/class_template#Explicit_instantiation
 template class GenericTreeCollection<UnrootedTree>;
 
+UnrootedTreeCollection::UnrootedTreeCollection(
+    const PreUnrootedTreeCollection& pre_collection)
+    : PreUnrootedTreeCollection(pre_collection){};
+
 UnrootedTreeCollection UnrootedTreeCollection::OfTreeCollection(
     const TreeCollection& trees) {
   TTreeVector unrooted_trees;

--- a/src/unrooted_tree_collection.hpp
+++ b/src/unrooted_tree_collection.hpp
@@ -12,6 +12,7 @@ class UnrootedTreeCollection : public PreUnrootedTreeCollection {
  public:
   // Inherit all constructors.
   using PreUnrootedTreeCollection::PreUnrootedTreeCollection;
+  UnrootedTreeCollection(const PreUnrootedTreeCollection& pre_collection);
 
   static UnrootedTreeCollection OfTreeCollection(const TreeCollection& trees);
 };


### PR DESCRIPTION
## Description

Enable loading of duplicates of the first loaded tree.

Closes #408 


## Tests

Tests that trees are properly duplicated, and that an exception is raised when there are no trees.

## Checklist:

* [ x] Code follows our detailed [contribution guidelines](CONTRIBUTING.md)
* [ x] `clang-format` has been run
* [ x] TODOs have been eliminated from the code
* [ x] Comments are up to date, document intent, and there are no commented-out code blocks
