### PR TITLE
PLV Handler

### DIFF
--- a/src/gp_dag.hpp
+++ b/src/gp_dag.hpp
@@ -14,21 +14,16 @@
 #include "sbn_maps.hpp"
 #include "subsplit_dag_node.hpp"
 #include "tidy_subsplit_dag.hpp"
+#include "plv_handler.hpp"
+
+using PLVType = PLVHandler::PLVType;
 
 class GPDAG : public TidySubsplitDAG {
  public:
-  // We store 6 PLVs per subsplit, and index them according to this enum.
-  // The notation is as described in the manuscript, but with a slight shift in the
-  // position of the tilde. For example P_HAT_TILDE for a subsplit s is
-  // \hat{p}(\tilde{s}).
-  enum class PLVType { P, P_HAT, P_HAT_TILDE, R_HAT, R, R_TILDE };
-
   using TidySubsplitDAG::TidySubsplitDAG;
 
-  // Get the index of a PLV of a given type and with a given index.
-  static PLVType RPLVType(bool rotated);
-  static size_t GetPLVIndexStatic(PLVType plv_type, size_t node_count, size_t src_idx);
-  size_t GetPLVIndex(PLVType plv_type, size_t src_idx) const;
+  // Get the GPEngine index of given PLV type and given node index.
+  size_t GetPLVIndex(PLVType plv_type, size_t node_idx) const;
 
   // ** GPOperations:
   // These methods generate a serial vector of operations, but perform no computation.

--- a/src/gp_doctest.cpp
+++ b/src/gp_doctest.cpp
@@ -11,6 +11,7 @@
 #include "rooted_sbn_instance.hpp"
 #include "stopwatch.hpp"
 #include "tidy_subsplit_dag.hpp"
+#include "plv_handler.hpp"
 
 using namespace GPOperations;  // NOLINT
 
@@ -223,6 +224,8 @@ TEST_CASE("GPInstance: marginal likelihood on seven taxa and four trees") {
 }
 
 TEST_CASE("GPInstance: gradient calculation") {
+  using PLVType = PLVHandler::PLVType;
+
   auto inst = MakeHelloGPInstanceSingleNucleotide();
   auto engine = inst.GetEngine();
 
@@ -233,10 +236,10 @@ TEST_CASE("GPInstance: gradient calculation") {
   size_t hello_node_count_without_dag_root_node = 5;
   size_t rootsplit_jupiter_idx = 2;
 
-  size_t leafward_idx = GPDAG::GetPLVIndexStatic(
-      GPDAG::PLVType::P, hello_node_count_without_dag_root_node, child_id);
-  size_t rootward_idx = GPDAG::GetPLVIndexStatic(
-      GPDAG::PLVType::R_TILDE, hello_node_count_without_dag_root_node, rootsplit_id);
+  size_t leafward_idx = PLVHandler::GetPLVIndex(
+      PLVType::P, hello_node_count_without_dag_root_node, child_id);
+  size_t rootward_idx = PLVHandler::GetPLVIndex(
+      PLVType::RLeft, hello_node_count_without_dag_root_node, rootsplit_id);
   OptimizeBranchLength op{leafward_idx, rootward_idx, rootsplit_jupiter_idx};
   DoublePair log_lik_and_derivative = engine->LogLikelihoodAndDerivative(op);
   // Expect log lik: -4.806671945.

--- a/src/gp_engine.hpp
+++ b/src/gp_engine.hpp
@@ -172,13 +172,13 @@ class GPEngine {
   std::unique_ptr<MmappedNucleotidePLV> mmapped_master_plv_ptr_ = nullptr;
   MmappedNucleotidePLV mmapped_master_plv_;
   // Partial Likelihood Vectors.
-  // plvs_ store the following (see GPDAG::GetPLVIndexStatic):
+  // plvs_ store the following (see PLVHandler::GetPLVIndex):
   // [0, num_nodes): p(s).
-  // [num_nodes, 2*num_nodes): phat(s).
-  // [2*num_nodes, 3*num_nodes): phat(s_tilde).
-  // [3*num_nodes, 4*num_nodes): rhat(s) = rhat(s_tilde).
-  // [4*num_nodes, 5*num_nodes): r(s).
-  // [5*num_nodes, 6*num_nodes): r(s_tilde).
+  // [num_nodes, 2*num_nodes): phat(s_right).
+  // [2*num_nodes, 3*num_nodes): phat(s_left).
+  // [3*num_nodes, 4*num_nodes): rhat(s_right) = rhat(s_left).
+  // [4*num_nodes, 5*num_nodes): r(s_right).
+  // [5*num_nodes, 6*num_nodes): r(s_left).
   NucleotidePLVRefVector plvs_;
   // Rescaling count for each plv.
   EigenVectorXi rescaling_counts_;

--- a/src/plv_handler.hpp
+++ b/src/plv_handler.hpp
@@ -1,0 +1,61 @@
+// Copyright 2019-2022 bito project contributors.
+// bito is free software under the GPLv3; see LICENSE file for details.
+//
+// PLVHandler is used by GPOperations to get index location of PLVs stored on the
+// GPEngine.
+
+#pragma once
+
+class PLVHandler {
+ public:
+  // We store 6 PLVs per subsplit, and index them according to this enum. (See
+  // GPEngine::plvs_).
+  static inline const size_t plv_count = 6;
+  enum class PLVType : size_t {
+    P,          // p(s)
+    PHatRight,  // phat(s_right)
+    PHatLeft,   // phat(s_left)
+    RHat,       // rhat(s_right) = rhat(s_left)
+    RRight,     // r(s_right)
+    RLeft       // r(s_left)
+  };
+
+  // Get the `GPEngine::plvs_` index of given node's given PLV type from DAG with
+  // node_count.
+  static size_t GetPLVIndex(const PLVType plv_type, const size_t node_count,
+                            const size_t node_idx) {
+    size_t plv_type_idx;
+    switch (plv_type) {
+      case PLVType::P:
+        plv_type_idx = 0;
+        break;
+      case PLVType::PHatRight:
+        plv_type_idx = 1;
+        break;
+      case PLVType::PHatLeft:
+        plv_type_idx = 2;
+        break;
+      case PLVType::RHat:
+        plv_type_idx = 3;
+        break;
+      case PLVType::RRight:
+        plv_type_idx = 4;
+        break;
+      case PLVType::RLeft:
+        plv_type_idx = 5;
+        break;
+      default:
+        Failwith("Invalid PLV index requested.");
+    }
+    return (plv_type_idx * node_count) + node_idx;
+  };
+
+  static size_t GetPLVIndex(const PLVType plv_type, const SubsplitDAG &dag,
+                            const size_t node_idx) {
+    return GetPLVIndex(plv_type, dag.NodeCountWithoutDAGRoot(), node_idx);
+  };
+
+  static PLVType RPLVType(const bool is_on_left) {
+    return is_on_left ? PLVType::RLeft : PLVType::RRight;
+  };
+};


### PR DESCRIPTION
## Description

- Adds PLVHandler, a static class of methods to facilitate GPOperations access of PLV indices in the GPEngine.
- Renames PLV enums to reflect present naming conventions in GP paper.


## Tests

Pre-existing tests utilizing GetPLVIndex() are sufficient for testing.


## Checklist:

* [x] Code follows our detailed [contribution guidelines](CONTRIBUTING.md)
* [x] `clang-format` has been run
* [x] TODOs have been eliminated from the code
* [x] Comments are up to date, document intent, and there are no commented-out code blocks
