### PR TITLE
411 build issues macos

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,7 @@
 _build
 build
 build_test
+build_work
 _ignore
 .clangd
 __pycache__

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,7 +16,7 @@ ExternalProject_Add(beagle-lib
   GIT_SHALLOW   true
   GIT_PROGRESS  true
   UPDATE_DISCONNECTED true
-  CMAKE_ARGS    -DCMAKE_INSTALL_PREFIX=${PROJECT_BINARY_DIR}/beagle-lib/install -DBUILD_CUDA=OFF -DBUILD_OPENCL=OFF -DBUILD_JNI=OFF -DCMAKE_CXX_FLAGS="-DHAVE_CPUID_H" -DCMAKE_SHARED_LINKER_FLAGS="-Wl,-rpath,${BITO_RPATH}"
+  CMAKE_ARGS    -DCMAKE_INSTALL_PREFIX=${PROJECT_BINARY_DIR}/beagle-lib/install -DBUILD_CUDA=OFF -DBUILD_OPENCL=OFF -DBUILD_JNI=OFF -DCMAKE_CXX_FLAGS="-DHAVE_CPUID_H" -DCMAKE_SHARED_LINKER_FLAGS="${BITO_RPATH}"
   PREFIX      beagle-lib
   INSTALL_DIR   beagle-lib/install
 )
@@ -32,9 +32,14 @@ ExternalProject_Add(pybind11
   INSTALL_DIR   pybind11/install
 )
 
+option(WERROR "Treat warnings as errors" ON)
+
 function(bito_compile_opts PRODUCT)
   target_compile_features(${PRODUCT} PUBLIC cxx_std_17)
-  target_compile_options(${PRODUCT} PUBLIC -Werror -Wno-unknown-warning -Wno-unknown-warning-option -Wall -Wold-style-cast)
+  target_compile_options(${PRODUCT} PUBLIC -Wno-unknown-warning -Wno-unknown-warning-option -Wall -Wold-style-cast)
+  if(${WERROR})
+    target_compile_options(${PRODUCT} PUBLIC -Werror)
+  endif()
   target_include_directories(${PRODUCT} PUBLIC
     ${PROJECT_BINARY_DIR}/beagle-lib/install/include/libhmsbeagle-1
     lib/eigen
@@ -42,7 +47,7 @@ function(bito_compile_opts PRODUCT)
 endfunction()
 
 function(bito_link_opts PRODUCT)
-  target_link_options(${PRODUCT} PUBLIC -pthread -Wl,-rpath,${BITO_RPATH})
+  target_link_options(${PRODUCT} PUBLIC -pthread ${BITO_RPATH})
   target_link_libraries(${PRODUCT} PUBLIC bito-core)
   add_dependencies(${PRODUCT} bito-core)
 endfunction()
@@ -105,7 +110,7 @@ add_library(bito-core SHARED
   src/zlib_stream.cpp
 )
 bito_compile_opts(bito-core)
-target_link_options(bito-core PUBLIC -pthread -Wl,-rpath,${BITO_RPATH})
+target_link_options(bito-core PUBLIC -pthread ${BITO_RPATH})
 target_link_libraries(bito-core PUBLIC hmsbeagle hmsbeagle-cpu z)
 target_link_directories(bito-core PUBLIC
   ${PROJECT_BINARY_DIR}/beagle-lib/install/lib
@@ -154,7 +159,7 @@ configure_file(__init__.py.in
 
 add_custom_target(pip ALL
   COMMAND ln -sf ${PROJECT_BINARY_DIR}/beagle-lib/install/lib/* ${PROJECT_BINARY_DIR}/py
-  COMMAND ln -sf ${PROJECT_BINARY_DIR}/libbito-core.so  ${PROJECT_BINARY_DIR}/py
-  COMMAND ln -sf ${PROJECT_BINARY_DIR}/libbito.so  ${PROJECT_BINARY_DIR}/py/__init__.so
+  COMMAND ln -sf ${PROJECT_BINARY_DIR}/$<TARGET_FILE_NAME:bito-core>  ${PROJECT_BINARY_DIR}/py
+  COMMAND ln -sf ${PROJECT_BINARY_DIR}/$<TARGET_FILE_NAME:bito>  ${PROJECT_BINARY_DIR}/py/__init__.so
   DEPENDS bito
 )

--- a/Makefile
+++ b/Makefile
@@ -23,8 +23,24 @@ buildtest:
 		mkdir -p _ignore
 	pip install ./build_test
 
+buildwork:
+	@mkdir -p build_work
+	@cd build_work && \
+		cmake -DCMAKE_BUILD_TYPE=Debug -DWERROR=OFF .. && \
+		cmake --build . ${j_flags} && \
+		ln -sf ../data . && \
+		ln -sf libbito.so bito.so && \
+		mkdir -p _ignore
+	pip install ./build_work
+
 fasttest: buildtest
 	@cd build_test && \
+		./doctest --test-case-exclude="* tree sampling" && \
+		./gp_doctest --test-case-exclude="UnrootedSBNInstance*"
+	pytest
+
+work: buildwork
+	@cd build_work && \
 		./doctest --test-case-exclude="* tree sampling" && \
 		./gp_doctest --test-case-exclude="UnrootedSBNInstance*"
 	pytest
@@ -61,7 +77,7 @@ format:
 	clang-format -i -style=file $(our_files)
 
 clean:
-	rm -rf build build_test dist bito.*.so $(find . -name __pycache)
+	rm -rf build build_test build_work dist bito.*.so $(find . -name __pycache)
 
 # We follow C++ core guidelines by allowing passing by non-const reference.
 lint:

--- a/get_rpath.py
+++ b/get_rpath.py
@@ -1,2 +1,2 @@
 import site
-print(".:" + site.getusersitepackages() + "/bito:" + ':'.join(site.getsitepackages()) + "/bito")
+print('-Wl,-rpath,.,-rpath,' + site.getusersitepackages() + '/bito,-rpath,' + ',-rpath,'.join(site.getsitepackages()) + '/bito')

--- a/src/gp_doctest.cpp
+++ b/src/gp_doctest.cpp
@@ -621,8 +621,9 @@ TEST_CASE("GPInstance: second simplest hybrid marginal") {
   inst.PopulatePLVs();
   const std::string tree_path = "_ignore/simplest-hybrid-marginal-trees.nwk";
   inst.ExportAllGeneratedTrees(tree_path);
-
-  auto request = dag.QuartetHybridRequestOf(12, true, 11);
+  
+  auto edge = dag.GetDAGEdge(2);
+  auto request = dag.QuartetHybridRequestOf(edge.GetParent(), true, edge.GetChild());
   EigenVectorXd quartet_log_likelihoods =
       inst.GetEngine()->CalculateQuartetHybridLikelihoods(request);
 

--- a/src/gp_engine.cpp
+++ b/src/gp_engine.cpp
@@ -48,6 +48,9 @@ GPEngine::GPEngine(SitePattern site_pattern, size_t plv_count, size_t gpcsp_coun
   quartet_r_sorted_plv_ = quartet_root_plv_;
 
   InitializePLVsWithSitePatterns();
+
+  std::ignore = plv_count_per_node_;
+  std::ignore = gpcsp_count_;
 }
 
 void GPEngine::operator()(const GPOperations::ZeroPLV& op) {
@@ -396,7 +399,7 @@ void GPEngine::HotStartBranchLengths(const RootedTreeCollection& tree_collection
 SizeDoubleVectorMap GPEngine::GatherBranchLengths(
     const RootedTreeCollection& tree_collection, const BitsetSizeMap& indexer) {
   SizeDoubleVectorMap gpcsp_branchlengths_map;
-  auto gather_branch_lengths = [&gpcsp_branchlengths_map, this](
+  auto gather_branch_lengths = [&gpcsp_branchlengths_map](
                                    size_t gpcsp_idx, const RootedTree& tree,
                                    const Node* focal_node) {
     gpcsp_branchlengths_map[gpcsp_idx].push_back(tree.BranchLength(focal_node));
@@ -413,8 +416,8 @@ void GPEngine::FunctionOverRootedTreeCollection(
   const size_t default_index = branch_lengths_.size();
   for (const auto& tree : tree_collection.Trees()) {
     tree.Topology()->RootedPCSPPreorder(
-        [&leaf_count, &default_index, &indexer, &tree, &function_on_tree_node_by_gpcsp,
-         this](const Node* sister_node, const Node* focal_node, const Node* child0_node,
+        [&leaf_count, &default_index, &indexer, &tree, &function_on_tree_node_by_gpcsp]
+         (const Node* sister_node, const Node* focal_node, const Node* child0_node,
                const Node* child1_node) {
           Bitset gpcsp_bitset =
               SBNMaps::PCSPBitsetOf(leaf_count, sister_node, false, focal_node, false,

--- a/src/graft_dag.cpp
+++ b/src/graft_dag.cpp
@@ -96,12 +96,8 @@ void GraftDAG::CreateGraftEdge(const size_t parent_id, const size_t child_id,
   auto parent_node = GetDAGNode(parent_id);
   auto child_node = GetDAGNode(child_id);
 
-  const Bitset &parent_bitset = parent_node.GetBitset();
-  const Bitset &child_bitset = child_node.GetBitset();
-
   // Add edge to grafted edges.
   if (!ContainsEdge(parent_id, child_id)) {
-    const Bitset &edge_bitset = Bitset::PCSP(parent_bitset, child_bitset);
     const size_t &edge_id = EdgeCount();
     graft_storage_.AddLine(
         {edge_id, parent_id, child_id, is_left ? Clade::Left : Clade::Right},
@@ -374,7 +370,7 @@ bool GraftDAG::ContainsNode(const size_t node_id) const {
 }
 
 bool GraftDAG::ContainsGraftEdge(const size_t parent_id, const size_t child_id) const {
-  return graft_storage_.GetLine(parent_id, child_id).has_value();
+  return graft_storage_.GetLine(parent_id, child_id, HostNodeCount(), HostEdgeCount()).has_value();
 }
 
 bool GraftDAG::ContainsEdge(const size_t parent_id, const size_t child_id) const {

--- a/src/subsplit_dag.cpp
+++ b/src/subsplit_dag.cpp
@@ -261,19 +261,19 @@ size_t SubsplitDAG::GetTaxonId(const std::string &name) const {
 
 SubsplitDAGNode SubsplitDAG::GetDAGNode(const size_t node_id) const {
   Assert(ContainsNode(node_id),
-         "Node with the given node_id does not exist in SubsplitDAG::GetDAGNode().");
+         "Node with the given node_id does not exist in DAG.");
   return storage_.GetVertices().at(node_id);
 }
 
 MutableSubsplitDAGNode SubsplitDAG::GetDAGNode(const size_t node_id) {
   Assert(ContainsNode(node_id),
-         "Node with the given node_id does not exist in SubsplitDAG::GetDAGNode().");
+         "Node with the given node_id does not exist in DAG.");
   return storage_.GetVertices().at(node_id);
 }
 
 size_t SubsplitDAG::GetDAGNodeId(const Bitset &subsplit) const {
   Assert(ContainsNode(subsplit),
-         "Node with the given subsplit does not exist in SubsplitDAG::GetDAGNodeId().");
+         "Node with the given subsplit does not exist in DAG.");
   return subsplit_to_id_.at(subsplit);
 }
 
@@ -281,6 +281,12 @@ size_t SubsplitDAG::DAGRootNodeId() const { return NodeCount() - 1; }
 
 ConstNeighborsView SubsplitDAG::RootsplitIds() const {
   return GetDAGNode(DAGRootNodeId()).GetLeftLeafward();
+}
+
+ConstLineView SubsplitDAG::GetDAGEdge(const size_t edge_id) const {
+  Assert(ContainsEdge(edge_id),
+         "Node with the given node_id does not exist in DAG.");
+  return *storage_.GetLine(edge_id);
 }
 
 size_t SubsplitDAG::GetEdgeIdx(const Bitset &parent_subsplit,
@@ -520,7 +526,7 @@ EigenVectorXd SubsplitDAG::UnconditionalNodeProbabilities(
   node_probabilities.setZero();
   node_probabilities[DAGRootNodeId()] = 1.;
 
-  TopologicalEdgeTraversal([this, &node_probabilities, &normalized_sbn_parameters](
+  TopologicalEdgeTraversal([&node_probabilities, &normalized_sbn_parameters](
                                const size_t parent_id, const bool,
                                const size_t child_id, const size_t edge_idx) {
     const double child_probability_given_parent = normalized_sbn_parameters[edge_idx];
@@ -913,6 +919,10 @@ bool SubsplitDAG::ContainsEdge(const size_t parent_id, const size_t child_id) co
   return storage_.GetLine(parent_id, child_id).has_value();
 }
 
+bool SubsplitDAG::ContainsEdge(const size_t edge_id) const {
+  return storage_.GetLine(edge_id).has_value();
+}
+
 // ** Build output indexes/vectors
 
 std::pair<SizeVector, SizeVector> SubsplitDAG::BuildParentIdVectors(
@@ -1215,16 +1225,16 @@ SizeVector SubsplitDAG::BuildNodeReindexer(const size_t prev_node_count) {
       {dag_root_node_id},
       SubsplitDAGTraversalAction(
           // BeforeNode
-          [this](size_t node_id) {},
+          [](size_t node_id) {},
           // AfterNode
-          [this, &node_reindexer, &running_traversal_idx](size_t node_id) {
+          [&node_reindexer, &running_traversal_idx](size_t node_id) {
             node_reindexer.at(node_id) = running_traversal_idx;
             running_traversal_idx++;
           },
           // BeforeNodeClade
-          [this](size_t node_id, bool rotated) {},
+          [](size_t node_id, bool rotated) {},
           // VisitEdge
-          [this](size_t node_id, size_t child_id, bool rotated) {}));
+          [](size_t node_id, size_t child_id, bool rotated) {}));
   return node_reindexer;
 }
 

--- a/src/subsplit_dag.hpp
+++ b/src/subsplit_dag.hpp
@@ -135,6 +135,8 @@ class SubsplitDAG {
   size_t DAGRootNodeId() const;
   // Return the node ids corresponding to the rootsplits.
   ConstNeighborsView RootsplitIds() const;
+  // Get edge based on edge id.
+  ConstLineView GetDAGEdge(const size_t edge_id) const;
   // Get the PCSP edge index by its parent-child pair subsplits from the DAG nodes.
   size_t GetEdgeIdx(const Bitset &parent_subsplit, const Bitset &child_subsplit) const;
   // Get the PCSP edge index by its parent-child pair id from the DAG nodes.
@@ -308,6 +310,7 @@ class SubsplitDAG {
   bool ContainsNode(const size_t node_id) const;
   // Does an edge that connects the two nodes exist?
   bool ContainsEdge(const size_t parent_id, const size_t child_id) const;
+  bool ContainsEdge(const size_t edge_id) const;
 
   // ** Modify DAG
   // These methods are for directly modifying the DAG by adding or removing nodes and

--- a/src/subsplit_dag_node.hpp
+++ b/src/subsplit_dag_node.hpp
@@ -136,16 +136,15 @@ class GenericSubsplitDAGNode {
     return rotated ? GetLeftRootward() : GetRightRootward();
   }
 
-  void RemapNodeIds(const SizeVector& node_reindexer) {
+  // After modifying parent DAG.
+  void RemapNodeIds(const SizeVector node_reindexer) {
+    Assert(Reindexer::IsValidReindexer(node_reindexer),
+         "Reindexer must be valid in GenericSubsplitDAGNode::RemapNodeIds.");
     node_.SetId(node_reindexer.at(node_.GetId()));
-    RemapNeighbors(node_.GetNeighbors(Direction::Leafward, Clade::Left),
-                   node_reindexer);
-    RemapNeighbors(node_.GetNeighbors(Direction::Leafward, Clade::Right),
-                   node_reindexer);
-    RemapNeighbors(node_.GetNeighbors(Direction::Rootward, Clade::Left),
-                   node_reindexer);
-    RemapNeighbors(node_.GetNeighbors(Direction::Rootward, Clade::Right),
-                   node_reindexer);
+    node_.GetNeighbors(Direction::Leafward, Clade::Left).RemapIds(node_reindexer);
+    node_.GetNeighbors(Direction::Leafward, Clade::Right).RemapIds(node_reindexer);
+    node_.GetNeighbors(Direction::Rootward, Clade::Left).RemapIds(node_reindexer);
+    node_.GetNeighbors(Direction::Rootward, Clade::Right).RemapIds(node_reindexer);
   }
 
   std::optional<std::tuple<LineId, Direction, Clade>> FindNeighbor(VertexId id) {
@@ -161,7 +160,8 @@ class GenericSubsplitDAGNode {
   friend class DAGVertex;
   template <typename>
   friend class GenericSubsplitDAGNode;
-  friend auto& GetStorage<>(const GenericSubsplitDAGNode&);
+  friend DAGVertex& GetStorage(const GenericSubsplitDAGNode<DAGVertex>&);
+  friend const DAGVertex& GetStorage(const GenericSubsplitDAGNode<const DAGVertex>&);
   T& node_;
 };
 
@@ -231,6 +231,13 @@ typename GenericVerticesView<T>::view_type GenericVerticesView<T>::at(size_t i) 
 }
 
 #ifdef DOCTEST_LIBRARY_INCLUDED
+
+inline DAGVertex& GetStorage(const GenericSubsplitDAGNode<DAGVertex>& node) {
+  return node.node_;
+}
+inline const DAGVertex& GetStorage(const GenericSubsplitDAGNode<const DAGVertex>& node) {
+  return node.node_;
+}
 
 /* Create the following topology:
             [0]

--- a/src/subsplit_dag_storage.hpp
+++ b/src/subsplit_dag_storage.hpp
@@ -198,6 +198,20 @@ class GenericNeighborsView {
   size_t size() const { return neighbors_.size(); }
   bool empty() const { return neighbors_.empty(); }
 
+  void RemapIds(const SizeVector& reindexer) {
+    for (auto [vertex_id, line_id] : neighbors_) {
+      std::ignore = line_id;
+      Assert(vertex_id < reindexer.size(),
+            "Neighbors cannot contain an id out of bounds of the reindexer in "
+            "GenericNeighborsView::RemapIds.");
+    }
+    T remaped{};
+    for (auto [vertex_id, line_id] : neighbors_) {
+      remaped[reindexer.at(vertex_id)] = line_id;
+    }
+    neighbors_ = remaped;
+  }
+
   operator SizeVector() const {
     SizeVector result;
     for (auto i : neighbors_) result.push_back(i.first);
@@ -372,11 +386,13 @@ class SubsplitDAGStorage {
   ConstLinesView GetLines() const { return *this; }
   LinesView GetLines() { return *this; }
 
-  std::optional<ConstLineView> GetLine(VertexId parent, VertexId child) const {
+  std::optional<ConstLineView> GetLine(VertexId parent, VertexId child, size_t vertex_offset = 0, size_t line_offset = 0) const {
+    parent -= vertex_offset;
+    child -= vertex_offset;
     if (parent >= vertices_.size() || child >= vertices_.size()) return {};
-    auto result = vertices_.at(parent).FindNeighbor(child);
+    auto result = vertices_.at(parent).FindNeighbor(child + vertex_offset);
     if (!result.has_value()) return {};
-    return lines_.at(std::get<0>(result.value()));
+    return lines_.at(std::get<0>(result.value()) - line_offset);
   }
 
   std::optional<ConstLineView> GetLine(LineId id) const {
@@ -419,12 +435,8 @@ class SubsplitDAGStorage {
  private:
   template <typename>
   friend class GenericLinesView;
-  template <typename T>
-  friend class GenericLinesView<T>::Iterator;
   template <typename>
   friend class GenericVerticesView;
-  template <typename T>
-  friend class GenericVerticesView<T>::Iterator;
 
   template <typename T, typename Id>
   static T& GetOrInsert(std::vector<T>& data, Id id, size_t offset = 0) {

--- a/src/zlib_stream.cpp
+++ b/src/zlib_stream.cpp
@@ -101,7 +101,7 @@ void ZStringBuf::ensure_avail(std::streamsize count) {
           throw std::runtime_error("Preset dictionary is needed");
         }
         if (ret.code == Result::Code::stream_end) {
-          throw std::logic_error("End of stream");
+          break;
         }
         throw std::logic_error("Unexpected result from zlib");
       }


### PR DESCRIPTION
## Description

Fix Build Issues with macOS/clang

* Various fixes for apple-clang compiler quirks.
* Also adds the option to disable -Werror at a new make target using "make work".   For bypassing build warnings during development.

Closes #411 


## Tests

N/A


## Checklist:

* [ x] Code follows our detailed [contribution guidelines](CONTRIBUTING.md)
* [ x] `clang-format` has been run
* [ x] TODOs have been eliminated from the code
* [ x] Comments are up to date, document intent, and there are no commented-out code blocks
