### PR TITLE
417 graft sdag storage

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -17,4 +17,5 @@ Please double check that you can make your tests fail by perturbing them.
 * [ ] `clang-format` has been run
 * [ ] TODOs have been eliminated from the code
 * [ ] Comments are up to date, document intent, and there are no commented-out code blocks
+* [ ] Issue branch has been squashed and rebased on main branch
 * [ ] GitHub CI build on PR branch completed successfully

--- a/src/bitset.cpp
+++ b/src/bitset.cpp
@@ -136,7 +136,7 @@ void Bitset::operator|=(const Bitset& other) {
 }
 
 std::ostream& operator<<(std::ostream& os, const Bitset& bitset) {
-  os << bitset.SubsplitToVectorOfSetBitsAsString();
+  os << bitset.SubsplitToString();
   return os;
 }
 

--- a/src/gp_instance.cpp
+++ b/src/gp_instance.cpp
@@ -147,12 +147,9 @@ SizeDoubleVectorMap GPInstance::GatherBranchLengths() {
 }
 
 void GPInstance::TakeFirstBranchLength() {
-  if (HasEngine()) {
-    GetEngine()->TakeFirstBranchLength(tree_collection_, dag_.BuildEdgeIndexer());
-  } else {
-    Failwith(
-        "Please load and process some trees before calling TakeFirstBranchLength.");
-  }
+  Assert(HasEngine(),
+         "Please load and process some trees before calling TakeFirstBranchLength.");
+  GetEngine()->TakeFirstBranchLength(tree_collection_, dag_.BuildEdgeIndexer());
 }
 
 void GPInstance::PopulatePLVs() { ProcessOperations(dag_.PopulatePLVs()); }

--- a/src/graft_dag.cpp
+++ b/src/graft_dag.cpp
@@ -8,7 +8,8 @@
 
 // ** Constructors
 
-GraftDAG::GraftDAG(SubsplitDAG &dag) : host_dag_(dag) {}
+GraftDAG::GraftDAG(SubsplitDAG &dag)
+    : SubsplitDAG{dag, HostDispatchTag{}}, host_dag_{dag} {}
 
 // ** Comparators
 
@@ -25,14 +26,14 @@ int GraftDAG::Compare(const GraftDAG &lhs, const GraftDAG &rhs) {
     return host_diff;
   }
   // (2) Compare graft nodes.
-  const BitsetVector &lhs_nodes = lhs.GetSortedVectorOfNodeBitsets();
-  const BitsetVector &rhs_nodes = rhs.GetSortedVectorOfNodeBitsets();
+  BitsetVector lhs_nodes = lhs.GetSortedVectorOfNodeBitsets();
+  BitsetVector rhs_nodes = rhs.GetSortedVectorOfNodeBitsets();
   if (lhs_nodes != rhs_nodes) {
     return (lhs_nodes < rhs_nodes) ? -1 : 1;
   }
   // (3) Compare graft edges.
-  const BitsetVector &lhs_edges = lhs.GetSortedVectorOfEdgeBitsets();
-  const BitsetVector &rhs_edges = rhs.GetSortedVectorOfEdgeBitsets();
+  BitsetVector lhs_edges = lhs.GetSortedVectorOfEdgeBitsets();
+  BitsetVector rhs_edges = rhs.GetSortedVectorOfEdgeBitsets();
   if (lhs_edges != rhs_edges) {
     return (lhs_edges < rhs_edges) ? -1 : 1;
   }
@@ -50,14 +51,14 @@ int GraftDAG::CompareToDAG(const GraftDAG &lhs, const SubsplitDAG &rhs) {
     return taxon_diff;
   }
   // Compare nodes.
-  const BitsetVector &lhs_nodes = lhs.GetSortedVectorOfNodeBitsets();
-  const BitsetVector &rhs_nodes = rhs.GetSortedVectorOfNodeBitsets();
+  BitsetVector lhs_nodes = lhs.GetSortedVectorOfNodeBitsets();
+  BitsetVector rhs_nodes = rhs.GetSortedVectorOfNodeBitsets();
   if (lhs_nodes != rhs_nodes) {
     return (lhs_nodes < rhs_nodes) ? -1 : 1;
   }
   // Compare edges.
-  const BitsetVector &lhs_edges = lhs.GetSortedVectorOfEdgeBitsets();
-  const BitsetVector &rhs_edges = rhs.GetSortedVectorOfEdgeBitsets();
+  BitsetVector lhs_edges = lhs.GetSortedVectorOfEdgeBitsets();
+  BitsetVector rhs_edges = rhs.GetSortedVectorOfEdgeBitsets();
   if (lhs_edges != rhs_edges) {
     return (lhs_edges < rhs_edges) ? -1 : 1;
   }
@@ -66,343 +67,48 @@ int GraftDAG::CompareToDAG(const GraftDAG &lhs, const SubsplitDAG &rhs) {
 
 // ** Modify GraftDAG
 
-void GraftDAG::CreateGraftNode(const Bitset &node_subsplit) {
-  // Do not add node to DAG if already exists in DAG.
-  if (ContainsNode(node_subsplit)) {
-    return;
-  }
-  // else, add node to graft node list.
-  const size_t node_id = NodeCount();
-  graft_storage_.AddVertex({node_id, node_subsplit}, HostNodeCount());
-  // insert node into subsplit map.
-  SafeInsert(subsplit_to_id_, node_subsplit, node_id);
-}
-
-void GraftDAG::CreateGraftEdge(const size_t parent_id, const size_t child_id) {
-  // find relationship between nodes.
-  const Bitset &parent_subsplit = GetDAGNode(parent_id).GetBitset();
-  const Bitset &child_subsplit = GetDAGNode(child_id).GetBitset();
-  bool is_left =
-      !Bitset::SubsplitIsChildOfWhichParentClade(parent_subsplit, child_subsplit);
-  CreateGraftEdge(parent_id, child_id, is_left);
-}
-
-void GraftDAG::CreateGraftEdge(const size_t parent_id, const size_t child_id,
-                               const bool is_left) {
-  // Add edge to edge list.
-  Assert(ContainsNode(parent_id), "Node with the given parent_id does not exist.");
-  Assert(ContainsNode(child_id), "Node with the given child_id does not exist.");
-
-  auto parent_node = GetDAGNode(parent_id);
-  auto child_node = GetDAGNode(child_id);
-
-  // Add edge to grafted edges.
-  if (!ContainsEdge(parent_id, child_id)) {
-    const size_t &edge_id = EdgeCount();
-    graft_storage_.AddLine(
-        {edge_id, parent_id, child_id, is_left ? Clade::Left : Clade::Right},
-        edge_id - graft_storage_.GetLines().size());
-    // Add edge to individual SubsplitDAGNodes (only adds them to graft nodes).
-    const bool parent_node_is_in_dag = !IsNodeFromHost(parent_id);
-    const bool child_node_is_in_dag = !IsNodeFromHost(child_id);
-    if (is_left) {
-      if (!parent_node_is_in_dag) {
-        parent_node.AddLeftLeafward(child_node.Id(), edge_id);
-      }
-      if (!child_node_is_in_dag) {
-        child_node.AddLeftRootward(parent_node.Id(), edge_id);
-      }
-    } else {
-      if (!parent_node_is_in_dag) {
-        parent_node.AddRightLeafward(child_node.Id(), edge_id);
-      }
-      if (!child_node_is_in_dag) {
-        child_node.AddRightRootward(parent_node.Id(), edge_id);
-      }
-    }
-  }
-}
-
-void GraftDAG::AddGraftNodePair(const NNIOperation &nni) {
-  return AddGraftNodePair(nni.parent_, nni.child_);
-}
-
-void GraftDAG::AddGraftNodePair(const Bitset &parent_subsplit,
-                                const Bitset &child_subsplit) {
-  Assert(IsValidAddGraftNodePair(parent_subsplit, child_subsplit),
-         "AddGraftNodePair(): Is not valid node pair.");
-  const bool parent_is_new =
-      !(host_dag_.ContainsNode(parent_subsplit) || ContainsGraftNode(parent_subsplit));
-  const bool child_is_new =
-      !(host_dag_.ContainsNode(child_subsplit) || ContainsGraftNode(child_subsplit));
-  // Assert that parent and child don't already exist in the DAG.
-  if (!parent_is_new && !child_is_new) {
-    return;
-  }
-  // Find relationship between nodes.
-  const bool is_left = child_subsplit.SubsplitIsLeftChildOf(parent_subsplit);
-  // Add nodes.
-  if (parent_is_new) {
-    CreateGraftNode(parent_subsplit);
-  }
-  const size_t parent_id = GetDAGNodeId(parent_subsplit);
-  if (child_is_new) {
-    CreateGraftNode(child_subsplit);
-  }
-  const size_t child_id = GetDAGNodeId(child_subsplit);
-  // Find all adjacent host nodes and add edges to fully connect to new graft nodes.
-  if (parent_is_new) {
-    ConnectNodeToHost(parent_id, parent_subsplit, child_id);
-  }
-  if (child_is_new) {
-    ConnectNodeToHost(child_id, child_subsplit, parent_id);
-  }
-  // Connect parent to child.
-  CreateGraftEdge(parent_id, child_id, is_left);
-}
-
-void GraftDAG::RemoveAllGrafts() {
-  graft_storage_ = {};
-  subsplit_to_id_.clear();
-}
-
-void GraftDAG::ConnectNodeToHost(const size_t node_id, const Bitset node_subsplit,
-                                 std::optional<size_t> node_to_ignore) {
-  const auto [left_parents, right_parents] =
-      host_dag_.BuildParentIdVectors(node_subsplit);
-  ConnectNodeToAdjacentHostNodes(node_id, left_parents, false, true, node_to_ignore);
-  ConnectNodeToAdjacentHostNodes(node_id, right_parents, false, false, node_to_ignore);
-  const auto [left_children, right_children] =
-      host_dag_.BuildChildIdVectors(node_subsplit);
-  ConnectNodeToAdjacentHostNodes(node_id, left_children, true, true, node_to_ignore);
-  ConnectNodeToAdjacentHostNodes(node_id, right_children, true, false, node_to_ignore);
-}
-
-void GraftDAG::ConnectNodeToAdjacentHostNodes(
-    const size_t main_node_id, const SizeVector adjacent_node_ids,
-    const bool is_main_node_parent, const bool is_left,
-    std::optional<size_t> ignored_node_id_opt) {
-  for (const auto adjacent_node_id : adjacent_node_ids) {
-    if (ignored_node_id_opt && (adjacent_node_id == *ignored_node_id_opt)) {
-      continue;
-    }
-    const size_t parent_id = (is_main_node_parent ? main_node_id : adjacent_node_id);
-    const size_t child_id = (is_main_node_parent ? adjacent_node_id : main_node_id);
-    CreateGraftEdge(parent_id, child_id, is_left);
-  }
-}
-
-// ** Build Indexers/Vectors
-
-std::pair<SizeVector, SizeVector> GraftDAG::BuildParentIdVectors(
-    const Bitset &subsplit) const {
-  SizeVector left_parents, right_parents;
-  const auto &subsplit_map = host_dag_.GetSubsplitToIdMap();
-  // Linear search for all parents.
-  for (const auto &[potential_parent_subsplit, node_id] : subsplit_map) {
-    if (subsplit.SubsplitIsLeftChildOf(potential_parent_subsplit)) {
-      left_parents.push_back(node_id);
-    } else if (subsplit.SubsplitIsRightChildOf(potential_parent_subsplit)) {
-      right_parents.push_back(node_id);
-    }
-  }
-  return {left_parents, right_parents};
-}
-
-std::pair<SizeVector, SizeVector> GraftDAG::BuildChildIdVectors(
-    const Bitset &subsplit) const {
-  SizeVector left_children, right_children;
-  const auto &subsplit_map = host_dag_.GetSubsplitToIdMap();
-  // Linear search for all parents.
-  for (const auto &[potential_child_subsplit, node_id] : subsplit_map) {
-    if (potential_child_subsplit.SubsplitIsLeftChildOf(subsplit)) {
-      left_children.push_back(node_id);
-    } else if (potential_child_subsplit.SubsplitIsRightChildOf(subsplit)) {
-      right_children.push_back(node_id);
-    }
-  }
-  return {left_children, right_children};
-}
+void GraftDAG::RemoveAllGrafts() { ResetHostDAG(host_dag_); }
 
 // ** Getters
 
 const SubsplitDAG &GraftDAG::GetHostDAG() const { return host_dag_; }
 
-SubsplitDAGNode GraftDAG::GetDAGNode(const size_t node_id) const {
-  Assert(node_id < NodeCount(), "Node Id is out of valid range.");
-  // Check if node is in the host DAG.
-  if (node_id < HostNodeCount()) {
-    return host_dag_.GetDAGNode(node_id);
-  }
-  // else, node is in the graft.
-  return graft_storage_.GetVertices().at(node_id - host_dag_.NodeCount());
-}
-
-MutableSubsplitDAGNode GraftDAG::GetDAGNode(const size_t node_id) {
-  Assert(node_id < NodeCount(), "Node Id is out of valid range.");
-  // Check if node is in the host DAG.
-  if (node_id < HostNodeCount()) {
-    return host_dag_.GetDAGNode(node_id);
-  }
-  // else, node is in the graft.
-  return graft_storage_.GetVertices().at(node_id - host_dag_.NodeCount());
-}
-
-size_t GraftDAG::GetDAGNodeId(const Bitset &node_subsplit) const {
-  // Check if subsplit is in the host DAG.
-  if (host_dag_.ContainsNode(node_subsplit)) {
-    return host_dag_.GetDAGNodeId(node_subsplit);
-  }
-  // Check if subsplit is in the graft.
-  Assert(subsplit_to_id_.find(node_subsplit) != subsplit_to_id_.end(),
-         "GetDAGNodeId(): Subsplit does not correspond to a node in GraftDAG.");
-  return subsplit_to_id_.at(node_subsplit);
-}
-
-size_t GraftDAG::GetDAGRootNodeId() const { return host_dag_.GetDAGRootNodeId(); }
-
-size_t GraftDAG::GetEdgeIdx(const Bitset &parent_subsplit,
-                            const Bitset &child_subsplit) const {
-  const size_t &parent_id = GetDAGNodeId(parent_subsplit);
-  const size_t &child_id = GetDAGNodeId(child_subsplit);
-  size_t edge_idx = 0;
-  if (host_dag_.ContainsEdge(parent_id, child_id)) {
-    host_dag_.GetEdgeIdx(parent_id, child_id);
-  } else {
-    Assert(ContainsGraftEdge(parent_id, child_id),
-           "GraftDAG::GetEdgeIdx(): Edge with given node pair does not exist.");
-    edge_idx = graft_storage_.GetLine(parent_id, child_id).value().GetId();
-  }
-  return edge_idx;
-}
-
-size_t GraftDAG::GetEdgeIdx(const size_t parent_id, const size_t child_id) const {
-  // Check for edge in graft.
-  const auto edge = graft_storage_.GetLine(parent_id, child_id);
-  if (edge.has_value()) {
-    return edge.value().GetId();
-  }
-  // Check for edge in host.
-  Assert(host_dag_.ContainsEdge(parent_id, child_id),
-         "GetEdgeIdx: There is no edge corresponding to given parent/child pair in "
-         "GraftDAG.");
-  return host_dag_.GetEdgeIdx(parent_id, child_id);
-}
-
-BitsetVector GraftDAG::GetSortedVectorOfNodeBitsets(bool include_host) const {
-  BitsetVector nodes;
-  // Get graft node bitsets.
-  for (const auto &subsplit_id_pair : subsplit_to_id_) {
-    nodes.push_back(subsplit_id_pair.first);
-  }
-  // Get host node bitsets.
-  if (include_host) {
-    BitsetVector host_nodes = host_dag_.GetSortedVectorOfNodeBitsets();
-    nodes.insert(nodes.end(), host_nodes.begin(), host_nodes.end());
-  }
-  std::sort(nodes.begin(), nodes.end());
-  return nodes;
-}
-
-BitsetVector GraftDAG::GetSortedVectorOfEdgeBitsets(bool include_host) const {
-  BitsetVector edges;
-  // Get graft edge bitsets.
-  for (const auto &[idpair_idx_pair, edge_idx] : graft_storage_.GetLines()) {
-    std::ignore = edge_idx;
-    const auto &[parent_id, child_id] = idpair_idx_pair;
-    const auto &parent_bitset = GetDAGNode(parent_id).GetBitset();
-    const auto &child_bitset = GetDAGNode(child_id).GetBitset();
-    Bitset edge_bitset = Bitset::PCSP(parent_bitset, child_bitset);
-    edges.push_back(edge_bitset);
-  }
-  // Get host edge bitsets.
-  if (include_host) {
-    BitsetVector host_edges = host_dag_.GetSortedVectorOfEdgeBitsets();
-    edges.insert(edges.end(), host_edges.begin(), host_edges.end());
-  }
-  std::sort(edges.begin(), edges.end());
-
-  return edges;
-}
-
 // ** Counts
 
-size_t GraftDAG::TaxonCount() const { return host_dag_.TaxonCount(); }
-
-size_t GraftDAG::NodeCount() const { return HostNodeCount() + GraftNodeCount(); }
-
-size_t GraftDAG::GraftNodeCount() const { return graft_storage_.GetVertices().size(); }
-
-size_t GraftDAG::HostNodeCount() const { return host_dag_.NodeCount(); }
-
-size_t GraftDAG::EdgeCount() const { return HostEdgeCount() + GraftEdgeCount(); }
-
-size_t GraftDAG::GraftEdgeCount() const { return graft_storage_.GetLines().size(); }
-
-size_t GraftDAG::HostEdgeCount() const {
-  return host_dag_.EdgeCountWithLeafSubsplits();
+size_t GraftDAG::GraftNodeCount() const {
+  return storage_.GetVertices().size() - storage_.HostVerticesCount();
 }
 
+size_t GraftDAG::HostNodeCount() const { return storage_.HostVerticesCount(); }
+
+size_t GraftDAG::GraftEdgeCount() const {
+  return storage_.GetLines().size() - storage_.HostLinesCount();
+}
+
+size_t GraftDAG::HostEdgeCount() const { return storage_.HostLinesCount(); }
+
 bool GraftDAG::IsNodeFromHost(size_t node_id) const {
-  return (node_id < HostNodeCount());
+  return node_id < HostNodeCount();
 }
 
 bool GraftDAG::IsEdgeFromHost(size_t edge_id) const {
-  return (edge_id < HostEdgeCount());
+  return edge_id < HostEdgeCount();
 }
 
 // ** Contains
 
 bool GraftDAG::ContainsGraftNode(const Bitset node_subsplit) const {
-  return subsplit_to_id_.find(node_subsplit) != subsplit_to_id_.end();
+  if (!ContainsNode(node_subsplit)) return false;
+  return !IsNodeFromHost(GetDAGNodeId(node_subsplit));
 }
 
 bool GraftDAG::ContainsGraftNode(const size_t node_id) const {
-  return (node_id >= HostNodeCount()) && (node_id < NodeCount());
-}
-
-bool GraftDAG::ContainsNode(const Bitset node_subsplit) const {
-  return host_dag_.ContainsNode(node_subsplit) || ContainsGraftNode(node_subsplit);
-}
-
-bool GraftDAG::ContainsNode(const size_t node_id) const {
-  return host_dag_.ContainsNode(node_id) || ContainsGraftNode(node_id);
+  if (IsNodeFromHost(node_id)) return false;
+  return ContainsNode(node_id);
 }
 
 bool GraftDAG::ContainsGraftEdge(const size_t parent_id, const size_t child_id) const {
-  return graft_storage_.GetLine(parent_id, child_id, HostNodeCount(), HostEdgeCount())
-      .has_value();
-}
-
-bool GraftDAG::ContainsEdge(const size_t parent_id, const size_t child_id) const {
-  return host_dag_.ContainsEdge(parent_id, child_id) ||
-         ContainsGraftEdge(parent_id, child_id);
-}
-
-// ** Validation Tests
-
-bool GraftDAG::IsValid() const {
-  if (!host_dag_.IsValid()) {
-    return false;
-  }
-  for (size_t i = 0; i < GraftNodeCount(); i++) {
-    const size_t correct_id = HostNodeCount() + i;
-    const auto node = graft_storage_.GetVertices()[i];
-    if (node.Id() != correct_id) {
-      return false;
-    }
-    if (!node.IsValid()) {
-      return false;
-    }
-  }
-  return true;
-}
-
-bool GraftDAG::IsValidAddGraftNodePair(const Bitset parent_subsplit,
-                                       const Bitset child_subsplit) const {
-  // Assert node pair does not already exist in host or graft.
-  if (ContainsNode(parent_subsplit) && ContainsNode(child_subsplit)) {
-    return false;
-  }
-  return host_dag_.IsValidAddNodePair(parent_subsplit, child_subsplit);
+  auto edge = storage_.GetLine(parent_id, child_id);
+  if (!edge.has_value()) return false;
+  return !IsEdgeFromHost(edge.value().GetId());
 }

--- a/src/graft_dag.hpp
+++ b/src/graft_dag.hpp
@@ -10,15 +10,12 @@
 
 #pragma once
 
-class GraftDAG {
+class GraftDAG : public SubsplitDAG {
  public:
   // ** Constructors:
 
   // Initialize empty GraftDAG.
   GraftDAG(SubsplitDAG &dag);
-  // Initialize GraftDAG with an initial graft.
-  GraftDAG(SubsplitDAG &dag, NNIOperation &nni);
-  GraftDAG(SubsplitDAG &dag, Bitset &parent_subsplit, Bitset &child_subsplit);
 
   // ** Comparators
 
@@ -31,57 +28,20 @@ class GraftDAG {
 
   // ** Modify GraftDAG
 
-  // Add node pair to graft.
-  void AddGraftNodePair(const NNIOperation &nni);
-  void AddGraftNodePair(const Bitset &parent_subsplit, const Bitset &child_subsplit);
-
   // Clear all nodes and edges from graft for reuse.
   void RemoveAllGrafts();
-
-  // ** Build Indexers/Vectors
-
-  // Get the left and right parents of the node with the given subsplit.
-  std::pair<SizeVector, SizeVector> BuildParentIdVectors(const Bitset &subsplit) const;
-  // Get the left and right children of the node with the given subsplit.
-  std::pair<SizeVector, SizeVector> BuildChildIdVectors(const Bitset &subsplit) const;
 
   // ** Getters
 
   // Get pointer to the host DAG.
   const SubsplitDAG &GetHostDAG() const;
-  // Get node based on node id.
-  SubsplitDAGNode GetDAGNode(const size_t node_id) const;
-  MutableSubsplitDAGNode GetDAGNode(const size_t node_id);
-  // Get the node id based on the subsplit bitset.
-  size_t GetDAGNodeId(const Bitset &subsplit) const;
-  // Gets the node id of the DAG root.
-  size_t GetDAGRootNodeId() const;
-  // Get the node based on the nodes id.
-  SubsplitDAGNode *GetNode(const size_t node_id) const;
-  // Return the node ids corresponding to the rootsplits.
-  const SizeVector &GetGetRootsplitNodeIds() const;
-  // Get the GPCSP/edge index by its parent/child pair.
-  size_t GetEdgeIdx(const Bitset &parent_subsplit, const Bitset &child_subsplit) const;
-  size_t GetEdgeIdx(const size_t parent_id, const size_t child_id) const;
-  // Get a sorted vector of all node subsplit bitset representation. Optionally only
-  // graft nodes, or graft and host nodes.
-  BitsetVector GetSortedVectorOfNodeBitsets(bool include_host = true) const;
-  // Get a sorted vector of all edge PCSP bitset representation. Optionally only graft
-  // edges, or graft and host edges.
-  BitsetVector GetSortedVectorOfEdgeBitsets(bool include_host = true) const;
 
   // ** Counts
 
-  // Total number of taxa in DAG (same as Subsplit length).
-  size_t TaxonCount() const;
-  // Total number of nodes in full proposed DAG.
-  size_t NodeCount() const;
   // Total number of nodes in graft only.
   size_t GraftNodeCount() const;
   // Total number of nodes in host DAG only.
   size_t HostNodeCount() const;
-  // Total number of edges in full proposed DAG.
-  size_t EdgeCount() const;
   // Total number of edges in graft only.
   size_t GraftEdgeCount() const;
   // Total number of edges in host DAG only.
@@ -93,66 +53,13 @@ class GraftDAG {
 
   // ** Contains
 
-  // Checks whether the node is in the host DAG or the graft.
-  bool ContainsNode(const Bitset node_subsplit) const;
-  bool ContainsNode(const size_t node_id) const;
   // Checks whether the node is in the graft only.
   bool ContainsGraftNode(const Bitset node_subsplit) const;
   bool ContainsGraftNode(const size_t node_id) const;
-  // Checks whether the edge is in the host DAG or the graft.
-  bool ContainsEdge(const size_t parent_id, const size_t child_id) const;
   // Checks whether the edge is in the graft only.
   bool ContainsGraftEdge(const size_t parent_id, const size_t child_id) const;
-
-  // ** Validity Tests
-
-  // Checks if host and graft are in a valid state.
-  // Specifically, checks that:
-  // - Host DAG is in valid state.
-  // - Each node Id corresponds to its array index.
-  // - Each node is valid. That is, either:
-  //    - Node has zero parents and zero children.
-  //    - Node has 1 or more parents, 1 or more right clade children, and 1 or more left
-  //    clade children.
-  // - All GraftDAG node ids are >= HostNodeCount.
-  bool IsValid() const;
-  // Checks if host and graft are in a valid state to add given node pair.
-  // Specifically, check that:
-  // - The nodes are adjacent.
-  // - The nodes do not add/remove any taxa.
-  // - The parent node has at least one parent.
-  // - Including the child node, each clade of the parent node has at least one child.
-  // - Each clade of the child node has at least 1 child.
-  bool IsValidAddGraftNodePair(const Bitset parent_subsplit,
-                               const Bitset child_subsplit) const;
-
- protected:
-  // ** Modify DAG
-  // These modifications do not ensure a valid, consistent state for DAG.
-
-  // Add node to the graft.
-  void CreateGraftNode(const Bitset &node_subsplit);
-  // Add edge to the graft.
-  void CreateGraftEdge(const size_t parent_id, const size_t child_id);
-  // Add edge to the graft (Overload for when edge relation is known).
-  void CreateGraftEdge(const size_t parent_id, const size_t child_id,
-                       const bool is_left);
-  // Connect main node to all adjacent nodes in vector.  `ignored_node_id_opt` provides
-  // the option for one adjacent node that will not be connected.
-  void ConnectNodeToAdjacentHostNodes(
-      const size_t main_node_id, const SizeVector adjacent_node_ids,
-      const bool is_main_node_parent, const bool is_left,
-      std::optional<size_t> ignored_node_id_opt = std::nullopt);
-  // Connect node in graft to all viable nodes in host.
-  void ConnectNodeToHost(const size_t node_id, const Bitset node_subsplit,
-                         std::optional<size_t> node_to_ignore = std::nullopt);
 
  protected:
   // DAG that the graft is proposed to be connected to.
   SubsplitDAG &host_dag_;
-  // Nodes and edges in the graft.
-  SubsplitDAGStorage graft_storage_;
-  // Map of all DAG Nodes:
-  //   - [ Node Subsplit (Bitset) => Node Id ]
-  BitsetSizeMap subsplit_to_id_;
 };

--- a/src/nni_engine.cpp
+++ b/src/nni_engine.cpp
@@ -86,7 +86,7 @@ void NNIEngine::EvaluateAdjacentNNIs() {
 
 void NNIEngine::GraftAdjacentNNIsToDAG() {
   for (const auto &nni : GetAdjacentNNIs()) {
-    graft_dag_->AddGraftNodePair(nni);
+    graft_dag_->AddNodePair(nni);
   }
 }
 

--- a/src/nni_engine.hpp
+++ b/src/nni_engine.hpp
@@ -31,7 +31,7 @@ class NNIEngine {
   // Get Reference of DAG.
   const GPDAG &GetGPDAG() const { return dag_; };
   // Get Reference of GraftDAG.
-  const GraftDAG &GetGraftDAG() const { return *graft_dag_.get(); };
+  GraftDAG &GetGraftDAG() const { return *graft_dag_.get(); };
   // Get Reference of GPEngine.
   const GPEngine &GetGPEngine() const { return gp_engine_; }
   // Get Adjacent NNIs to DAG.

--- a/src/numerical_utils.hpp
+++ b/src/numerical_utils.hpp
@@ -105,6 +105,7 @@ TEST_CASE("NumericalUtils") {
 
   // Here we use volatile to avoid GCC optimizing away the variable.
   volatile double d = 4.;
+  std::ignore = d;
   d /= 0.;
   auto fp_description = NumericalUtils::DescribeFloatingPointEnvironmentExceptions();
   CHECK_EQ(*fp_description,

--- a/src/pybito.cpp
+++ b/src/pybito.cpp
@@ -443,7 +443,9 @@ PYBIND11_MODULE(bito, m) {
            "Return branch lengths from the GPInstance.")
       .def(
           "build_edge_idx_to_pcsp_map",
-          [](GPInstance &self) { return self.GetDAG().BuildEdgeIdxToPCSPBoolVectorMap(); },
+          [](GPInstance &self) {
+            return self.GetDAG().BuildEdgeIdxToPCSPBoolVectorMap();
+          },
           "Build a map from SubsplitDAG edge index to its corresponding PCSP bitset.")
 
       // ** Estimation

--- a/src/subsplit_dag.hpp
+++ b/src/subsplit_dag.hpp
@@ -50,6 +50,8 @@ class SubsplitDAG {
   // Build a Subsplit DAG expressing all tree topologies from tree_collection.
   explicit SubsplitDAG(const RootedTreeCollection &tree_collection);
 
+  SubsplitDAG(const SubsplitDAG &) = default;
+
   // ** Comparator methods:
 
   // This compare ensures that both DAGs have the same topology according to their
@@ -146,9 +148,9 @@ class SubsplitDAG {
   SizePair GetChildEdgeRange(const Bitset &subsplit, const bool rotated) const;
   // Get set of all taxon names.
   std::vector<std::string> GetSortedVectorOfTaxonNames() const;
-  // Get set of all node Subsplit bitsets.
+  // Get sorted vector of all node Subsplit bitsets.
   std::vector<Bitset> GetSortedVectorOfNodeBitsets() const;
-  // Get set of all edge PCSP bitsets.
+  // Get sorted vector of all edge PCSP bitsets.
   std::vector<Bitset> GetSortedVectorOfEdgeBitsets() const;
   // Get reference to taxon map.
   const std::map<std::string, size_t> &GetTaxonMap() const;
@@ -424,6 +426,9 @@ class SubsplitDAG {
   static TagStringMap BuildDummyTagTaxonMap(const size_t taxon_count);
 
  protected:
+  explicit SubsplitDAG(SubsplitDAG &host_dag, HostDispatchTag);
+  void ResetHostDAG(SubsplitDAG &host_dag);
+
   // Builds a vector of subsplits of all children , optionally including leaf nodes.
   std::vector<Bitset> GetChildSubsplits(const SizeBitsetMap &index_to_child,
                                         const Bitset &subsplit,

--- a/test/test_bito.py
+++ b/test/test_bito.py
@@ -162,9 +162,9 @@ def test_sbn_unrooted_instance():
 
 
 def test_gp_instance():
-    """ Tests added functionality for gp_instance """
+    """Tests added functionality for gp_instance."""
     if not os.path.exists("_ignore"):
-      os.makedirs("_ignore")
+        os.makedirs("_ignore")
     inst = bito.gp_instance("_ignore/mmapped_plv_pybito.data")
     inst.read_fasta_file("data/six_taxon.fasta")
     inst.read_newick_file("data/six_taxon_rootsplit.nwk")


### PR DESCRIPTION
## Description

Move the graft node and edge accessing logic to SubsplitDAGStorage, and make GraftDAG inherit from SubsplitDAG. This replaces the previous fragile implementation with Id offsets, and reduces duplication of methods between GraftDAG and SubsplitDAG. 

Closes #417 


## Tests

Added additional testing to TEST_CASE("NNI Engine: GraftDAG").

## Checklist:

* [x] Code follows our detailed [contribution guidelines](CONTRIBUTING.md)
* [x] `clang-format` has been run
* [x] TODOs have been eliminated from the code
* [x] Comments are up to date, document intent, and there are no commented-out code blocks
* [x] GitHub CI build on PR branch completed successfully
