### PR TITLE
GPEngine: Resizing and Reindexing

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,5 @@
 cmake_minimum_required(VERSION 3.19)
+
 project(bito)
 find_package(Python COMPONENTS Interpreter Development)
 set(BITO_VERSION "0.1")
@@ -92,6 +93,7 @@ add_library(bito-core SHARED
   src/phylo_model.cpp
   src/psp_indexer.cpp
   src/quartet_hybrid_request.cpp
+  src/reindexer.cpp
   src/rooted_gradient_transforms.cpp
   src/rooted_sbn_instance.cpp
   src/rooted_tree.cpp

--- a/src/bitset.cpp
+++ b/src/bitset.cpp
@@ -136,7 +136,7 @@ void Bitset::operator|=(const Bitset& other) {
 }
 
 std::ostream& operator<<(std::ostream& os, const Bitset& bitset) {
-  os << bitset.SubsplitToString();
+  os << bitset.ToString();
   return os;
 }
 

--- a/src/eigen_sugar.hpp
+++ b/src/eigen_sugar.hpp
@@ -64,6 +64,20 @@ void CheckVectorXdEquality(double value, const EigenVectorXd v, double tolerance
   }
 };
 
+bool VectorXdEquality(const EigenVectorXd v1, const EigenVectorXd v2,
+                      double tolerance) {
+  if (v1.size() != v2.size()) {
+    return false;
+  }
+  for (Eigen::Index i = 0; i < v1.size(); i++) {
+    double error = fabs(v1[i] - v2[i]);
+    if (error > tolerance) {
+      return false;
+    }
+  }
+  return true;
+};
+
 void CheckVectorXdEquality(const EigenVectorXd v1, const EigenVectorXd v2,
                            double tolerance) {
   CHECK_EQ(v1.size(), v2.size());

--- a/src/gp_dag.cpp
+++ b/src/gp_dag.cpp
@@ -10,7 +10,7 @@ using namespace GPOperations;  // NOLINT
 using PLVType = PLVHandler::PLVType;
 
 size_t GPDAG::GetPLVIndex(PLVType plv_type, size_t node_idx) const {
-  return PLVHandler::GetPLVIndex(plv_type, *this, node_idx);
+  return PLVHandler::GetPLVIndex(plv_type, NodeCountWithoutDAGRoot(), node_idx);
 }
 
 // The R PLV update that corresponds to our rotation status.

--- a/src/gp_instance.hpp
+++ b/src/gp_instance.hpp
@@ -33,6 +33,8 @@ class GPInstance {
   GPEngine *GetEngine() const;
   bool HasEngine() const;
   void PrintEdgeIndexer();
+
+  void ReinitializePriors();
   void ProcessOperations(const GPOperationVector &operations);
   void HotStartBranchLengths();
   SizeDoubleVectorMap GatherBranchLengths();

--- a/src/mmapped_plv.hpp
+++ b/src/mmapped_plv.hpp
@@ -22,6 +22,10 @@ class MmappedNucleotidePLV {
   MmappedNucleotidePLV(const std::string &file_path, Eigen::Index total_plv_length)
       : mmapped_matrix_(file_path, base_count_, total_plv_length){};
 
+  void Resize(Eigen::Index total_plv_length) {
+    mmapped_matrix_.ResizeMMap(base_count_, total_plv_length);
+  }
+
   NucleotidePLVRefVector Subdivide(size_t into_count) {
     Assert(into_count > 0, "into_count is zero in MmappedNucleotidePLV::Subdivide.");
     auto entire_plv = mmapped_matrix_.Get();

--- a/src/nni_engine.cpp
+++ b/src/nni_engine.cpp
@@ -45,7 +45,7 @@ void NNIEngine::RunMainLoop() {
   // (2) Compute marginal likelihoods for each adjacent NNI.
   EvaluateAdjacentNNIs();
   // (3) Select whether to accept or reject adjacent NNIs via filter.
-  FilterAdjacentNNIsToAcceptedNNIs();
+  FilterAdjacentNNIs();
   // (4) Add accepted NNIs to permanent DAG.
   AddAcceptedNNIsToDAG();
 
@@ -115,9 +115,13 @@ void NNIEngine::FilterUpdate() {
   // !ISSUE #405: Need to implement filtering scheme
 }
 
-void NNIEngine::FilterAdjacentNNIsToAcceptedNNIs() {
-  Failwith(
-      "Currently no implementation for NNIEngine::FilterAdjacentNNIsToAcceptedNNIs().");
+bool NNIEngine::NoFilter(NNIEngine &this_nni_engine, GPEngine &this_gp_engine,
+                         const NNIOperation &nni) {
+  return true;
+}
+
+void NNIEngine::FilterAdjacentNNIs() {
+  Failwith("Currently no implementation for NNIEngine::FilterAdjacentNNIs().");
   // !ISSUE #405: Need to implement filtering scheme
 }
 
@@ -260,3 +264,5 @@ void NNIEngine::ClearAdjacentNNIs() {
 }
 
 void NNIEngine::ClearAcceptedNNIs() { accepted_nnis_.clear(); }
+
+void NNIEngine::ClearRejectedNNIs() { rejected_nnis_.clear(); }

--- a/src/nni_engine.hpp
+++ b/src/nni_engine.hpp
@@ -38,8 +38,10 @@ class NNIEngine {
   const NNISet &GetAdjacentNNIs() const { return adjacent_nnis_; };
   // Get Number of Adjacent NNIs.
   size_t GetAdjacentNNICount() const { return adjacent_nnis_.size(); };
-  // Get Accepted NNIs to DAG.
+  // Get All NNIs that have been accepted into the DAG.
   const std::vector<NNIOperation> &GetAcceptedNNIs() const { return accepted_nnis_; };
+  // Get All NNIs that have been rejected from the DAG.
+  const std::vector<NNIOperation> &GetRejectedNNIs() const { return rejected_nnis_; };
   // Get Number of Accepted NNIs.
   size_t GetAcceptedNNICount() const { return accepted_nnis_.size(); };
   // Get Map of Adjacent NNIs with their score.
@@ -74,13 +76,20 @@ class NNIEngine {
 
   // ** Filtering
 
+  // Function template for filtering adjacent NNI to accepted or rejected.
+  using FilterFunction =
+      std::function<bool(NNIEngine &, GPEngine &, const NNIOperation &)>;
+  static bool NoFilter(NNIEngine &this_nni_engine, GPEngine &this_gp_engine,
+                       const NNIOperation &nni);
+
   // Initialize filter before first NNI sweep.
   void FilterInit();
   // Update filter parameters for each NNI sweep.
   void FilterUpdate();
   // Apply the filtering method to determine whether each Adjacent NNI will be accepted
   // or rejected.
-  void FilterAdjacentNNIsToAcceptedNNIs();
+  // Note: default function accepts all.
+  void FilterAdjacentNNIs();
 
   // ** DAG & GPEngine Maintenance
 
@@ -131,6 +140,8 @@ class NNIEngine {
   void ClearAdjacentNNIs();
   // Remove all accepted nnis from list.
   void ClearAcceptedNNIs();
+  // Remove all rejected nnis from list.
+  void ClearRejectedNNIs();
 
  private:
   GPDAG &dag_;
@@ -141,6 +152,8 @@ class NNIEngine {
   NNISet adjacent_nnis_;
   // NNIs which have passed the filtering threshold, to be added to the DAG.
   std::vector<NNIOperation> accepted_nnis_;
+  // NNIs which have failed the filtering threshold, to be added to the DAG.
+  std::vector<NNIOperation> rejected_nnis_;
   // Map of adjacent NNIs to their score.
   std::map<NNIOperation, double> scored_nnis_;
   // Count number of loops executed by engine.

--- a/src/plv_handler.hpp
+++ b/src/plv_handler.hpp
@@ -6,56 +6,87 @@
 
 #pragma once
 
+#include "sugar.hpp"
+
 class PLVHandler {
  public:
   // We store 6 PLVs per subsplit, and index them according to this enum. (See
   // GPEngine::plvs_).
-  static inline const size_t plv_count = 6;
+  static inline const size_t plv_count_ = 6;
   enum class PLVType : size_t {
     P,          // p(s)
     PHatRight,  // phat(s_right)
     PHatLeft,   // phat(s_left)
     RHat,       // rhat(s_right) = rhat(s_left)
     RRight,     // r(s_right)
-    RLeft       // r(s_left)
+    RLeft,      // r(s_left)
   };
+  typedef EnumIterator<PLVType, PLVType::P, PLVType::RLeft> PLVTypeIterator;
 
   // Get the `GPEngine::plvs_` index of given node's given PLV type from DAG with
   // node_count.
   static size_t GetPLVIndex(const PLVType plv_type, const size_t node_count,
                             const size_t node_idx) {
-    size_t plv_type_idx;
-    switch (plv_type) {
-      case PLVType::P:
-        plv_type_idx = 0;
-        break;
-      case PLVType::PHatRight:
-        plv_type_idx = 1;
-        break;
-      case PLVType::PHatLeft:
-        plv_type_idx = 2;
-        break;
-      case PLVType::RHat:
-        plv_type_idx = 3;
-        break;
-      case PLVType::RRight:
-        plv_type_idx = 4;
-        break;
-      case PLVType::RLeft:
-        plv_type_idx = 5;
-        break;
-      default:
-        Failwith("Invalid PLV index requested.");
-    }
-    return (plv_type_idx * node_count) + node_idx;
-  };
-
-  static size_t GetPLVIndex(const PLVType plv_type, const SubsplitDAG &dag,
-                            const size_t node_idx) {
-    return GetPLVIndex(plv_type, dag.NodeCountWithoutDAGRoot(), node_idx);
+    return GetPLVIndex(GetPLVTypeIndex(plv_type), node_count, node_idx);
   };
 
   static PLVType RPLVType(const bool is_on_left) {
     return is_on_left ? PLVType::RLeft : PLVType::RRight;
   };
+
+  static PLVType PPLVType(const bool is_on_left) {
+    return is_on_left ? PLVType::PHatLeft : PLVType::PHatRight;
+  };
+
+  // ** I/O
+
+  static std::string PLVTypeToString(const PLVType plv_type) {
+    return "PLVType::" + std::to_string(GetPLVTypeIndex(plv_type));
+  };
+
+  friend std::ostream &operator<<(std::ostream &os, const PLVType plv_type) {
+    os << PLVTypeToString(plv_type);
+    return os;
+  };
+
+ protected:
+  static size_t GetPLVTypeIndex(const PLVType plv_type) {
+    return static_cast<std::underlying_type<PLVType>::type>(plv_type);
+  };
+
+  static size_t GetPLVIndex(const size_t plv_type_idx, const size_t node_count,
+                            const size_t node_idx) {
+    return (plv_type_idx * node_count) + node_idx;
+  };
 };
+
+#ifdef DOCTEST_LIBRARY_INCLUDED
+
+using PLVType = PLVHandler::PLVType;
+
+// Check that PLV iterator iterates over all PLVs exactly once.
+TEST_CASE("PLVHandler: EnumIterator") {
+  const std::array<PLVType, PLVHandler::plv_count_> plv_types{
+      PLVType::P,    PLVType::PHatRight, PLVType::PHatLeft,
+      PLVType::RHat, PLVType::RRight,    PLVType::RLeft};
+  std::map<PLVType, size_t> plv_visited_map;
+  // Iterate using vector.
+  for (const PLVType plv_type : plv_types) {
+    plv_visited_map.insert({plv_type, 0});
+  }
+  // Iterate using EnumIterator.
+  for (const PLVType plv_type : PLVHandler::PLVTypeIterator()) {
+    CHECK_MESSAGE(plv_visited_map.find(plv_type) != plv_visited_map.end(),
+                  "Iterator has PLV not in plv_vector.");
+    plv_visited_map.at(plv_type) += 1;
+  }
+  // Check that each was visited only once.
+  for (const auto [plv_type, visit_count] : plv_visited_map) {
+    std::ignore = plv_type;
+    CHECK_FALSE_MESSAGE(visit_count < 1, "One or more PLVs skipped by EnumIterator.");
+    CHECK_FALSE_MESSAGE(visit_count > 1,
+                        "One or more PLVs in visited more than once by EnumIterator.");
+  }
+}
+
+#endif  // DOCTEST_LIBRARY_INCLUDED

--- a/src/reindexer.cpp
+++ b/src/reindexer.cpp
@@ -1,0 +1,106 @@
+// Copyright 2019-2022 bito project contributors.
+// bito is free software under the GPLv3; see LICENSE file for details.
+
+#include "reindexer.hpp"
+
+Reindexer Reindexer::IdentityReindexer(const size_t size) {
+  Reindexer reindexer = Reindexer(size);
+  std::iota(reindexer.GetData().begin(), reindexer.GetData().end(), 0);
+  return reindexer;
+}
+
+bool Reindexer::IsValid(std::optional<size_t> length) const {
+  const size_t reindexer_size = (length.has_value() ? length.value() : size());
+  Assert(length <= size(),
+         "Length of reindexer cannot be larger than the vector containing it.");
+  std::vector<bool> already_used(reindexer_size, false);
+  for (size_t idx = 0; idx < reindexer_size; idx++) {
+    if (GetNewIndexByOldIndex(idx) >= reindexer_size ||
+        already_used[GetNewIndexByOldIndex(idx)]) {
+      return false;
+    }
+    already_used[GetNewIndexByOldIndex(idx)] = true;
+  }
+  return true;
+}
+
+// ** Modification Operations
+
+// Gets the inverse of a given reindexer.
+Reindexer Reindexer::InvertReindexer() const {
+  Assert(IsValid(), "Reindexer must be valid in Reindexer::InvertedReindexer.");
+  Reindexer inverted_reindexer(size());
+  for (size_t idx = 0; idx < size(); idx++) {
+    inverted_reindexer.SetReindex(GetNewIndexByOldIndex(idx), idx);
+  }
+  return inverted_reindexer;
+}
+
+Reindexer Reindexer::RemoveOldIndex(const size_t remove_old_idx) {
+  Assert(IsValid(), "Reindexer must be valid in Reindexer::RemoveOldIndex.");
+  Reindexer result_reindexer;
+  result_reindexer.reserve(size() - 1);
+  const size_t remove_new_idx = GetNewIndexByOldIndex(remove_old_idx);
+  for (size_t old_idx = 0; old_idx < size(); old_idx++) {
+    if (old_idx == remove_old_idx) {
+      continue;
+    }
+    const size_t new_idx = GetNewIndexByOldIndex(old_idx);
+    result_reindexer.AppendNewIndex(new_idx - (new_idx > remove_new_idx));
+  }
+  return result_reindexer;
+}
+
+Reindexer Reindexer::RemoveNewIndex(const size_t remove_new_idx) {
+  const size_t remove_old_idx = GetOldIndexByNewIndex(remove_new_idx);
+  return RemoveOldIndex(remove_old_idx);
+}
+
+Reindexer Reindexer::ComposeWith(const Reindexer &apply_reindexer) {
+  Assert(IsValid(), "base_reindexer not valid in Reindexer::ComposeWith.");
+  Assert(apply_reindexer.IsValid(),
+         "apply_reindexer not valid in Reindexer::ComposeWith.");
+  Assert(size_t(size()) <= apply_reindexer.size(),
+         "The base_reindexer cannot be larger than the reindexer it is being "
+         "composed with.");
+  Reindexer result_reindexer(apply_reindexer.size());
+  // Pad base_reindexer if it needs to grow to accept apply_reindexer.
+  for (size_t idx = size(); idx < apply_reindexer.size(); idx++) {
+    AppendNewIndex();
+  }
+  // Reindex.
+  Reindexer inverted_reindexer = InvertReindexer();
+  for (size_t idx = 0; idx < apply_reindexer.size(); idx++) {
+    result_reindexer.SetReindex(inverted_reindexer.GetNewIndexByOldIndex(idx),
+                                apply_reindexer.GetNewIndexByOldIndex(idx));
+  }
+  return result_reindexer;
+}
+
+void Reindexer::ReassignAndShift(const size_t old_id, const size_t new_id) {
+  Assert(old_id < size() && new_id < size(),
+         "The given ids must be within the bounds of the reindexer in "
+         "Reindexer::ReassignAndShift.");
+  Assert(IsValid(), "Reindexer must be valid in Reindexer::ReassignAndShift.");
+  if (old_id == new_id) {
+    return;
+  }
+  // Find position with value old_id.
+  const size_t old_id_position = GetOldIndexByNewIndex(old_id);
+  // Shift.
+  if (old_id > new_id) {
+    for (size_t &id : GetData()) {
+      if (id < old_id && id >= new_id) {
+        id++;
+      }
+    }
+  } else {
+    for (size_t &id : GetData()) {
+      if (id > old_id && id <= new_id) {
+        id--;
+      }
+    }
+  }
+  // Reassign old_id to new_id.
+  SetReindex(old_id_position, new_id);
+}

--- a/src/reindexer.hpp
+++ b/src/reindexer.hpp
@@ -7,11 +7,11 @@
 // correspond the ordering of SubsplitDAG data arrays, such as with the node or edge
 // arrays.
 //
-// A reindexer is a SizeVector that can be thought of as a one-to-one function that maps
-// from an old indexing scheme to a new indexing scheme. In other words, if old index
-// `i` maps to new index `j`, then reindexer[`i`] = `j`. For example, if old_vector =
-// [A, B, C] and reindexer = [1, 2, 0], then new_vector = [C, A, B]. Note that
-// old_vector and reindexer must have the same size.
+// A reindexer is a one-to-one function that maps from an old indexing scheme to a new
+// indexing scheme. In other words, if old index `i` maps to new index `j`, then
+// reindexer.GetNewIndexByOldIndex(`i`) = `j`. This is implemented by an underlying
+// SizeVector.  For example, if old_vector = [A, B, C] and reindexer = [1, 2, 0], then
+// new_vector = [C, A, B]. Note that old_vector and reindexer must have the same size.
 
 #pragma once
 
@@ -20,146 +20,217 @@
 #include "eigen_sugar.hpp"
 #include "sugar.hpp"
 
-// These operations are for working with reindexers.
-namespace Reindexer {
+class Reindexer {
+ public:
+  Reindexer() : data_(){};
+  Reindexer(size_t size) : data_(size){};
+  Reindexer(SizeVector data) : data_(std::move(data)){};
 
-// For each position in a identity reindexer, reindexer[`i`] = `i`.
-// E.g. for size = 5, reindexer = [0, 1, 2, 3, 4].
-inline SizeVector IdentityReindexer(const size_t size) {
-  SizeVector reindexer(size);
-  std::iota(reindexer.begin(), reindexer.end(), 0);
-  return reindexer;
-}
+  // ** Special Constructors
+  // For each position in a identity reindexer, reindexer[`i`] = `i`.
+  // E.g. for size = 5, reindexer = [0, 1, 2, 3, 4].
+  static Reindexer IdentityReindexer(const size_t size);
 
-// Check if a SizeVector is a valid reindexer (contains every index exactly once).
-inline bool IsValidReindexer(const SizeVector &reindexer) {
-  std::vector<bool> already_used(reindexer.size(), false);
-  for (size_t idx = 0; idx < reindexer.size(); idx++) {
-    if (reindexer[idx] >= reindexer.size() || already_used[reindexer[idx]]) {
-      return false;
+  friend bool operator==(const Reindexer &lhs, const Reindexer &rhs) {
+    return lhs.GetData() == rhs.GetData();
+  }
+  friend bool operator!=(const Reindexer &lhs, const Reindexer &rhs) {
+    return lhs.GetData() != rhs.GetData();
+  }
+
+  size_t size() const { return data_.size(); }
+  void reserve(const size_t size) { data_.reserve(size); }
+  void SetReindex(const size_t old_index, const size_t new_index) {
+    data_.at(old_index) = new_index;
+  }
+  // Find mapped new/output index corresponding to given old/input index.
+  size_t GetNewIndexByOldIndex(const size_t old_index) const {
+    return data_.at(old_index);
+  }
+  // Find mapped old/input index corresponding to new/output index.
+  size_t GetOldIndexByNewIndex(const size_t new_index) const {
+    return size_t(std::find(GetData().begin(), GetData().end(), new_index) -
+                  GetData().begin());
+  }
+  // Add new index to end of reindexer.
+  void AppendNewIndex() { data_.push_back(size()); }
+  void AppendNewIndex(const size_t new_index) { data_.push_back(new_index); }
+  // Get underlying index vector from reindexer.
+  const SizeVector &GetData() const { return data_; }
+  SizeVector &GetData() { return data_; }
+
+  // Check if reindexer is in a valid state (contains every index exactly once,
+  // ranging from 0 to reindexer_size - 1).
+  bool IsValid(std::optional<size_t> length = std::nullopt) const;
+
+  // ** Modification Operations
+
+  // Builds new inverse reindexer of a given reindexer, such that input->output becomes
+  // output->input.
+  Reindexer InvertReindexer() const;
+
+  // Builds new reindexer by removing an element identified by its index and shifting
+  // other idx to maintain valid reindexer.
+  Reindexer RemoveOldIndex(const size_t remove_old_idx);
+  Reindexer RemoveNewIndex(const size_t remove_new_idx);
+
+  // Builds a reindexer composing apply_reindexer onto a base_reindexer. Resulting
+  // reindexer contains both reindexing operations combined.
+  Reindexer ComposeWith(const Reindexer &apply_reindexer);
+
+  // In a given reindexer, take the old_id in the reindexer and reassign it to the
+  // new_id and shift over the ids strictly between old_id and new_id to ensure that the
+  // reindexer remains valid. For example if old_id = 1 and new_id = 4, this method
+  // would shift 1 -> 4, 4 -> 3, 3 -> 2, and 2 -> 1.
+  void ReassignAndShift(const size_t old_id, const size_t new_id);
+
+  // ** Apply Operations
+
+  // Reindexes the given data vector according to the reindexer.
+  template <typename VectorType>
+  static VectorType Reindex(VectorType &old_vector, const Reindexer &reindexer,
+                            std::optional<size_t> length = std::nullopt) {
+    size_t reindex_size = (length.has_value() ? length.value() : old_vector.size());
+    Assert(
+        size_t(old_vector.size()) >= reindex_size,
+        "The vector must be at least as long as reindex_size in Reindexer::Reindex.");
+    Assert(size_t(reindexer.size()) >= reindex_size,
+           "The reindexer must be at least as long as reindex_size in "
+           "Reindexer::Reindex.");
+    Assert(reindexer.IsValid(reindex_size),
+           "Reindexer must be valid in Reindexer::Reindex.");
+    VectorType new_vector(old_vector.size());
+    // Data to reindex.
+    for (size_t idx = 0; idx < reindex_size; idx++) {
+      new_vector[reindexer.GetNewIndexByOldIndex(idx)] = std::move(old_vector[idx]);
     }
-    already_used[reindexer[idx]] = true;
-  }
-  return true;
-}
+    // Data to copy over.
+    for (size_t idx = reindex_size; idx < size_t(new_vector.size()); idx++) {
+      new_vector[idx] = std::move(old_vector[idx]);
+    }
+    return new_vector;
+  };
 
-// Reindexes the given vector according to the reindexer.
-template <typename VectorType>
-inline VectorType Reindex(VectorType &old_vector, const SizeVector &reindexer) {
-  Assert(IsValidReindexer(reindexer), "Reindexer must be valid in Reindexer::Reindex.");
-  Assert(old_vector.size() == reindexer.size(),
-         "The vector and reindexer must have the same size in Reindexer::Reindex.");
-  VectorType new_vector(reindexer.size());
-  for (size_t idx = 0; idx < old_vector.size(); idx++) {
-    new_vector[reindexer[idx]] = std::move(old_vector[idx]);
-  }
-  return new_vector;
-}
+  // Reindexes the given data vector concatenated with additional data values.
+  template <typename VectorType>
+  static VectorType Reindex(VectorType &old_vector, const Reindexer &reindexer,
+                            VectorType &additional_values) {
+    Assert(reindexer.IsValid(), "Reindexer must be valid in Reindexer::Reindex.");
+    Assert(old_vector.size() + additional_values.size() ==
+               static_cast<Eigen::Index>(reindexer.size()),
+           "Size of the vector and additional values must add up to the reindexer size "
+           "in Reindexer::Reindex.");
+    VectorType new_vector(reindexer.size());
+    // Data to reindex.
+    for (Eigen::Index idx = 0; idx < old_vector.size(); idx++) {
+      new_vector[reindexer.GetNewIndexByOldIndex(idx)] = std::move(old_vector[idx]);
+    }
+    // Data to copy over.
+    for (Eigen::Index idx = 0; idx < additional_values.size(); idx++) {
+      new_vector[reindexer.GetNewIndexByOldIndex(old_vector.size() + idx)] =
+          std::move(additional_values[idx]);
+    }
+    return new_vector;
+  };
 
-// Reindexes the given vector concatenated with some additional values.
-template <typename VectorType>
-inline VectorType Reindex(VectorType &old_vector, const SizeVector &reindexer,
-                          VectorType &additional_values) {
-  Assert(IsValidReindexer(reindexer), "Reindexer must be valid in Reindexer::Reindex.");
-  Assert(old_vector.size() + additional_values.size() ==
-             static_cast<Eigen::Index>(reindexer.size()),
-         "Size of the vector and additional values must add up to the reindexer size "
-         "in Reindexer::Reindex.");
-  VectorType new_vector(reindexer.size());
-  for (Eigen::Index idx = 0; idx < old_vector.size(); idx++) {
-    new_vector[reindexer[idx]] = std::move(old_vector[idx]);
-  }
-  for (Eigen::Index idx = 0; idx < additional_values.size(); idx++) {
-    new_vector[reindexer[old_vector.size() + idx]] = std::move(additional_values[idx]);
-  }
-  return new_vector;
-}
-
-// Gets the inverse of a given reindexer.
-inline SizeVector InvertReindexer(const SizeVector &reindexer) {
-  Assert(IsValidReindexer(reindexer),
-         "Reindexer must be valid in Reindexer::InvertReindexer.");
-  SizeVector inverted_reindexer(reindexer.size());
-  for (size_t idx = 0; idx < reindexer.size(); idx++) {
-    inverted_reindexer[reindexer[idx]] = idx;
-  }
-  return inverted_reindexer;
-}
-
-// Remaps each of the ids in the vector according to the reindexer.
-template <typename Target, typename Reindexer>
-inline void RemapIdVector(Target &&vector, const Reindexer &reindexer) {
-  Assert(IsValidReindexer(reindexer),
-         "Reindexer must be valid in Reindexer::RemapIdVector.");
-  for (size_t id : vector) {
-    Assert(id < reindexer.size(),
-           "The vector cannot contain an id out of bounds of the reindexer in "
-           "Reindexer::RemapIdVector.");
-  }
-  std::transform(vector.begin(), vector.end(), vector.begin(),
-                 [reindexer](size_t id) { return reindexer[id]; });
-}
-
-// In a given reindexer, take the old_id in the reindexer and reassign it to the new_id
-// and shift over the ids strictly between old_id and new_id to ensure that the
-// reindexer remains valid. For example if old_id = 1 and new_id = 4, this method would
-// shift 1 -> 4, 4 -> 3, 3 -> 2, and 2 -> 1.
-inline void ReassignAndShift(SizeVector &reindexer, const size_t old_id,
-                             const size_t new_id) {
-  Assert(old_id < reindexer.size() && new_id < reindexer.size(),
-         "The given ids must be within the bounds of the reindexer in "
-         "Reindexer::ReassignAndShift.");
-  Assert(IsValidReindexer(reindexer),
-         "Reindexer must be valid in Reindexer::ReassignAndShift.");
-  if (old_id == new_id) {
-    return;
-  }
-  // Find position with value old_id.
-  const size_t old_id_position =
-      std::find(reindexer.begin(), reindexer.end(), old_id) - reindexer.begin();
-  // Shift.
-  if (old_id > new_id) {
-    for (size_t &id : reindexer) {
-      if (id < old_id && id >= new_id) {
-        id++;
+  // Reindex data vector in-place. Expects VectorType to have `operator[]` accessor and
+  // `size()`.
+  template <typename VectorType, typename DataType>
+  static void ReindexInPlace(VectorType &data_vector, const Reindexer &reindexer,
+                             size_t length, DataType &temp1, DataType &temp2) {
+    Assert(size_t(data_vector.size()) >= length,
+           "data_vector wrong size for Reindexer::ReindexInPlace.");
+    Assert(size_t(reindexer.size()) >= length,
+           "reindexer wrong size for Reindexer::ReindexInPlace.");
+    BoolVector updated_idx = BoolVector(length, false);
+    for (size_t i = 0; i < length; i++) {
+      size_t old_idx = i;
+      size_t new_idx = reindexer.GetNewIndexByOldIndex(i);
+      if (old_idx == new_idx) {
+        updated_idx[old_idx] = true;
+        continue;
+      }
+      // Because reindexing is one-to-one function, starting at any given index in the
+      // the vector, if we follow the chain of remappings from each old index to its new
+      // index, we will eventually form a cycle that returns to the initial old index.
+      // This avoid allocating a second data array to perform the reindex, as only two
+      // temporary values are needed. Only a boolean array is needed to check for
+      // already updated indexes.
+      bool is_current_node_updated = updated_idx[new_idx];
+      temp1 = data_vector[old_idx];
+      while (is_current_node_updated == false) {
+        // copy data at old_idx to new_idx, and store data at new_idx in temporary.
+        temp2 = data_vector[new_idx];
+        data_vector[new_idx] = temp1;
+        temp1 = temp2;
+        // update to next idx in cycle.
+        updated_idx[new_idx] = true;
+        old_idx = new_idx;
+        new_idx = reindexer.GetNewIndexByOldIndex(old_idx);
+        is_current_node_updated = updated_idx[new_idx];
       }
     }
-  } else {
-    for (size_t &id : reindexer) {
-      if (id > old_id && id <= new_id) {
-        id--;
-      }
-    }
-  }
-  // Reassign old_id to new_id.
-  reindexer[old_id_position] = new_id;
-}
+  };
 
-}  // namespace Reindexer
+  // Reindex id vector. Expects VectorType to have `operator[]` accessor and
+  // `size()`.
+  template <typename VectorType, typename DataType>
+  static void ReindexInPlace(VectorType &data_vector, const Reindexer &reindexer,
+                             size_t length) {
+    DataType temp1, temp2;
+    Reindexer::ReindexInPlace(data_vector, reindexer, length, temp1, temp2);
+  }
+
+  // Remaps each of the ids in the vector according to the reindexer.
+  template <typename VectorType>
+  static void RemapIdVector(VectorType &&vector, const Reindexer &reindexer) {
+    Assert(reindexer.IsValid(), "Reindexer must be valid in Reindexer::RemapIdVector.");
+    for (size_t id : vector) {
+      Assert(id < reindexer.size(),
+             "The vector cannot contain an id out of bounds of the reindexer in "
+             "Reindexer::RemapIdVector.");
+    }
+    std::transform(vector.begin(), vector.end(), vector.begin(),
+                   [reindexer](size_t old_idx) {
+                     return reindexer.GetNewIndexByOldIndex(old_idx);
+                   });
+  };
+
+  // ** I/O
+
+  friend std::ostream &operator<<(std::ostream &os, const Reindexer &reindexer) {
+    os << reindexer.GetData();
+    return os;
+  };
+
+ private:
+  SizeVector data_;
+};
 
 #ifdef DOCTEST_LIBRARY_INCLUDED
-TEST_CASE("IdentityReindexer") {
+TEST_CASE("Reindexer: IdentityReindexer") {
   // Check that IdentityReindexer returns correctly.
-  SizeVector correct_default{0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
+  Reindexer correct_default({0, 1, 2, 3, 4, 5, 6, 7, 8, 9});
   CHECK_EQ(correct_default, Reindexer::IdentityReindexer(10));
 }
 
 TEST_CASE("IsValidReindexer") {
   // Index appears more than once.
-  CHECK(!Reindexer::IsValidReindexer({1, 3, 0, 0}));
-  // Missing an index.
-  CHECK(!Reindexer::IsValidReindexer({1, 3, 4, 2}));
+  CHECK_FALSE(Reindexer({1, 3, 0, 0}).IsValid());
+  // Missing an index and/or index is out of range.
+  CHECK_FALSE(Reindexer({1, 3, 4, 2}).IsValid());
   // Valid reindexer.
-  CHECK(Reindexer::IsValidReindexer({1, 3, 0, 2}));
+  CHECK(Reindexer({1, 3, 0, 2}).IsValid());
 }
 
-TEST_CASE("Reindex") {
-  // Check that Reindex throws if the given vector and reindexer have different sizes.
+TEST_CASE("Reindexer: Reindex") {
+  // Check that Reindex throws if the given vector and reindexer have different
+  // sizes.
   SizeVector old_size_vector{7, 8, 9};
-  SizeVector reindexer{2, 0, 3, 1};
+  Reindexer reindexer({2, 0, 3, 1});
   CHECK_THROWS(Reindexer::Reindex(old_size_vector, reindexer));
   // Check that Reindex returns correctly.
-  reindexer = {2, 0, 1};
+  reindexer = Reindexer({2, 0, 1});
   SizeVector new_size_vector = Reindexer::Reindex(old_size_vector, reindexer);
   SizeVector correct_new_size_vector{8, 9, 7};
   CHECK_EQ(new_size_vector, correct_new_size_vector);
@@ -168,7 +239,7 @@ TEST_CASE("Reindex") {
   old_eigen_vector << 7, 8, 9;
   EigenVectorXd additional_values(2);
   additional_values << 10, 11;
-  reindexer = {2, 4, 0, 3, 1};
+  reindexer = Reindexer({2, 4, 0, 3, 1});
   EigenVectorXd new_eigen_vector =
       Reindexer::Reindex(old_eigen_vector, reindexer, additional_values);
   EigenVectorXd correct_new_eigen_vector(5);
@@ -176,53 +247,68 @@ TEST_CASE("Reindex") {
   CHECK_EQ(new_eigen_vector, correct_new_eigen_vector);
 }
 
-TEST_CASE("InvertReindexer") {
+TEST_CASE("Reindexer: InvertReindexer") {
   // Check that inverting a vector twice results in the original vector.
-  SizeVector reindexer{1, 3, 0, 2};
-  SizeVector correct_inverted_reindexer{2, 0, 3, 1};
-  SizeVector inverted_reindexer = Reindexer::InvertReindexer(reindexer);
+  Reindexer reindexer({1, 3, 0, 2});
+  Reindexer correct_inverted_reindexer({2, 0, 3, 1});
+  Reindexer inverted_reindexer = reindexer.InvertReindexer();
   CHECK_EQ(inverted_reindexer, correct_inverted_reindexer);
-  SizeVector correct_reindexer{1, 3, 0, 2};
-  reindexer = Reindexer::InvertReindexer(inverted_reindexer);
+  Reindexer correct_reindexer = Reindexer({1, 3, 0, 2});
+  reindexer = inverted_reindexer.InvertReindexer();
   CHECK_EQ(reindexer, correct_reindexer);
 }
 
-TEST_CASE("RemapIdVector") {
+TEST_CASE("Reindexer: RemapIdVector") {
   // Check that Reindex throws if the given vector has an index out of bounds of the
   // reindexer.
   SizeVector size_vector{3, 5};
-  SizeVector reindexer{2, 0, 3, 1};
+  Reindexer reindexer({2, 0, 3, 1});
   CHECK_THROWS(Reindexer::RemapIdVector(size_vector, reindexer));
   // Check that RemapIdVector returns correctly.
   size_vector = {3, 5};
-  reindexer = {2, 0, 3, 1, 6, 4, 5};
+  reindexer = Reindexer({2, 0, 3, 1, 6, 4, 5});
   Reindexer::RemapIdVector(size_vector, reindexer);
-  SizeVector correct_size_vector{1, 4};
+  SizeVector correct_size_vector = {1, 4};
   CHECK_EQ(size_vector, correct_size_vector);
 }
 
-TEST_CASE("ReassignAndShift") {
+TEST_CASE("Reindexer: ReassignAndShift") {
   // Check that ReassignAndShift returns correctly when old_id > new_id.
-  SizeVector reindexer{0, 1, 2, 3, 4, 5, 6};
-  Reindexer::ReassignAndShift(reindexer, 4, 1);
-  SizeVector correct_reindexer{0, 2, 3, 4, 1, 5, 6};
+  Reindexer reindexer({0, 1, 2, 3, 4, 5, 6});
+  reindexer.ReassignAndShift(4, 1);
+  Reindexer correct_reindexer({0, 2, 3, 4, 1, 5, 6});
   CHECK_EQ(reindexer, correct_reindexer);
-  Reindexer::ReassignAndShift(reindexer, 5, 2);
-  correct_reindexer = {0, 3, 4, 5, 1, 2, 6};
+  reindexer.ReassignAndShift(5, 2);
+  correct_reindexer = Reindexer({0, 3, 4, 5, 1, 2, 6});
   CHECK_EQ(reindexer, correct_reindexer);
-  Reindexer::ReassignAndShift(reindexer, 1, 3);
-  correct_reindexer = {0, 2, 4, 5, 3, 1, 6};
+  reindexer.ReassignAndShift(1, 3);
+  correct_reindexer = Reindexer({0, 2, 4, 5, 3, 1, 6});
   CHECK_EQ(reindexer, correct_reindexer);
   // Check that ReassignAndShift returns correctly when old_id = new_id.
-  reindexer = {1, 0, 4, 6, 5, 3, 2};
-  Reindexer::ReassignAndShift(reindexer, 4, 4);
-  correct_reindexer = {1, 0, 4, 6, 5, 3, 2};
+  reindexer = Reindexer({1, 0, 4, 6, 5, 3, 2});
+  reindexer.ReassignAndShift(4, 4);
+  correct_reindexer = Reindexer({1, 0, 4, 6, 5, 3, 2});
   CHECK_EQ(reindexer, correct_reindexer);
   // Check that ReassignAndShift returns correctly when old_id < new_id.
-  reindexer = {6, 0, 4, 1, 5, 3, 2};
-  Reindexer::ReassignAndShift(reindexer, 1, 5);
-  correct_reindexer = {6, 0, 3, 5, 4, 2, 1};
+  reindexer = Reindexer({6, 0, 4, 1, 5, 3, 2});
+  reindexer.ReassignAndShift(1, 5);
+  correct_reindexer = Reindexer({6, 0, 3, 5, 4, 2, 1});
   CHECK_EQ(reindexer, correct_reindexer);
+}
+
+TEST_CASE("Reindexer: ComposeWith") {
+  // Check that identity reindexer composed with a second reindexer results in that
+  // reindexer.
+  Reindexer identity_reindexer, inverted_reindexer, pairswap_reindexer,
+      composed_reindexer, correct_reindexer;
+  identity_reindexer = Reindexer::IdentityReindexer(6);
+  inverted_reindexer = Reindexer({5, 4, 3, 2, 1, 0});
+  pairswap_reindexer = Reindexer({1, 0, 3, 2, 5, 4});
+  composed_reindexer = identity_reindexer;
+  composed_reindexer = composed_reindexer.ComposeWith(inverted_reindexer);
+  composed_reindexer = composed_reindexer.ComposeWith(pairswap_reindexer);
+  correct_reindexer = Reindexer({4, 5, 2, 3, 0, 1});
+  CHECK_EQ(composed_reindexer, correct_reindexer);
 }
 
 #endif  // DOCTEST_LIBRARY_INCLUDED

--- a/src/subsplit_dag_node.hpp
+++ b/src/subsplit_dag_node.hpp
@@ -138,15 +138,24 @@ class GenericSubsplitDAGNode {
     return rotated ? GetLeftRootward() : GetRightRootward();
   }
 
-  // After modifying parent DAG.
-  void RemapNodeIds(const SizeVector node_reindexer) {
-    Assert(Reindexer::IsValidReindexer(node_reindexer),
+  // Remap node ids modifying parent DAG.
+  void RemapNodeIds(const Reindexer& node_reindexer) {
+    Assert(node_reindexer.IsValid(),
            "Reindexer must be valid in GenericSubsplitDAGNode::RemapNodeIds.");
-    node_.SetId(node_reindexer.at(node_.GetId()));
-    node_.GetNeighbors(Direction::Leafward, Clade::Left).RemapIds(node_reindexer);
-    node_.GetNeighbors(Direction::Leafward, Clade::Right).RemapIds(node_reindexer);
-    node_.GetNeighbors(Direction::Rootward, Clade::Left).RemapIds(node_reindexer);
-    node_.GetNeighbors(Direction::Rootward, Clade::Right).RemapIds(node_reindexer);
+    node_.SetId(node_reindexer.GetNewIndexByOldIndex(node_.GetId()));
+    node_.GetNeighbors(Direction::Leafward, Clade::Left).RemapNodeIds(node_reindexer);
+    node_.GetNeighbors(Direction::Leafward, Clade::Right).RemapNodeIds(node_reindexer);
+    node_.GetNeighbors(Direction::Rootward, Clade::Left).RemapNodeIds(node_reindexer);
+    node_.GetNeighbors(Direction::Rootward, Clade::Right).RemapNodeIds(node_reindexer);
+  }
+  // Remap edge ids after modifying parent DAG.
+  void RemapEdgeIdxs(const Reindexer& edge_reindexer) {
+    Assert(edge_reindexer.IsValid(),
+           "Reindexer must be valid in GenericSubsplitDAGNode::RemapNodeIds.");
+    node_.GetNeighbors(Direction::Leafward, Clade::Left).RemapEdgeIdxs(edge_reindexer);
+    node_.GetNeighbors(Direction::Leafward, Clade::Right).RemapEdgeIdxs(edge_reindexer);
+    node_.GetNeighbors(Direction::Rootward, Clade::Left).RemapEdgeIdxs(edge_reindexer);
+    node_.GetNeighbors(Direction::Rootward, Clade::Right).RemapEdgeIdxs(edge_reindexer);
   }
 
   std::optional<std::tuple<LineId, Direction, Clade>> FindNeighbor(VertexId id) {

--- a/src/subsplit_dag_storage.hpp
+++ b/src/subsplit_dag_storage.hpp
@@ -198,7 +198,7 @@ class GenericNeighborsView {
   size_t size() const { return neighbors_.size(); }
   bool empty() const { return neighbors_.empty(); }
 
-  void RemapIds(const SizeVector& reindexer) {
+  void RemapNodeIds(const Reindexer& reindexer) {
     for (auto [vertex_id, line_id] : neighbors_) {
       std::ignore = line_id;
       Assert(vertex_id < reindexer.size(),
@@ -207,7 +207,21 @@ class GenericNeighborsView {
     }
     T remapped{};
     for (auto [vertex_id, line_id] : neighbors_) {
-      remapped[reindexer.at(vertex_id)] = line_id;
+      remapped[reindexer.GetNewIndexByOldIndex(vertex_id)] = line_id;
+    }
+    neighbors_ = remapped;
+  }
+
+  void RemapEdgeIdxs(const Reindexer& reindexer) {
+    for (auto [vertex_id, line_id] : neighbors_) {
+      std::ignore = vertex_id;
+      Assert(line_id < reindexer.size(),
+             "Neighbors cannot contain an id out of bounds of the reindexer in "
+             "GenericNeighborsView::RemapIds.");
+    }
+    T remapped{};
+    for (auto [vertex_id, line_id] : neighbors_) {
+      remapped[vertex_id] = reindexer.GetNewIndexByOldIndex(line_id);
     }
     neighbors_ = remapped;
   }

--- a/src/sugar.hpp
+++ b/src/sugar.hpp
@@ -18,7 +18,10 @@
 // Put typedefs that are built of STL types here.
 using Tag = uint64_t;
 using SymbolVector = std::vector<int>;
+using BoolVector = std::vector<bool>;
+using IntVector = std::vector<int>;
 using SizeVector = std::vector<size_t>;
+using DoubleVector = std::vector<double>;
 using SizeVectorVector = std::vector<SizeVector>;
 using DoubleVectorVector = std::vector<std::vector<double>>;
 using TagDoubleMap = std::unordered_map<Tag, double>;
@@ -39,6 +42,7 @@ using SizeDoubleMap = std::unordered_map<size_t, double>;
 using SizeDoubleVectorMap = std::unordered_map<size_t, std::vector<double>>;
 using DoublePair = std::pair<double, double>;
 using SizePair = std::pair<size_t, size_t>;
+using SizePairVector = std::vector<std::pair<size_t, size_t>>;
 using SizeOptionVector = std::vector<std::optional<size_t>>;
 
 inline uint32_t MaxLeafIDOfTag(Tag tag) { return UnpackFirstInt(tag); }
@@ -136,3 +140,26 @@ std::unordered_map<Key, T> UnorderedMapOf(const std::vector<std::pair<Key, T>> &
   }
   return m;
 }
+
+// Generic Iterator for enum class types.
+// Requires that enum's underlying types have no gaps.
+template <typename EnumType, EnumType FirstEnum, EnumType LastEnum>
+class EnumIterator {
+  typedef typename std::underlying_type<EnumType>::type val_t;
+  int val;
+
+ public:
+  EnumIterator(const EnumType &f) : val(static_cast<val_t>(f)) {}
+  EnumIterator() : val(static_cast<val_t>(FirstEnum)) {}
+  EnumIterator operator++() {
+    ++val;
+    return *this;
+  }
+  EnumType operator*() { return static_cast<EnumType>(val); }
+  EnumIterator begin() { return *this; }  // default ctor is good
+  EnumIterator end() {
+    static const EnumIterator endIter = ++EnumIterator(LastEnum);  // cache it
+    return endIter;
+  }
+  bool operator!=(const EnumIterator &i) { return val != i.val; }
+};

--- a/src/tidy_subsplit_dag.cpp
+++ b/src/tidy_subsplit_dag.cpp
@@ -17,11 +17,19 @@ TidySubsplitDAG::TidySubsplitDAG(size_t taxon_count,
                                  const Node::TopologyCounter &topology_counter,
                                  const TagStringMap &tag_taxon_map)
     : SubsplitDAG(taxon_count, topology_counter, tag_taxon_map) {
+  ReinitializeTidyVectors();
+}
+
+void TidySubsplitDAG::ReinitializeTidyVectors() {
   auto node_count = NodeCount();
-  above_rotated_ = EigenMatrixXb::Identity(node_count, node_count);
-  above_sorted_ = EigenMatrixXb::Identity(node_count, node_count);
-  dirty_rotated_ = EigenArrayXb::Zero(node_count);
-  dirty_sorted_ = EigenArrayXb::Zero(node_count);
+  above_rotated_.resize(node_count, node_count);
+  above_rotated_.setIdentity();
+  above_sorted_.resize(node_count, node_count);
+  above_sorted_.setIdentity();
+  dirty_rotated_.resize(node_count);
+  dirty_rotated_.setZero();
+  dirty_sorted_.resize(node_count);
+  dirty_sorted_.setZero();
 
   SubsplitDAG::DepthFirstWithAction(
       {GetDAGRootNodeId()}, SubsplitDAGTraversalAction(

--- a/src/tidy_subsplit_dag.hpp
+++ b/src/tidy_subsplit_dag.hpp
@@ -19,6 +19,9 @@ class TidySubsplitDAG : public SubsplitDAG {
   TidySubsplitDAG();
   explicit TidySubsplitDAG(const RootedTreeCollection &tree_collection);
 
+  // Initialize tidy vectors for after initialization or modification of DAG.
+  void ReinitializeTidyVectors();
+
   // What nodes are above or below the specified node? We consider a node to be both
   // above and below itself (this just happens to be handy for the implementation).
   EigenArrayXb BelowNode(size_t node_id);


### PR DESCRIPTION
## Description

- Resize GPEngine
  - Adds methods for resizing the GPEngine according to the SubsplitDAG's node and edge counts.  Reallocates space in PLV mmap using a doubling scheme.

- Reindex GPEngine
  - Updates to DAG Storage for proper edge-reindexing of DAGNode neighbors.
  - Add methods for reindexing the GPEngine according to the node_reindexer and edge_reindexer that result from SubsplitDAG's AddNodePair function.
  
- Other
  - Change reindexer from a namespace to full class.
  - Add method for reinitializing priors for GPEngine after DAG modification.
  - Add method for reinitializing tidy vector for TidySubsplitDAG after DAG modification.

Closes #404
Closes #364 


## Tests

- TEST_CASE("GPEngine: Resize and Reindexing") 
  - Tests GPEngine by adding a series of NNIs to the DAG.  First populates the GPEngine's PLVs and branch lengths.  After each node pair is added, GPEngine resizes when necessary, reindexes PLVs and other node-based data according to DAG's node_reindexer, and reindexes branch lengths and other edge-based data according to the DAG's edge_reindexer.  Then tests whether node-based data maps to the same node bitset and edge-base data maps to the same edge bitset.  Finally, runs a full GP optimization on GPInstance.


## Checklist:

* [x] Code follows our detailed [contribution guidelines](CONTRIBUTING.md)
* [x] `clang-format` has been run
* [x] TODOs have been eliminated from the code
* [x] Comments are up to date, document intent, and there are no commented-out code blocks
* [x] Issue branch has been squashed and rebased on main branch
* [ ] GitHub CI build on PR branch completed successfully
