### PR TITLE
Sampling conditional on a subsplit #304

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -107,6 +107,7 @@ add_library(bito-core SHARED
   src/substitution_model.cpp
   src/taxon_name_munging.cpp
   src/tidy_subsplit_dag.cpp
+  src/topology_sampler.cpp
   src/tree.cpp
   src/tree_collection.cpp
   src/unrooted_sbn_instance.cpp

--- a/src/gp_doctest.cpp
+++ b/src/gp_doctest.cpp
@@ -13,6 +13,7 @@
 #include "tidy_subsplit_dag.hpp"
 #include "nni_engine.hpp"
 #include "plv_handler.hpp"
+#include "topology_sampler.hpp"
 
 using namespace GPOperations;  // NOLINT
 

--- a/src/subsplit_dag_node.hpp
+++ b/src/subsplit_dag_node.hpp
@@ -111,6 +111,10 @@ class GenericSubsplitDAGNode {
     }
   }
 
+  ConstNeighborsView GetNeighbors(Direction direction, Clade clade) const {
+    return node_.GetNeighbors(direction, clade);
+  }
+
   void AddEdge(size_t adjacent_node_id, LineId edge_id, Direction which_direction,
                Clade which_clade) {
     node_.AddNeighbor(which_direction, which_clade, adjacent_node_id, edge_id);

--- a/src/subsplit_dag_storage.hpp
+++ b/src/subsplit_dag_storage.hpp
@@ -267,6 +267,16 @@ class DAGVertex {
     return neighbors_.at({direction, clade});
   }
 
+  bool IsRoot() const {
+    return GetNeighbors(Direction::Rootward, Clade::Left).empty() &&
+           GetNeighbors(Direction::Rootward, Clade::Right).empty();
+  }
+
+  bool IsLeaf() const {
+    return GetNeighbors(Direction::Leafward, Clade::Left).empty() &&
+           GetNeighbors(Direction::Leafward, Clade::Right).empty();
+  }
+
   std::optional<std::tuple<LineId, Direction, Clade>> FindNeighbor(
       VertexId neighbor) const {
     for (auto i : neighbors_) {

--- a/src/subsplit_dag_storage.hpp
+++ b/src/subsplit_dag_storage.hpp
@@ -182,22 +182,22 @@ class GenericNeighborsView {
  public:
   class Iterator : public std::iterator<std::forward_iterator_tag, VertexId> {
    public:
-    Iterator(const iterator_type& i, map_type& map) : i_{i}, map_{map} {}
+    Iterator(const iterator_type& i, map_type& map) : iter_{i}, map_{map} {}
 
     Iterator operator++() {
-      ++i_;
+      ++iter_;
       return *this;
     }
-    bool operator!=(const Iterator& other) const { return i_ != other.i_; }
-    bool operator==(const Iterator& other) const { return i_ == other.i_; }
+    bool operator!=(const Iterator& other) const { return iter_ != other.iter_; }
+    bool operator==(const Iterator& other) const { return iter_ == other.iter_; }
 
-    VertexId operator*() { return i_->first; }
+    VertexId operator*() { return iter_->first; }
 
-    VertexId GetNodeId() const { return i_->first; }
-    LineId GetEdge() const { return i_->second; }
+    VertexId GetNodeId() const { return iter_->first; }
+    LineId GetEdge() const { return iter_->second; }
 
    private:
-    iterator_type i_;
+    iterator_type iter_;
     map_type& map_;
   };
 
@@ -599,12 +599,12 @@ class SubsplitDAGStorage {
     vertices_.ResetHost(&host.vertices_);
   }
 
-  void ConnectVertices(LineId lineId) {
-    auto& line = lines_.at(lineId);
+  void ConnectVertices(LineId line_id) {
+    auto& line = lines_.at(line_id);
     auto& parent = vertices_.at(line.GetParent());
     auto& child = vertices_.at(line.GetChild());
-    parent.AddNeighbor(Direction::Leafward, line.GetClade(), child.GetId(), lineId);
-    child.AddNeighbor(Direction::Rootward, line.GetClade(), parent.GetId(), lineId);
+    parent.AddNeighbor(Direction::Leafward, line.GetClade(), child.GetId(), line_id);
+    child.AddNeighbor(Direction::Rootward, line.GetClade(), parent.GetId(), line_id);
   }
 
   void ConnectAllVertices() {

--- a/src/subsplit_dag_storage.hpp
+++ b/src/subsplit_dag_storage.hpp
@@ -42,9 +42,12 @@ enum class Clade { Unspecified, Left, Right };
 
 inline Clade Opposite(Clade clade) {
   switch (clade) {
-  case Clade::Left: return Clade::Right;
-  case Clade::Right: return Clade::Left;
-  default: Failwith("Use of unspecified clade");
+    case Clade::Left:
+      return Clade::Right;
+    case Clade::Right:
+      return Clade::Left;
+    default:
+      Failwith("Use of unspecified clade");
   }
 }
 
@@ -189,7 +192,7 @@ class GenericNeighborsView {
     bool operator==(const Iterator& other) const { return i_ == other.i_; }
 
     VertexId operator*() { return i_->first; }
-    
+
     VertexId GetNodeId() const { return i_->first; }
     LineId GetEdge() const { return i_->second; }
 
@@ -303,10 +306,10 @@ class DAGVertex {
 
   void ClearNeighbors() {
     neighbors_ = {
-      {{Direction::Rootward, Clade::Left}, {}},
-      {{Direction::Rootward, Clade::Right}, {}},
-      {{Direction::Leafward, Clade::Left}, {}},
-      {{Direction::Leafward, Clade::Right}, {}},
+        {{Direction::Rootward, Clade::Left}, {}},
+        {{Direction::Rootward, Clade::Right}, {}},
+        {{Direction::Leafward, Clade::Left}, {}},
+        {{Direction::Leafward, Clade::Right}, {}},
     };
   }
 
@@ -523,9 +526,7 @@ class SubsplitDAGStorage {
     return line;
   }
 
-  const DAGVertex& GetVertex(VertexId id) const {
-    return vertices_.at(id);
-  }
+  const DAGVertex& GetVertex(VertexId id) const { return vertices_.at(id); }
 
   bool ContainsVertex(VertexId id) const {
     if (id >= vertices_.size()) return false;
@@ -626,8 +627,8 @@ class SubsplitDAGStorage {
       }
       if (vertex.GetNeighbors(Direction::Rootward, Clade::Left).empty() &&
           vertex.GetNeighbors(Direction::Rootward, Clade::Right).empty()) {
-            return vertex;
-          }
+        return vertex;
+      }
     }
     return std::nullopt;
   }

--- a/src/topology_sampler.cpp
+++ b/src/topology_sampler.cpp
@@ -116,13 +116,13 @@ Node::NodePtr TopologySampler::BuildTree(SamplingSession& session,
                       BuildTree(session, session.result_.GetVertex(right_id)),
                       node.GetId());
   }
-  if (left_id != NoId) {
+  if (node.IsLeaf()) {
+    return Node::Leaf(node.GetId());
+  }
+  if (node.IsRoot()) {
+    Assert(left_id != NoId, "Root has no children");
     return Node::Join({BuildTree(session, session.result_.GetVertex(left_id))},
                       node.GetId());
   }
-  if (right_id != NoId) {
-    return Node::Join({BuildTree(session, session.result_.GetVertex(right_id))},
-                      node.GetId());
-  }
-  return Node::Leaf(node.GetId());
+  Failwith("Node can't have only one child");
 }

--- a/src/topology_sampler.cpp
+++ b/src/topology_sampler.cpp
@@ -1,0 +1,121 @@
+// Copyright 2019-2021 bito project contributors.
+// bito is free software under the GPLv3; see LICENSE file for details.
+
+#include "topology_sampler.hpp"
+
+Node::NodePtr TopologySampler::Sample(SubsplitDAGNode node, SubsplitDAG& dag,
+    EigenConstVectorXdRef normalized_sbn_parameters, EigenConstVectorXdRef inverted_probabilities) {
+  SamplingSession session{dag, normalized_sbn_parameters, inverted_probabilities};
+  session.result_.AddVertex({node.Id(), node.GetBitset()});
+  SampleRootward(session, node);
+  SampleLeafward(session, node, Clade::Left);
+  SampleLeafward(session, node, Clade::Right);
+  session.result_.ConnectAllVertices();
+  auto root = session.result_.FindRoot();
+  if (!root.has_value()) Failwith("No root found");
+  return BuildTree(session, root.value().get());
+}
+
+void TopologySampler::SetSeed(uint64_t seed) { mersenne_twister_.SetSeed(seed); }
+
+void TopologySampler::VisitNode(SamplingSession& session, SubsplitDAGNode node, Direction direction, Clade clade) {
+  session.result_.AddVertex({node.Id(), node.GetBitset()});
+  switch (direction) {
+    case Direction::Rootward:
+      SampleLeafward(session, node, Clade::Left);
+      SampleLeafward(session, node, Clade::Right);
+      break;
+    case Direction::Leafward:
+      SampleRootward(session, node);
+      SampleLeafward(session, node, Opposite(clade));
+      break;
+  }
+}
+
+void TopologySampler::SampleRootward(SamplingSession& session, SubsplitDAGNode node) {
+  auto left = node.GetLeftRootward();
+  auto right = node.GetRightRootward();
+  if (left.empty() && right.empty()) {
+    // reached root
+    return;
+  }
+  auto parent = SampleParent(session, left, right);
+  session.result_.AddLine({parent.second.GetId(), parent.second.GetParent(), parent.second.GetChild(), parent.second.GetClade()});
+  VisitNode(session, parent.first, Direction::Leafward, parent.second.GetClade());
+}
+
+void TopologySampler::SampleLeafward(SamplingSession& session, SubsplitDAGNode node, Clade clade) {
+  auto neighbors = node.GetNeighbors(Direction::Leafward, clade);
+  if (neighbors.empty()) {
+    // reached leaf
+    return;
+  }
+  auto child = SampleChild(session, neighbors);
+  session.result_.AddLine({child.second.GetId(), child.second.GetParent(), child.second.GetChild(), child.second.GetClade()});
+  VisitNode(session, child.first, Direction::Rootward, clade);
+}
+
+std::pair<SubsplitDAGNode, ConstLineView> TopologySampler::SampleParent(SamplingSession& session, ConstNeighborsView left, ConstNeighborsView right) {
+  std::vector<double> weights;
+  weights.resize(left.size() + right.size());
+  size_t i = 0;
+  for (auto parent = left.begin(); parent != left.end(); ++parent)
+    weights[i++] = session.inverted_probabilities_[parent.GetEdge()];
+  for (auto parent = right.begin(); parent != right.end(); ++parent)
+    weights[i++] = session.inverted_probabilities_[parent.GetEdge()];
+  std::discrete_distribution<> distribution(weights.begin(), weights.end());
+  i = static_cast<size_t>(distribution(mersenne_twister_.GetGenerator()));
+  if (i < left.size()) {
+    auto parent = left.begin();
+    std::advance(parent, i);
+    return {session.dag_.GetDAGNode(parent.GetNodeId()), session.dag_.GetDAGEdge(parent.GetEdge())};
+  }
+  auto parent = right.begin();
+  std::advance(parent, i - left.size());
+  return {session.dag_.GetDAGNode(parent.GetNodeId()), session.dag_.GetDAGEdge(parent.GetEdge())};
+}
+
+std::pair<SubsplitDAGNode, ConstLineView> TopologySampler::SampleChild(SamplingSession& session, ConstNeighborsView neighbors) {
+  std::vector<double> weights;
+  weights.resize(neighbors.size());
+  size_t i = 0;
+  for (auto child = neighbors.begin(); child != neighbors.end(); ++child)
+    weights[i++] = session.normalized_sbn_parameters_[child.GetEdge()];
+  std::discrete_distribution<> distribution(weights.begin(), weights.end());
+  i = static_cast<size_t>(distribution(mersenne_twister_.GetGenerator()));
+  auto child = neighbors.begin();
+  std::advance(child, i);
+  return {session.dag_.GetDAGNode(child.GetNodeId()), session.dag_.GetDAGEdge(child.GetEdge())};
+}
+
+Node::NodePtr TopologySampler::BuildTree(SamplingSession& session, const DAGVertex& node) {
+  auto left = node.GetNeighbors(Direction::Leafward, Clade::Left);
+  auto right = node.GetNeighbors(Direction::Leafward, Clade::Right);
+  VertexId left_id = NoId, right_id = NoId;
+  if (!left.empty()) {
+    left_id = left.begin().GetNodeId();
+  }
+  if (!right.empty()) {
+    right_id = right.begin().GetNodeId();
+  }
+  if (left_id != NoId && right_id != NoId) {
+    return Node::Join(
+      BuildTree(session, session.result_.GetVertex(left_id)),
+      BuildTree(session, session.result_.GetVertex(right_id)),
+      node.GetId()
+    );
+  }
+  if (left_id != NoId) {
+    return Node::Join(
+      {BuildTree(session, session.result_.GetVertex(left_id))},
+      node.GetId()
+    );
+  }
+  if (right_id != NoId) {
+    return Node::Join(
+      {BuildTree(session, session.result_.GetVertex(right_id))},
+      node.GetId()
+    );
+  }
+  return Node::Leaf(node.GetId());
+}

--- a/src/topology_sampler.hpp
+++ b/src/topology_sampler.hpp
@@ -1,6 +1,13 @@
 // Copyright 2019-2021 bito project contributors.
 // bito is free software under the GPLv3; see LICENSE file for details.
 
+// A class that samples one tree topology per call to the Sample() function.
+// The parameters are as follows:
+//   node - a node to start sampling for
+//   dag - the SubsplitDAG that owns "node"
+//   normalized_sbn_parameters - edge probabilities for leafward sampling
+//   inverted_probabilities - edge probabilities for rootward sampling
+
 #pragma once
 
 #include "subsplit_dag.hpp"
@@ -9,10 +16,13 @@
 
 class TopologySampler {
  public:
+  // Sample a single tree from the DAG according to the provided edge
+  // probabilities.
   Node::NodePtr Sample(SubsplitDAGNode node, SubsplitDAG& dag,
                        EigenConstVectorXdRef normalized_sbn_parameters,
                        EigenConstVectorXdRef inverted_probabilities);
 
+  // Set a seed value for the internal random number generator.
   void SetSeed(uint64_t seed);
 
  private:
@@ -23,15 +33,25 @@ class TopologySampler {
     SubsplitDAGStorage result_;
   };
 
+  // Called for each newly sampled node. Direction and clade are pointing to the
+  // previously visited node. 
   void VisitNode(SamplingSession& session, SubsplitDAGNode node, Direction direction,
                  Clade clade);
+  // Continue sampling in the rootward direction from "node".
   void SampleRootward(SamplingSession& session, SubsplitDAGNode node);
+  // Continue sampling in the leafward direction and specified "clade" from "node".
   void SampleLeafward(SamplingSession& session, SubsplitDAGNode node, Clade clade);
+  // Choose a parent node (and return it with the corresponding edge) according to
+  // the values in "inverted_probabilities".
   std::pair<SubsplitDAGNode, ConstLineView> SampleParent(SamplingSession& session,
                                                          ConstNeighborsView left,
                                                          ConstNeighborsView right);
+  // Choose a child node among the "neighbors" clade according to the values
+  // in "normalized_sbn_parameters".
   std::pair<SubsplitDAGNode, ConstLineView> SampleChild(SamplingSession& session,
                                                         ConstNeighborsView neighbors);
+  // Construct a Node topology from a successful sampling. Recursion is started
+  // by passing the root node.
   Node::NodePtr BuildTree(SamplingSession& session, const DAGVertex& node);
 
   MersenneTwister mersenne_twister_;

--- a/src/topology_sampler.hpp
+++ b/src/topology_sampler.hpp
@@ -1,0 +1,62 @@
+// Copyright 2019-2021 bito project contributors.
+// bito is free software under the GPLv3; see LICENSE file for details.
+
+#pragma once
+
+#include "subsplit_dag.hpp"
+#include "node.hpp"
+#include "mersenne_twister.hpp"
+
+class TopologySampler {
+ public:
+
+  Node::NodePtr Sample(SubsplitDAGNode node,
+    SubsplitDAG& dag,
+    EigenConstVectorXdRef normalized_sbn_parameters,
+    EigenConstVectorXdRef inverted_probabilities);
+
+  void SetSeed(uint64_t seed);
+
+ private:
+
+  struct SamplingSession {
+    SubsplitDAG& dag_;
+    EigenConstVectorXdRef normalized_sbn_parameters_;
+    EigenConstVectorXdRef inverted_probabilities_;
+    SubsplitDAGStorage result_;
+  };
+
+  void VisitNode(SamplingSession& session, SubsplitDAGNode node, Direction direction, Clade clade);
+  void SampleRootward(SamplingSession& session, SubsplitDAGNode node);
+  void SampleLeafward(SamplingSession& session, SubsplitDAGNode node, Clade clade);
+  std::pair<SubsplitDAGNode, ConstLineView> SampleParent(SamplingSession& session, ConstNeighborsView left, ConstNeighborsView right);
+  std::pair<SubsplitDAGNode, ConstLineView> SampleChild(SamplingSession& session, ConstNeighborsView neighbors);
+  Node::NodePtr BuildTree(SamplingSession& session, const DAGVertex& node);
+
+  MersenneTwister mersenne_twister_;
+};
+
+#ifdef DOCTEST_LIBRARY_INCLUDED
+
+TEST_CASE("TopologySampler") {
+  Driver driver;
+  auto tree_collection = RootedTreeCollection::OfTreeCollection(
+      driver.ParseNewickFile("data/five_taxon_rooted.nwk"));
+  SubsplitDAG dag(tree_collection);
+
+  MersenneTwister mersenne_twister;
+  std::uniform_int_distribution<> distribution(0, dag.TaxonCount());
+  auto leaf = dag.GetDAGNode(distribution(mersenne_twister.GetGenerator()));
+
+  EigenVectorXd normalized_sbn_parameters = dag.BuildUniformOnTopologicalSupportPrior();
+  EigenVectorXd node_probabilities =
+      dag.UnconditionalNodeProbabilities(normalized_sbn_parameters);
+  EigenVectorXd inverted_probabilities =
+      dag.InvertedGPCSPProbabilities(normalized_sbn_parameters, node_probabilities);
+
+  TopologySampler sampler;
+  auto tree = sampler.Sample(leaf, dag, normalized_sbn_parameters, inverted_probabilities);
+  std::ignore = tree;
+}
+
+#endif  // DOCTEST_LIBRARY_INCLUDED

--- a/src/topology_sampler.hpp
+++ b/src/topology_sampler.hpp
@@ -9,16 +9,13 @@
 
 class TopologySampler {
  public:
-
-  Node::NodePtr Sample(SubsplitDAGNode node,
-    SubsplitDAG& dag,
-    EigenConstVectorXdRef normalized_sbn_parameters,
-    EigenConstVectorXdRef inverted_probabilities);
+  Node::NodePtr Sample(SubsplitDAGNode node, SubsplitDAG& dag,
+                       EigenConstVectorXdRef normalized_sbn_parameters,
+                       EigenConstVectorXdRef inverted_probabilities);
 
   void SetSeed(uint64_t seed);
 
  private:
-
   struct SamplingSession {
     SubsplitDAG& dag_;
     EigenConstVectorXdRef normalized_sbn_parameters_;
@@ -26,11 +23,15 @@ class TopologySampler {
     SubsplitDAGStorage result_;
   };
 
-  void VisitNode(SamplingSession& session, SubsplitDAGNode node, Direction direction, Clade clade);
+  void VisitNode(SamplingSession& session, SubsplitDAGNode node, Direction direction,
+                 Clade clade);
   void SampleRootward(SamplingSession& session, SubsplitDAGNode node);
   void SampleLeafward(SamplingSession& session, SubsplitDAGNode node, Clade clade);
-  std::pair<SubsplitDAGNode, ConstLineView> SampleParent(SamplingSession& session, ConstNeighborsView left, ConstNeighborsView right);
-  std::pair<SubsplitDAGNode, ConstLineView> SampleChild(SamplingSession& session, ConstNeighborsView neighbors);
+  std::pair<SubsplitDAGNode, ConstLineView> SampleParent(SamplingSession& session,
+                                                         ConstNeighborsView left,
+                                                         ConstNeighborsView right);
+  std::pair<SubsplitDAGNode, ConstLineView> SampleChild(SamplingSession& session,
+                                                        ConstNeighborsView neighbors);
   Node::NodePtr BuildTree(SamplingSession& session, const DAGVertex& node);
 
   MersenneTwister mersenne_twister_;
@@ -41,7 +42,6 @@ class TopologySampler {
 TEST_CASE("TopologySampler") {
   Driver driver;
   auto tree_collection = RootedTreeCollection::OfTreeCollection(
-      // driver.ParseNewickFile("data/five_taxon_rooted.nwk"));
       driver.ParseNewickFile("data/five_taxon_rooted_more_2.nwk"));
   SubsplitDAG dag(tree_collection);
 
@@ -58,7 +58,8 @@ TEST_CASE("TopologySampler") {
   const size_t iterations = 10000;
 
   for (size_t i = 0; i < iterations; ++i) {
-    auto tree = sampler.Sample(origin, dag, normalized_sbn_parameters, inverted_probabilities);
+    auto tree =
+        sampler.Sample(origin, dag, normalized_sbn_parameters, inverted_probabilities);
     ++counts[tree->Newick([](const Node* node) {
       if (!node->IsLeaf()) return std::string();
       return std::string("x") + std::to_string(node->Id());
@@ -70,6 +71,48 @@ TEST_CASE("TopologySampler") {
     const double expected = 1.0 / 3.0;
     std::cout << i.first << " : " << observed << "\n";
     CHECK_LT(fabs(observed - expected), 5e-2);
+  }
+}
+
+TEST_CASE("TopologySampler: Non-uniform prior") {
+  Driver driver;
+  auto tree_collection = RootedTreeCollection::OfTreeCollection(
+      driver.ParseNewickFile("data/five_taxon_rooted_more_2.nwk"));
+  SubsplitDAG dag(tree_collection);
+
+  std::vector<double> params{0.5, 0.3, 0.2, 1.0, 1.0, 1.0, 1.0, 1.0,
+                             0.8, 0.2, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0,
+                             1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0};
+  EigenVectorXd normalized_sbn_parameters =
+      EigenVectorXd::Map(params.data(), params.size());
+  EigenVectorXd node_probabilities =
+      dag.UnconditionalNodeProbabilities(normalized_sbn_parameters);
+  EigenVectorXd inverted_probabilities =
+      dag.InvertedGPCSPProbabilities(normalized_sbn_parameters, node_probabilities);
+
+  SubsplitDAGNode origin = dag.GetDAGNode(5);
+
+  TopologySampler sampler;
+  std::map<std::string, size_t> counts;
+  std::map<std::string, double> expected = {
+      {"((((x0,x1),x2),(x3,x4)));", 0.312},
+      {"(((x0,x1),(x2,(x3,x4))));", 0.52},
+      {"((x0,(x1,(x2,(x3,x4)))));", 0.1666},
+  };
+  const size_t iterations = 10000;
+
+  for (size_t i = 0; i < iterations; ++i) {
+    auto tree =
+        sampler.Sample(origin, dag, normalized_sbn_parameters, inverted_probabilities);
+    ++counts[tree->Newick([](const Node* node) {
+      if (!node->IsLeaf()) return std::string();
+      return std::string("x") + std::to_string(node->Id());
+    })];
+  }
+
+  for (auto& i : counts) {
+    const double observed = static_cast<double>(i.second) / iterations;
+    CHECK_LT(fabs(observed - expected[i.first]), 5e-2);
   }
 }
 

--- a/src/topology_sampler.hpp
+++ b/src/topology_sampler.hpp
@@ -1,4 +1,4 @@
-// Copyright 2019-2021 bito project contributors.
+// Copyright 2019-2022 bito project contributors.
 // bito is free software under the GPLv3; see LICENSE file for details.
 
 // A class that samples one tree topology per call to the Sample() function.
@@ -34,22 +34,21 @@ class TopologySampler {
   };
 
   // Called for each newly sampled node. Direction and clade are pointing to the
-  // previously visited node. 
+  // previously visited node.
   void VisitNode(SamplingSession& session, SubsplitDAGNode node, Direction direction,
                  Clade clade);
-  // Continue sampling in the rootward direction from "node".
+  // Continue sampling in the rootward direction from `node`.
   void SampleRootward(SamplingSession& session, SubsplitDAGNode node);
-  // Continue sampling in the leafward direction and specified "clade" from "node".
+  // Continue sampling in the leafward direction and specified `clade` from `node`.
   void SampleLeafward(SamplingSession& session, SubsplitDAGNode node, Clade clade);
   // Choose a parent node (and return it with the corresponding edge) according to
-  // the values in "inverted_probabilities".
-  std::pair<SubsplitDAGNode, ConstLineView> SampleParent(SamplingSession& session,
-                                                         ConstNeighborsView left,
-                                                         ConstNeighborsView right);
-  // Choose a child node among the "neighbors" clade according to the values
-  // in "normalized_sbn_parameters".
-  std::pair<SubsplitDAGNode, ConstLineView> SampleChild(SamplingSession& session,
-                                                        ConstNeighborsView neighbors);
+  // the values in `inverted_probabilities`.
+  std::pair<SubsplitDAGNode, ConstLineView> SampleParentNodeAndEdge(
+      SamplingSession& session, ConstNeighborsView left, ConstNeighborsView right);
+  // Choose a child node among the `neighbors` clade according to the values
+  // in `normalized_sbn_parameters`.
+  std::pair<SubsplitDAGNode, ConstLineView> SampleChildNodeAndEdge(
+      SamplingSession& session, ConstNeighborsView neighbors);
   // Construct a Node topology from a successful sampling. Recursion is started
   // by passing the root node.
   Node::NodePtr BuildTree(SamplingSession& session, const DAGVertex& node);
@@ -89,7 +88,6 @@ TEST_CASE("TopologySampler") {
   for (auto& i : counts) {
     const double observed = static_cast<double>(i.second) / iterations;
     const double expected = 1.0 / 3.0;
-    std::cout << i.first << " : " << observed << "\n";
     CHECK_LT(fabs(observed - expected), 5e-2);
   }
 }
@@ -130,9 +128,9 @@ TEST_CASE("TopologySampler: Non-uniform prior") {
     })];
   }
 
-  for (auto& i : counts) {
-    const double observed = static_cast<double>(i.second) / iterations;
-    CHECK_LT(fabs(observed - expected[i.first]), 5e-2);
+  for (auto& [tree, count] : counts) {
+    const double observed = static_cast<double>(count) / iterations;
+    CHECK_LT(fabs(observed - expected[tree]), 5e-2);
   }
 }
 


### PR DESCRIPTION
## Description

Added a new class (TopologySampler) that is able to sample a random tree out of a SubsplitDAG.

Closes #304 


## Tests

Two tests cover the functionality:
- "TopologySampler"
- "TopologySampler: Non-uniform prior"


## Checklist:

* [x] Code follows our detailed [contribution guidelines](CONTRIBUTING.md)
* [x] `clang-format` has been run
* [x] TODOs have been eliminated from the code
* [x] Comments are up to date, document intent, and there are no commented-out code blocks
* [x] Issue branch has been squashed and rebased on main branch
* [x] GitHub CI build on PR branch completed successfully
