### PR TITLE
NNI Engine: Add Filtering Scheme

### DIFF
--- a/extras/reps_and_likelihoods.cpp
+++ b/extras/reps_and_likelihoods.cpp
@@ -6,12 +6,11 @@
 #include "reps_and_likelihoods.hpp"
 
 int main(int argc, char *argv[]) {
-  if (argc <= 3 || argc % 2 !=0) {
-    std::cout
-        << "We need at least 3 arguments: fasta, rooted_nwk, and repr_out_path." 
-        << std::endl
-        << "Additional arguments must come in pairs: extra_rooted_nwk, "
-        << "extra_repr_out_path." << std::endl;
+  if (argc <= 3 || argc % 2 != 0) {
+    std::cout << "We need at least 3 arguments: fasta, rooted_nwk, and repr_out_path."
+              << std::endl
+              << "Additional arguments must come in pairs: extra_rooted_nwk, "
+              << "extra_repr_out_path." << std::endl;
     abort();
   }
   std::string fasta_path = argv[1];
@@ -19,9 +18,9 @@ int main(int argc, char *argv[]) {
   std::string out_path = argv[3];
   std::vector<std::string> extra_nwk_paths;
   std::vector<std::string> extra_out_paths;
-  for (int arg_index = 4; arg_index < argc; arg_index+=2) {
+  for (int arg_index = 4; arg_index < argc; arg_index += 2) {
     extra_nwk_paths.push_back(argv[arg_index]);
-    extra_out_paths.push_back(argv[arg_index+1]);
+    extra_out_paths.push_back(argv[arg_index + 1]);
   }
   const auto extras_count = extra_nwk_paths.size();
   auto thread_count = std::thread::hardware_concurrency();
@@ -32,18 +31,17 @@ int main(int argc, char *argv[]) {
   all_trees_gp_inst.MakeEngine();
   all_trees_gp_inst.TakeFirstBranchLength();
   std::vector<RootedSBNInstance> extra_r_insts;
-  for (size_t i=0; i<extras_count; i++) {
-    extra_r_insts.push_back( RootedSBNInstance("extra_trees"+std::to_string(i)) );
+  for (size_t i = 0; i < extras_count; i++) {
+    extra_r_insts.push_back(RootedSBNInstance("extra_trees" + std::to_string(i)));
     extra_r_insts.at(i).ReadNewickFile(extra_nwk_paths.at(i));
   }
 
   const auto taxa_order = all_trees_gp_inst.GetTaxonNames();
   for (const auto &r_inst : extra_r_insts) {
-    if (r_inst.tree_collection_.TaxonNames() != taxa_order)
-    {
-    std::cout << "The first tree of each newick file must have the taxa appearing in "
-      << "the same order. Insert a dummy tree if needed." << std::endl;
-    abort();
+    if (r_inst.tree_collection_.TaxonNames() != taxa_order) {
+      std::cout << "The first tree of each newick file must have the taxa appearing in "
+                << "the same order. Insert a dummy tree if needed." << std::endl;
+      abort();
     }
   }
 
@@ -59,11 +57,10 @@ int main(int argc, char *argv[]) {
   const auto log_likelihoods = ur_inst.UnrootedLogLikelihoods(all_trees);
   WriteTreesToFile(out_path, all_representations, log_likelihoods);
 
-  for (size_t i=0; i<extras_count; i++) {
+  for (size_t i = 0; i < extras_count; i++) {
     WriteTreesToFile(
-      extra_out_paths.at(i),
-      GetIndexerRepresentations( extra_r_insts.at(i).tree_collection_, indexer ) 
-    ); 
+        extra_out_paths.at(i),
+        GetIndexerRepresentations(extra_r_insts.at(i).tree_collection_, indexer));
   }
 }
 

--- a/src/graft_dag.cpp
+++ b/src/graft_dag.cpp
@@ -23,14 +23,14 @@ int GraftDAG::Compare(const GraftDAG &lhs, const GraftDAG &rhs) {
     return host_diff;
   }
   // (2) Compare graft nodes.
-  BitsetVector lhs_nodes = lhs.GetSortedVectorOfNodeBitsets();
-  BitsetVector rhs_nodes = rhs.GetSortedVectorOfNodeBitsets();
+  BitsetVector lhs_nodes = lhs.BuildSortedVectorOfNodeBitsets();
+  BitsetVector rhs_nodes = rhs.BuildSortedVectorOfNodeBitsets();
   if (lhs_nodes != rhs_nodes) {
     return (lhs_nodes < rhs_nodes) ? -1 : 1;
   }
   // (3) Compare graft edges.
-  BitsetVector lhs_edges = lhs.GetSortedVectorOfEdgeBitsets();
-  BitsetVector rhs_edges = rhs.GetSortedVectorOfEdgeBitsets();
+  BitsetVector lhs_edges = lhs.BuildSortedVectorOfEdgeBitsets();
+  BitsetVector rhs_edges = rhs.BuildSortedVectorOfEdgeBitsets();
   if (lhs_edges != rhs_edges) {
     return (lhs_edges < rhs_edges) ? -1 : 1;
   }
@@ -48,14 +48,14 @@ int GraftDAG::CompareToDAG(const GraftDAG &lhs, const SubsplitDAG &rhs) {
     return taxon_diff;
   }
   // Compare nodes.
-  BitsetVector lhs_nodes = lhs.GetSortedVectorOfNodeBitsets();
-  BitsetVector rhs_nodes = rhs.GetSortedVectorOfNodeBitsets();
+  BitsetVector lhs_nodes = lhs.BuildSortedVectorOfNodeBitsets();
+  BitsetVector rhs_nodes = rhs.BuildSortedVectorOfNodeBitsets();
   if (lhs_nodes != rhs_nodes) {
     return (lhs_nodes < rhs_nodes) ? -1 : 1;
   }
   // Compare edges.
-  BitsetVector lhs_edges = lhs.GetSortedVectorOfEdgeBitsets();
-  BitsetVector rhs_edges = rhs.GetSortedVectorOfEdgeBitsets();
+  BitsetVector lhs_edges = lhs.BuildSortedVectorOfEdgeBitsets();
+  BitsetVector rhs_edges = rhs.BuildSortedVectorOfEdgeBitsets();
   if (lhs_edges != rhs_edges) {
     return (lhs_edges < rhs_edges) ? -1 : 1;
   }

--- a/src/nni_engine.cpp
+++ b/src/nni_engine.cpp
@@ -112,9 +112,7 @@ bool NNIEngine::FilterPostNNIBetterThanPreNNI(NNIEngine &this_nni_engine,
                                               const NNIOperation &nni) {
   const double postnni_likelihood = this_nni_engine.GetPostNNILikelihood(nni);
   const double prenni_likelihood = this_nni_engine.GetBestPreNNILikelihood(nni);
-  const double diff = postnni_likelihood - prenni_likelihood;
-  const bool accept = (diff > 0.0);
-  return accept;
+  return postnni_likelihood > prenni_likelihood;
 }
 
 // ** NNI Likelihoods

--- a/src/nni_engine.hpp
+++ b/src/nni_engine.hpp
@@ -30,32 +30,62 @@ class NNIEngine {
   // Constructors:
   NNIEngine(GPDAG &dag, GPEngine &gp_engine);
 
-  // ** Getters
+  // ** Access
 
   // Get Reference of DAG.
-  const GPDAG &GetGPDAG() const { return dag_; };
+  const GPDAG &GetGPDAG() const { return dag_; }
   // Get Reference of GraftDAG.
-  GraftDAG &GetGraftDAG() const { return *graft_dag_.get(); };
+  GraftDAG &GetGraftDAG() const { return *graft_dag_.get(); }
   // Get Reference of GPEngine.
   const GPEngine &GetGPEngine() const { return gp_engine_; }
   // Get Adjacent NNIs to DAG.
-  const NNISet &GetAdjacentNNIs() const { return adjacent_nnis_; };
+  const NNISet &GetAdjacentNNIs() const { return adjacent_nnis_; }
   // Get Number of Adjacent NNIs.
-  size_t GetAdjacentNNICount() const { return adjacent_nnis_.size(); };
+  size_t GetAdjacentNNICount() const { return adjacent_nnis_.size(); }
   // Get NNIs that have been accepted into the DAG on current pass.
-  const NNISet &GetAcceptedNNIs() const { return accepted_nnis_; };
+  const NNISet &GetAcceptedNNIs() const { return accepted_nnis_; }
+  // Get Number of Accepted NNIs.
+  size_t GetAcceptedNNICount() const { return accepted_nnis_.size(); }
   // Get all past NNIs that have been accepted into the DAG during run.
-  const NNISet &GetPastAcceptedNNIs() const { return accepted_past_nnis_; };
+  const NNISet &GetPastAcceptedNNIs() const { return accepted_past_nnis_; }
+  // Get Number of Past Accepted NNIs.
+  size_t GetPastAcceptedNNICount() const { return accepted_past_nnis_.size(); }
   // Get NNIs that have been rejected from the DAG on current pass.
-  const NNISet &GetRejectedNNIs() const { return rejected_nnis_; };
+  const NNISet &GetRejectedNNIs() const { return rejected_nnis_; }
+  // Get Number of Rejected NNIs.
+  size_t GetRejectedNNICount() const { return rejected_nnis_.size(); }
   // Get all past NNIs that have been rejected from the DAG during run.
-  const NNISet &GetPastRejectedNNIs() const { return rejected_past_nnis_; };
-  // Get Number of Accepted NNIs during the current pass.
-  size_t GetAcceptedNNICount() const { return accepted_nnis_.size(); };
+  const NNISet &GetPastRejectedNNIs() const { return rejected_past_nnis_; }
+  // Get Number of Past Rejected NNIs.
+  size_t GetPastRejectedNNICount() const { return rejected_past_nnis_.size(); }
   // Get Map of proposed NNIs with their score.
-  const NNIDoubleMap &GetScoredNNIs() const { return scored_nnis_; };
-  // Get number of runs of NNI engine.
-  size_t GetSweepCount() const { return sweep_count_; };
+  const NNIDoubleMap &GetScoredNNIs() const { return scored_nnis_; }
+  // Get number of iterations of NNI engine.
+  size_t GetSweepCount() const { return sweep_count_; }
+  // Get DAG likelihoods.
+  const EigenVectorXd &GetDAGLikelihoods() const { return *dag_likelihoods_; }
+  // Get DAG likelihoods for
+  double GetDAGEdgeLikelihood(const size_t edge_idx) const {
+    const auto &dag_likelihoods = GetDAGLikelihoods();
+    Assert(edge_idx < size_t(dag_likelihoods.size()),
+           "Requested likelihood for edge index is out-of-range.");
+    return dag_likelihoods[edge_idx];
+  }
+
+  // ** Setters
+
+  // Set whether to track accepted past NNIs.
+  void SetKeepAcceptedNNIs(const bool keep_accepted_past_nnis) {
+    keep_accepted_past_nnis_ = keep_accepted_past_nnis;
+  }
+  // Set whether to track rejected past NNIs.
+  void SetKeepRejectedNNIs(const bool keep_rejected_past_nnis) {
+    keep_rejected_past_nnis_ = keep_rejected_past_nnis;
+  }
+  // Set whether to re-evalute rejected past NNIs.
+  void SetReevaluateRejecteddNNIs(const bool reevaluate_rejected_nnis) {
+    reevaluate_rejected_nnis_ = reevaluate_rejected_nnis;
+  }
 
   // ** Runners
   // These start the engine, which procedurally ranks and adds (and maybe removes) NNIs
@@ -65,36 +95,70 @@ class NNIEngine {
   void Run();
   // Runner subroutines.
   void RunInit();
+  // Graft Adjacent NNIs to GraftDAG. Evaluate and Accept or Reject Adjacent NNIs.
   void RunMainLoop();
+  // Remove Graft and add Accepted NNIs to HostDAG. Update Adjacent NNIs to account for
+  // new Accepted NNIs.  Update Accepted and Rejected NNI lists.
   void RunPostLoop();
 
-  // ** Filter Functions
+  // ** Runner Subroutines
 
-  // Initialization step for filter before beginning
+  // Initialize filter before first NNI sweep.
+  void FilterInit();
+  // Update filter parameters for each NNI sweep (before evaluation).
+  void FilterPreUpdate();
+  // Apply the filtering method to determine whether each Adjacent NNI will be added
+  // to Accepted NNI or Rejected NNI.
+  void FilterProcessAdjacentNNIs();
+  // Update filter parameters for each NNI sweep (after evaluation).
+  void FilterPostUpdate();
+
+  // ** Static Filter Functions
+
+  // Initialization step for filter before beginning engine run.
   using StaticFilterInitFunction =
       std::function<void(NNIEngine &, GPEngine &, GraftDAG &)>;
   // Update step for any filter computation work to be done at start of each sweep.
   using StaticFilterUpdateFunction =
       std::function<void(NNIEngine &, GPEngine &, GraftDAG &)>;
-  // Function template for computational evaluation to be performed on an adjacent NNI.
-  using StaticFilterEvaluateFunction =
-      std::function<double(NNIEngine &, GPEngine &, GraftDAG &, const NNIOperation &)>;
   // Function template for processing an adjacent NNI to be accepted or rejected.
   using StaticFilterProcessFunction =
       std::function<bool(NNIEngine &, GPEngine &, GraftDAG &, const NNIOperation &)>;
 
-  // StaticFilterEvaluateFunction: dummy function that assigns all score of 0.0.
-  static double NoEvaluate(NNIEngine &this_nni_engine, GPEngine &this_gp_engine,
-                           GraftDAG &this_graft_dag, const NNIOperation &nni);
-  // StaticFilterProcessFunction: dummy function that accepts all NNIs.
+  // This StaticFilterInitFunction does nothing.
+  static void NoInit(NNIEngine &this_nni_engine, GPEngine &this_gp_engine,
+                     GraftDAG &this_graft_dag);
+  // This StaticFilterUpdateFunction does nothing.
+  static void NoUpdate(NNIEngine &this_nni_engine, GPEngine &this_gp_engine,
+                       GraftDAG &this_graft_dag);
+  // This StaticFilterProcessFunction accepts all or rejects all NNIs, according to
+  // templated parameter.
+  template <bool accept = true>
   static bool NoFilter(NNIEngine &this_nni_engine, GPEngine &this_gp_engine,
-                       GraftDAG &this_graft_dag, const NNIOperation &nni);
-  // StaticFilterEvaluateFunction: estimate an NNI's per GPCSP Likelihood using the
-  // Pre-NNI in the DAG.
-  static double EstimateNNILikelihoodViaPreNNI(NNIEngine &this_nni_engine,
-                                               GPEngine &this_gp_engine,
-                                               GraftDAG &this_graft_dag,
-                                               const NNIOperation &nni);
+                       GraftDAG &this_graft_dag, const NNIOperation &nni) {
+    return accept;
+  }
+  // This StaticFilterProcessFunction is for Hill-climbing, only accepting a proposed
+  // NNI if it has an improved likelihood over Pre-NNI.
+  static bool FilterPostNNIBetterThanPreNNI(NNIEngine &this_nni_engine,
+                                            GPEngine &this_gp_engine,
+                                            GraftDAG &this_graft_dag,
+                                            const NNIOperation &nni);
+  // This StaticFilterUpdateFunction computes likelihood for all proposed NNIs.
+  static void UpdateScoreAdjacentNNIsByLikelihood(NNIEngine &this_nni_engine,
+                                                  GPEngine &this_gp_engine,
+                                                  GraftDAG &this_graft_dag);
+
+  // Finds best Pre-NNI likelihood in DAG for given NNI in HostDAG.  For use in
+  // hill-climbing filtering scheme.
+  // - NOTE: For any proposed NNI in the GraftDAG, there are two possible NNIs which
+  // could have produced it, depending on which child clade is swapped with the parent
+  // sister clade.  One or both of those Pre-NNIs could be present in the HostDAG.  This
+  // function checks for both, and if both are present, selects the one with the highest
+  // likelihood.
+  double GetBestPreNNILikelihood(const NNIOperation &nni);
+  // Get Post-NNI likelihood for proposed NNI in GraftDAG.
+  double GetPostNNILikelihood(const NNIOperation &nni);
 
   // ** NNI Likelihoods
   // Functions for computation or estimating likelihood of NNIs.
@@ -122,8 +186,8 @@ class NNIEngine {
   using NNIClade = NNIOperation::NNIClade;
   static KeyIndex NNICladeToPHatPLV(NNIClade clade_type);
 
-  // Builds an array containing a mapping of plvs from Pre-NNI to Post-NNI, according to
-  // remapping of the NNI clades (sister, right_child, left_child).
+  // Builds an array containing a mapping of plvs from Pre-NNI to Post-NNI, according
+  // to remapping of the NNI clades (sister, right_child, left_child).
   static KeyIndexPairArray BuildKeyIndexTypePairsFromPreNNIToPostNNI(
       const NNIOperation &pre_nni, const NNIOperation &post_nni);
 
@@ -149,8 +213,8 @@ class NNIEngine {
   KeyIndexMapPair PassDataFromPreNNIToPostNNIViaReference(
       const NNIOperation &pre_nni, const NNIOperation &post_nni,
       const size_t nni_count = 0, const bool use_unique_temps = false);
-  // Fetches Data from Pre-NNI for Post-NNI. Can be used for initial values when moving
-  // accepted NNIs from Graft to Host DAG.
+  // Fetches Data from Pre-NNI for Post-NNI. Can be used for initial values when
+  // moving accepted NNIs from Graft to Host DAG.
   KeyIndexMapPair PassDataFromPreNNIToPostNNIViaCopy(const NNIOperation &pre_nni,
                                                      const NNIOperation &post_nni);
 
@@ -163,8 +227,8 @@ class NNIEngine {
       const bool via_reference = true);
   // Grow engine to handle computing NNI Likelihoods for all adjacent NNIs.
   // Option to grow engine for computing likelihoods via reference or via copy. If
-  // computing via reference, option whether to use unique temporaries (for testing and
-  // computing in parallel).
+  // computing via reference, option whether to use unique temporaries (for testing
+  // and computing in parallel).
   void GrowEngineForAdjacentNNILikelihoods(const bool via_reference = true,
                                            const bool use_unique_temps = false);
   // Performs entire likelihood computation for all Adjacent NNIs.
@@ -172,31 +236,33 @@ class NNIEngine {
   // GPOperationVector, then retrieves results and stores in Scored NNIs.
   void ScoreAdjacentNNIsByLikelihood();
 
-  // ** Filtering
-  // !ISSUE #429: Need filtering scheme.
+  // ** Set Filtering Scheme
 
-  // Initialize filter before first NNI sweep.
-  void FilterInit(std::optional<StaticFilterInitFunction> FilterInitFn = std::nullopt);
-  // Update filter parameters for each NNI sweep (before evaluation).
-  void FilterPreUpdate(
-      std::optional<StaticFilterUpdateFunction> FilterUpdateFn = std::nullopt);
-  // Perform computation on each Adjacent NNI.
-  void FilterEvaluateAdjacentNNIs(
-      std::optional<StaticFilterEvaluateFunction> FilterEvaluateFn = std::nullopt);
-  // Update filter parameters for each NNI sweep (after evaluation).
-  void FilterPostUpdate(
-      std::optional<StaticFilterUpdateFunction> FilterUpdateFn = std::nullopt);
-  // Apply the filtering method to determine whether each Adjacent NNI will be added to
-  // Accepted NNI or Rejected NNI.
-  void FilterProcessAdjacentNNIs(
-      std::optional<StaticFilterProcessFunction> FilterProcessFn = NoFilter);
+  // Set custom functions for filtering NNIs.
+  void SetFilteringCustom(StaticFilterInitFunction init_fn,
+                          StaticFilterUpdateFunction pre_update_fn,
+                          StaticFilterProcessFunction process_fn,
+                          StaticFilterUpdateFunction post_update_fn);
+  // Set no filters for NNIs. Accept parameter determines whether to accept or reject
+  // all NNIs.
+  void SetFilteringNone();
+  // Set filter to accept only Post-NNIs which are an improvement over Pre-NNIs.
+  void SetFilteringHillclimb();
+  // Set filter to compare Pre-NNI likelihood to Post-NNI likelihood.  Accept Post-NNIs
+  // whose loss in likelihood relative to its Pre-NNI is less than the loss_tolerance.
+  // A loss_tolerance of zero is equivalent to hill-climbing.
+  void SetFilteringLossThreshold(const double loss_tolerance);
+  // Set filter to have a hard cutoff for accepted Post-NNI likelihood.
+  void SetFilteringCutoffThreshold(const double cutoff_threshold);
 
   // ** DAG & GPEngine Maintenance
 
   // Initial GPEngine for use with GraftDAG.
-  void InitGPEngine();
-  // Populate PLVs so that
-  void PrepGPEngineForLikelihoods();
+  void GPEngineInit();
+  // Resize GPEngine for use with GraftDAG, Populate PLVs and Compute Likelihoods for
+  // HostDAG.
+  void GPEngineUpdate();
+
   // Add all Accepted NNIs to Main DAG.
   void AddAcceptedNNIsToDAG();
   // Add all Adjacent NNIs to Graft DAG.
@@ -212,14 +278,15 @@ class NNIEngine {
   // internal edges in the DAG. (For each internal edges, two NNIs are possible.)
   void SyncAdjacentNNIsWithDAG();
   // Updates NNI Set after given parent/child node pair have been added to the DAG.
-  // Removes pair from NNI Set and adds adjacent pairs coming from newly created edges.
+  // Removes pair from NNI Set and adds adjacent pairs coming from newly created
+  // edges.
   void UpdateAdjacentNNIsAfterDAGAddNodePair(const NNIOperation &nni);
   void UpdateAdjacentNNIsAfterDAGAddNodePair(const Bitset &parent_bitset,
                                              const Bitset &child_bitset);
-  // Adds all NNIs from all (node_id, other_id) pairs, where other_id's are elements of
-  // the adjacent_node_ids vector. is_edge_leafward tells whether node_id is the child
-  // or parent. is_edge_edgeclade determines which side of parent the child descends
-  // from.
+  // Adds all NNIs from all (node_id, other_id) pairs, where other_id's are elements
+  // of the adjacent_node_ids vector. is_edge_leafward tells whether node_id is the
+  // child or parent. is_edge_edgeclade determines which side of parent the child
+  // descends from.
   void AddAllNNIsFromNodeVectorToAdjacentNNIs(const size_t &node_id,
                                               const SizeVector &adjacent_node_ids,
                                               const bool is_edge_on_left,
@@ -237,15 +304,15 @@ class NNIEngine {
   double GetScoreForNNI(const NNIOperation &nni) const;
 
   // Update adjacent NNIs at end of current sweep. If not re-evaluating rejected NNIs,
-  // then current adjacent NNIs are removed. Then NNIs that are adjacent to last sweep's
-  // accepted NNIs are added.
-  void UpdateAdjacentNNIs(const bool reevaluate_rejected_nnis = false);
+  // then current adjacent NNIs are removed. Then NNIs that are adjacent to last
+  // sweep's accepted NNIs are added.
+  void UpdateAdjacentNNIs();
   // Remove all accepted NNIs and optionally save to past NNIs.
-  void UpdateAcceptedNNIs(const bool save_past_nnis = true);
+  void UpdateAcceptedNNIs();
   // Remove all rejected NNIs and optionally save to past NNIs.
-  void UpdateRejectedNNIs(const bool save_past_nnis = true);
+  void UpdateRejectedNNIs();
   // Remove all scored NNIs and optionally save to past NNIs.
-  void UpdateScoredNNIs(const bool save_past_nnis = false);
+  void UpdateScoredNNIs();
   // Reset all NNIs, current and past.
   void ResetAllNNIs();
 
@@ -260,8 +327,9 @@ class NNIEngine {
   std::unique_ptr<GraftDAG> graft_dag_;
   // Un-owned reference GPEngine.
   GPEngine &gp_engine_;
-  // Tracks modifications to the DAG.
+  // Tracks node modifications to the DAG.
   Reindexer node_reindexer_;
+  // Tracks edge modifications to the DAG.
   Reindexer edge_reindexer_;
 
   // Set of NNIs to be evaluated, which are a single NNI.
@@ -270,15 +338,38 @@ class NNIEngine {
   NNISet accepted_nnis_;
   // NNIs which have been accepted in a previous sweep of the search.
   NNISet accepted_past_nnis_;
+  // Determines whether past accepted NNIs are tracked.
+  bool keep_accepted_past_nnis_ = false;
   // NNIs which have failed the filtering threshold, not to be added to the DAG.
   NNISet rejected_nnis_;
   // NNIs which have been rejected in a previous sweep of the search.
   NNISet rejected_past_nnis_;
+  // Determines whether past rejected NNIs are tracked.
+  bool keep_rejected_past_nnis_ = false;
+  // Determines whether to keep rejected NNIs in Adjacent NNI list for re-evaluation.
+  bool reevaluate_rejected_nnis_ = false;
 
   // Map of adjacent NNIs to their score.
   NNIDoubleMap scored_nnis_;
   // Map of previous rejected NNIs to their score.
   NNIDoubleMap scored_past_nnis_;
+  // Determines whether past scored NNIs are tracked.
+  bool keep_scored_past_nnis_ = false;
+
+  // DAG Likelihoods.
+  std::unique_ptr<EigenVectorXd> dag_likelihoods_ = nullptr;
+
+  // Determines whether branch lengths are optimized when updating DAG likelihoods.
+  bool do_optimitize_branch_lengths_ = false;
+
+  // Initial step before running any sweep iterations.
+  StaticFilterInitFunction filter_init_fn_ = NoInit;
+  // Update step for any filter computation work to be done at start of each sweep.
+  StaticFilterUpdateFunction filter_pre_update_fn_ = NoUpdate;
+  // Update step for any filter computation work to be done at end of each sweep.
+  StaticFilterUpdateFunction filter_post_update_fn_ = NoUpdate;
+  // Processing an adjacent NNI to be accepted or rejected.
+  StaticFilterProcessFunction filter_process_fn_ = NoFilter<true>;
 
   // Count number of loops executed by engine.
   size_t sweep_count_ = 0;

--- a/src/pybito.cpp
+++ b/src/pybito.cpp
@@ -561,6 +561,8 @@ PYBIND11_MODULE(bito, m) {
       .def("dag_summary_statistics", &GPInstance::DAGSummaryStatistics,
            "Return summary statistics about the DAG.")
       .def("make_dag", &GPInstance::MakeDAG, "Build subsplit DAG.")
+      .def("get_dag", &GPInstance::GetDAG, py::return_value_policy::reference,
+           "Get subsplit DAG.")
       .def("print_dag", &GPInstance::PrintDAG, "Print the subsplit DAG.")
 
       // ** I/O
@@ -624,18 +626,53 @@ PYBIND11_MODULE(bito, m) {
       .def("estimate_branch_lengths", &GPInstance::EstimateBranchLengths,
            "Estimate branch lengths for the GPInstance.", py::arg("tol"),
            py::arg("max_iter"), py::arg("quiet") = false)
-
-      // ** NNI Engine
       .def("make_nni_engine", &GPInstance::MakeNNIEngine,
            R"raw(Initialize NNI Engine.)raw")
+      .def("get_nni_engine", &GPInstance::GetNNIEngine,
+           py::return_value_policy::reference, R"raw(Get Reference to NNI Engine.)raw");
+
+  // CLASS
+  // GPDAG
+  py::class_<GPDAG> gp_dag_class(m, "gp_dag", R"raw(SubsplitDAG for GPInstance.)raw");
+  gp_dag_class.def("get_node_count", &SubsplitDAG::NodeCount, "Number of nodes in DAG.")
+      .def("get_edge_count", &SubsplitDAG::EdgeCountWithLeafSubsplits,
+           "Number of edges in DAG.");
+
+  // CLASS
+  // NNI Engine
+  py::class_<NNIEngine> nni_engine_class(
+      m, "nni_engine",
+      R"raw(NNI Engine for a performing a systematic search on GPInstance.)raw");
+  nni_engine_class
+      .def("get_adjacent_nni_count", &NNIEngine::GetAdjacentNNICount,
+           R"raw(Get number of adjacent NNIs in current DAG.)raw")
+      .def("get_accepted_nni_count", &NNIEngine::GetAcceptedNNICount,
+           R"raw(Get number of accepted NNIs during current search.)raw")
+      .def("get_past_accepted_nni_count", &NNIEngine::GetAcceptedNNICount,
+           R"raw(Get number of past accepted NNIs during current search.)raw")
+      .def("get_rejected_nni_count", &NNIEngine::GetRejectedNNICount,
+           R"raw(Get number of rejected NNIs during current search.)raw")
+      .def("get_past_rejected_nni_count", &NNIEngine::GetRejectedNNICount,
+           R"raw(Get number of past rejected NNIs during current search.)raw")
+      .def("sync_adjacent_nnis_with_dag", &NNIEngine::SyncAdjacentNNIsWithDAG,
+           R"raw(Find all adjacent NNIs of DAG.)raw")
+      .def("run", &NNIEngine::Run,
+           R"raw(Run NNI search until no more NNIs are accepted.)raw")
+      .def("run_init", &NNIEngine::RunInit,
+           R"raw(Run initialization step of NNI search.)raw")
+      .def("run_main_loop", &NNIEngine::RunMainLoop,
+           R"raw(Run single iteration of main loop step of NNI search.)raw")
+      .def("run_post_loop", &NNIEngine::RunPostLoop,
+           R"raw(Run single iteration of post loop step of NNI search.)raw")
       .def(
-          "sync_adjacent_nnis_with_dag",
-          [](GPInstance &self) { self.GetNNIEngine().SyncAdjacentNNIsWithDAG(); },
-          R"raw(Find all adjacent NNIs of DAG.)raw")
+          "set_filtering_none", &NNIEngine::SetFilteringNone,
+          R"raw(Set filtering scheme to filter none, and accept all proposed NNIs.)raw")
       .def(
-          "adjacent_nni_count",
-          [](GPInstance &self) { self.GetNNIEngine().GetAdjacentNNICount(); },
-          R"raw(Get number of adjacent NNIs to current DAG.)raw");
+          "set_filtering_loss_threshold", &NNIEngine::SetFilteringLossThreshold,
+          R"raw(Set filtering scheme to accept Post-NNIs which have a loss of likelihood relative to its Pre-NNI less than the loss_tolerance.)raw")
+      .def(
+          "set_filtering_cutoff_threshold", &NNIEngine::SetFilteringCutoffThreshold,
+          R"raw(Set filtering scheme to accept all NNIs above given cutoff threshold.)raw");
 
   // If you want to be sure to get all of the stdout and cerr messages, put your
   // Python code in a context like so:

--- a/src/subsplit_dag.hpp
+++ b/src/subsplit_dag.hpp
@@ -106,8 +106,18 @@ class SubsplitDAG {
   // Output DOT format graph of DAG to a string.
   std::string ToDot(bool show_index_labels = true) const;
 
-  // ** Build Output Indexers/Vectors
+  // ** Build
 
+  // Get set of all taxon names.
+  std::vector<std::string> BuildSortedVectorOfTaxonNames() const;
+  // Get sorted vector of all node Subsplit bitsets.
+  std::vector<Bitset> BuildSortedVectorOfNodeBitsets() const;
+  // Get sorted vector of all edge PCSP bitsets.
+  std::vector<Bitset> BuildSortedVectorOfEdgeBitsets() const;
+  // Get sorted vector of all node clade bitsets.
+  std::vector<Bitset> BuildSortedVectorOfCladeBitsets() const;
+  // Get sorted vector of all node clade bitsets.
+  std::map<Bitset, SizeVector> BuildCladeMap() const;
   // Create a EdgeIndexer representing the DAG.
   // The EdgeIndexer is a map (edge/PCSP bitset -> edge/PCSP index).
   // The edge/PCSP indexer contains leafs and rootsplits.
@@ -126,7 +136,7 @@ class SubsplitDAG {
   // Each node in a topology is constructed with SubsplitDAGNode ID as Node ID.
   Node::NodePtrVec GenerateAllTopologies() const;
 
-  // ** Getters
+  // ** Access
 
   // Get Taxon's bitset clade positional id.
   size_t GetTaxonId(const std::string &name) const;
@@ -147,18 +157,12 @@ class SubsplitDAG {
   size_t GetEdgeIdx(const Bitset &edge_pcsp) const;
   // Get the range of outgoing idxs from the given clade of a subsplit.
   SizePair GetChildEdgeRange(const Bitset &subsplit, const bool rotated) const;
-  // Get set of all taxon names.
-  std::vector<std::string> GetSortedVectorOfTaxonNames() const;
-  // Get sorted vector of all node Subsplit bitsets.
-  std::vector<Bitset> GetSortedVectorOfNodeBitsets() const;
-  // Get sorted vector of all edge PCSP bitsets.
-  std::vector<Bitset> GetSortedVectorOfEdgeBitsets() const;
   // Get reference to taxon map.
   const std::map<std::string, size_t> &GetTaxonMap() const;
   // Get reference to subsplit -> node_id map.
   const BitsetSizeMap &GetSubsplitToIdMap() const;
-  // Get reference to parent_node -> child_edge_range map.
-  const BitsetSizePairMap &GetParentNodeToChildEdgeRangeMap() const;
+  // Get reference to DAGStorage.
+  const SubsplitDAGStorage &GetStorage() const;
 
   // ** DAG Lambda Iterators
   // These methods iterate over the nodes and take lambda functions with arguments
@@ -439,6 +443,8 @@ class SubsplitDAG {
  protected:
   explicit SubsplitDAG(SubsplitDAG &host_dag, HostDispatchTag);
   void ResetHostDAG(SubsplitDAG &host_dag);
+
+  // ** Build
 
   // Builds a vector of subsplits of all children , optionally including leaf nodes.
   std::vector<Bitset> GetChildSubsplits(const SizeBitsetMap &index_to_child,

--- a/test/test_bito.py
+++ b/test/test_bito.py
@@ -170,7 +170,9 @@ def test_gp_instance():
     inst = bito.gp_instance("_ignore/mmapped_plv_pybito.data")
     inst.read_fasta_file("data/six_taxon.fasta")
     inst.read_newick_file("data/six_taxon_rootsplit.nwk")
+    inst.make_dag()
     inst.make_engine()
+    inst.make_nni_engine()
 
     init_branches = inst.get_branch_lengths()
     print("init_branch_lengths:", init_branches)
@@ -180,7 +182,16 @@ def test_gp_instance():
 
     edge_idx_to_pcsp_map = inst.build_edge_idx_to_pcsp_map()
     print("edge_pcsp_map:", edge_idx_to_pcsp_map)
-    pass
+
+    nni_engine = inst.get_nni_engine()
+    nni_engine.run_init()
+    adj_nni_count = nni_engine.get_adjacent_nni_count()
+    nni_engine.run()
+
+    dag = inst.get_dag()
+    node_count = dag.get_node_count()
+    edge_count = dag.get_edge_count()
+    print("dag_counts: ", node_count, edge_count)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Description

- Adds Filtering Schemes for accepting or rejecting proposed NNIs.
   - Added std::function members to NNI Engine, which can be modified to select different filtering schemes, or user make a custom scheme by passing lambdas.
   - Added Schemes:  
     - None (accepts all NNIs)
     - Cutoff (accepts NNIs with likelihood greater than cutoff threshold).
     - Hill-climbing / Loss threshold (accepts NNIs which have higher likelihood than their Pre-NNIs present in DAG, or do not fall below a certain threshold).
- Added NNI Engine to Pybito.

Closes #429 


## Tests

`TEST_CASE("NNI Engine: Complete Run NNI Engine with No Filter")`:  Tests that running NNI Engine with no filter results in a complete subsplitDAG.

`TEST_CASE("NNI Engine: Run Hillclimbing")`: Tests that hillclimbing only accepts NNIs with higher likelihood.

## Checklist:

* [x] Code follows our detailed [contribution guidelines](CONTRIBUTING.md)
* [x] `clang-format` has been run
* [x] TODOs have been eliminated from the code
* [x] Comments are up to date, document intent, and there are no commented-out code blocks
* [x] Issue branch has been squashed and rebased on main branch
* [ ] GitHub CI build on PR branch completed successfully
