### PR TITLE
Top-Pruning: ChoiceMap and TreeMask.

### DIFF
--- a/src/choice_map.hpp
+++ b/src/choice_map.hpp
@@ -129,9 +129,8 @@ class ChoiceMap {
   }
 
   // ** TreeMask
-
-  // A TreeMask is a vector of IDs, which represent a tree contained in the DAG, from a
-  // selected subset of DAG nodes and edges.
+  // A TreeMask is a vector of edge Ids, which represent a tree contained in the DAG,
+  // from the selected subset of DAG edges.
   using TreeMask = std::vector<size_t>;
 
   // Convert stack to a vector.

--- a/src/choice_map.hpp
+++ b/src/choice_map.hpp
@@ -53,7 +53,7 @@ class ChoiceMap {
       const SizeVector &right_children =
           child_node.GetNeighbors(Direction::Leafward, SubsplitClade::Right);
 
-      // If neighbor lists are non-empty, find the associated edges.
+      // If neighbor lists are non-empty, get first edge from list.
       if (!left_parents.empty()) {
         edge_choice.parent_edge_id = dag_.GetEdgeIdx(left_parents[0], parent_node.Id());
       } else if (!right_parents.empty()) {
@@ -75,11 +75,11 @@ class ChoiceMap {
   }
 
   // Check if choice selection is valid.
-  // Specifically, checks that
-  // - Every edge choice vector has a valid id for all options, unless
-  //   - Edge goes to root (NoId for sister and parent)
-  //   - Edge goes to leaf (NoId for left and right child)
-  // - Edges reach every leaf and root.
+  // Specifically, checks that:
+  // - Every edge choice vector has a valid id for all options, unless...
+  //   - Edge goes to root (NoId for sister and parent).
+  //   - Edge goes to leaf (NoId for left and right child).
+  // - Edges span every leaf and root node.
   bool SelectionIsValid(const bool is_quiet = true) const {
     size_t edge_limit = dag_.EdgeCountWithLeafSubsplits();
     for (size_t edge_idx = 0; edge_idx < edge_choice_vector_.size(); edge_idx++) {
@@ -197,9 +197,9 @@ class ChoiceMap {
   // Checks that TreeMask represents a valid, complete tree in the DAG.
   // Specifically, checks that:
   // - There is a single edge that goes to the root.
-  // - There is a single edge to each leave in the DAG.
-  // - For each internal node reached by the mask, there is a single parent, left and
-  // right child.
+  // - There is a single edge that goes to each leaf.
+  // - For each node in mask, there is a single parent, left and right child.
+  //   - Unless node is root (no parent) or leaf (no children).
   bool TreeMaskIsValid(const TreeMask &tree_mask, const bool is_quiet = true) const {
     SizeVector node_ids;
     bool root_check = false;
@@ -249,6 +249,7 @@ class ChoiceMap {
     for (const auto &[node_id, connections] : nodemap_check) {
       // Check children.
       if (!(connections[0] || connections[1])) {
+        // If one child is not connected, neither should be.
         if (connections[0] ^ connections[1]) {
           return false;
         }
@@ -267,7 +268,7 @@ class ChoiceMap {
     return true;
   }
 
-  // ** Printing
+  // ** I/O
 
   // Output edge choice to string.
   static std::string EdgeChoiceToString(const EdgeChoice &edge_choice) {

--- a/src/choice_map.hpp
+++ b/src/choice_map.hpp
@@ -290,21 +290,14 @@ class ChoiceMap {
 
   // ** I/O
 
-  // Output edge choice to string.
-  static std::string EdgeChoiceToString(const EdgeChoice &edge_choice) {
-    std::stringstream os;
+  // Output edge choice map to iostream.
+  friend std::ostream &operator<<(std::ostream &os, const EdgeChoice &edge_choice) {
     os << "{ ";
     os << "parent: " << edge_choice.parent_edge_id << ", ";
     os << "sister: " << edge_choice.sister_edge_id << ", ";
     os << "left_child: " << edge_choice.left_child_edge_id << ", ";
     os << "right_child: " << edge_choice.right_child_edge_id;
     os << " }";
-    return os.str();
-  }
-
-  // Output edge choice map to iostream.
-  friend std::ostream &operator<<(std::ostream &os, const EdgeChoice &edge_choice) {
-    os << EdgeChoiceToString(edge_choice);
     return os;
   }
 

--- a/src/choice_map.hpp
+++ b/src/choice_map.hpp
@@ -131,11 +131,11 @@ class ChoiceMap {
   // ** TreeMask
   // A TreeMask is an unordered vector of edge Ids, which represent a tree contained in
   // the DAG, from the selected subset of DAG edges.
-  using TreeMask = std::vector<size_t>;
+  using TreeMask = std::unordered_set<size_t>;
 
   // Convert stack to a vector.
   template <typename T>
-  static std::vector<T> StackToVector(std::stack<T> &stack) {
+  static std::set<T> StackToVector(std::stack<T> &stack) {
     T *end = &stack.top() + 1;
     T *begin = end - stack.size();
     std::vector<T> stack_contents(begin, end);
@@ -302,22 +302,15 @@ class ChoiceMap {
     return os.str();
   }
 
-  // Output edge choice vector to string.
-  static std::string EdgeChoiceVectorToString(
-      const EdgeChoiceVector &edge_choice_vector) {
-    std::stringstream os;
-    os << "[ " << std::endl;
-    for (size_t i = 0; i < edge_choice_vector.size(); i++) {
-      const auto &edge_choice = edge_choice_vector[i];
-      os << "\t" << EdgeChoiceToString(edge_choice) << ", " << std::endl;
-    }
-    os << "]";
-    return os.str();
+  // Output edge choice map to iostream.
+  friend std::ostream &operator<<(std::ostream &os, const EdgeChoice &edge_choice) {
+    os << EdgeChoiceToString(edge_choice);
+    return os;
   }
 
   // Output edge choice map to iostream.
   friend std::ostream &operator<<(std::ostream &os, const ChoiceMap &choice_map) {
-    os << EdgeChoiceVectorToString(choice_map.edge_choice_vector_);
+    os << choice_map.edge_choice_vector_;
     return os;
   }
 

--- a/src/choice_map.hpp
+++ b/src/choice_map.hpp
@@ -131,7 +131,7 @@ class ChoiceMap {
   // ** TreeMask
   // A TreeMask is an unordered vector of edge Ids, which represent a tree contained in
   // the DAG, from the selected subset of DAG edges.
-  using TreeMask = std::unordered_set<size_t>;
+  using TreeMask = std::vector<size_t>;
 
   // Convert stack to a vector.
   template <typename T>

--- a/src/choice_map.hpp
+++ b/src/choice_map.hpp
@@ -244,7 +244,7 @@ class ChoiceMap {
       }
       nodemap_check[child_node.Id()][2] = true;
     }
-    // Final check if all nodes are fully connected.
+    // Check if all nodes are fully connected.
     for (const auto &[node_id, connections] : nodemap_check) {
       // Check children.
       if (!(connections[0] || connections[1])) {
@@ -261,6 +261,15 @@ class ChoiceMap {
         if (!dag_.IsNodeRoot(node_id)) {
           return false;
         }
+      }
+    }
+    // Check if spans root and all leaf nodes.
+    if (!root_check) {
+      return false;
+    }
+    for (size_t i = 0; i < leaf_check.size(); i++) {
+      if (!leaf_check[i]) {
+        return false;
       }
     }
 

--- a/src/choice_map.hpp
+++ b/src/choice_map.hpp
@@ -1,0 +1,308 @@
+// Copyright 2019-2022 bito project contributors.
+// bito is free software under the GPLv3; see LICENSE file for details.
+//
+// A ChoiceMap is a per-edge map of the best adjacent edges applied to a SubsplitDAG
+// for Top-Pruning. Used for selecting, updating, and extracting the top tree from the
+// DAG. A ChoiceMap can generate a TreeMask, which is a list of edge ids which express a
+// single, complete tree embedded in the DAG.
+
+#pragma once
+
+#include <stack>
+#include "sugar.hpp"
+#include "gp_dag.hpp"
+#include "tree.hpp"
+#include "tree_collection.hpp"
+
+class ChoiceMap {
+ public:
+  // Per-edge choices of best adjacent edges.
+  struct EdgeChoice {
+    size_t parent_edge_id = NoId;
+    size_t sister_edge_id = NoId;
+    size_t left_child_edge_id = NoId;
+    size_t right_child_edge_id = NoId;
+    double tree_likelihood = -INFINITY;
+  };
+  using EdgeChoiceVector = std::vector<EdgeChoice>;
+
+  ChoiceMap(GPDAG &dag)
+      : dag_(dag), edge_choice_vector_(dag.EdgeCountWithLeafSubsplits()){};
+
+  // ** Selectors
+
+  // Naive choice selector. Chooses the first edge from each list of candidates.
+  void SelectFirstEdge() {
+    for (size_t edge_idx = 0; edge_idx < dag_.EdgeCountWithLeafSubsplits();
+         edge_idx++) {
+      const auto edge = dag_.GetDAGEdge(edge_idx);
+      const auto focal_clade = edge.GetSubsplitClade();
+      const auto parent_node = dag_.GetDAGNode(edge.GetParent());
+      const auto child_node = dag_.GetDAGNode(edge.GetChild());
+      auto &edge_choice = edge_choice_vector_[edge_idx];
+
+      // Query neighbor nodes.
+      const SizeVector &left_parents =
+          parent_node.GetNeighbors(Direction::Rootward, SubsplitClade::Left);
+      const SizeVector &right_parents =
+          parent_node.GetNeighbors(Direction::Rootward, SubsplitClade::Right);
+      const SizeVector &sisters =
+          parent_node.GetNeighbors(Direction::Leafward, Bitset::Opposite(focal_clade));
+      const SizeVector &left_children =
+          child_node.GetNeighbors(Direction::Leafward, SubsplitClade::Left);
+      const SizeVector &right_children =
+          child_node.GetNeighbors(Direction::Leafward, SubsplitClade::Right);
+
+      // If neighbor lists are non-empty, find the associated edges.
+      if (!left_parents.empty()) {
+        edge_choice.parent_edge_id = dag_.GetEdgeIdx(left_parents[0], parent_node.Id());
+      } else if (!right_parents.empty()) {
+        edge_choice.parent_edge_id =
+            dag_.GetEdgeIdx(right_parents[0], parent_node.Id());
+      }
+      if (!sisters.empty()) {
+        edge_choice.sister_edge_id = dag_.GetEdgeIdx(parent_node.Id(), sisters[0]);
+      }
+      if (!left_children.empty()) {
+        edge_choice.left_child_edge_id =
+            dag_.GetEdgeIdx(child_node.Id(), left_children[0]);
+      }
+      if (!right_children.empty()) {
+        edge_choice.right_child_edge_id =
+            dag_.GetEdgeIdx(child_node.Id(), right_children[0]);
+      }
+    }
+  }
+
+  // Check if choice selection is valid.
+  // Specifically, checks that
+  // - Every edge choice vector has a valid id for all options, unless
+  //   - Edge goes to root (NoId for sister and parent)
+  //   - Edge goes to leaf (NoId for left and right child)
+  // - Edges reach every leaf and root.
+  bool SelectionIsValid(const bool is_quiet = true) const {
+    size_t edge_limit = dag_.EdgeCountWithLeafSubsplits();
+    for (size_t edge_idx = 0; edge_idx < edge_choice_vector_.size(); edge_idx++) {
+      const auto &edge_choice = edge_choice_vector_[edge_idx];
+      // If edge id is outside valid range.
+      if ((edge_choice.parent_edge_id > edge_limit) ||
+          (edge_choice.sister_edge_id > edge_limit)) {
+        // If they are not NoId, then it is an invalid edge_id.
+        if ((edge_choice.parent_edge_id != NoId) ||
+            (edge_choice.sister_edge_id != NoId)) {
+          if (!is_quiet) {
+            std::cerr << "Parent or Sister has invalid edge id." << std::endl;
+          }
+          return false;
+        }
+        // NoId is valid only if edge goes to a root.
+        if (!dag_.IsEdgeRoot(edge_idx)) {
+          if (!is_quiet) {
+            std::cerr << "Parent or Sister has NoId when edge is not a root."
+                      << std::endl;
+          }
+          return false;
+        }
+      }
+      for (const auto &child_edge_id :
+           {edge_choice.left_child_edge_id, edge_choice.right_child_edge_id}) {
+        // If edge id is outside valid range.
+        if (child_edge_id > edge_limit) {
+          // If they are not NoId, then it is an invalid edge_id.
+          if (child_edge_id != NoId) {
+            if (!is_quiet) {
+              std::cerr << "Child has invalid edge id." << std::endl;
+            }
+            return false;
+          }
+          // NoId is valid only if edge goes to a leaf.
+          if (!dag_.IsEdgeLeaf(edge_idx)) {
+            if (!is_quiet) {
+              std::cerr << "Child has NoId when edge is not a leaf." << std::endl;
+            }
+            return false;
+          }
+        }
+      }
+    }
+    return true;
+  }
+
+  // ** TreeMask
+
+  // A TreeMask is a vector of IDs, which represent a tree contained in the DAG, from a
+  // selected subset of DAG nodes and edges.
+  using TreeMask = std::vector<size_t>;
+
+  // Convert stack to a vector.
+  template <typename T>
+  static std::vector<T> StackToVector(std::stack<T> stack) {
+    T *end = &stack.top() + 1;
+    T *begin = end - stack.size();
+    std::vector<T> stack_contents(begin, end);
+    return stack_contents;
+  }
+
+  // Extract TreeMask from DAG based on edge choices to find best tree with given
+  // central edge.
+  TreeMask ExtractTreeMask(size_t central_edge_id) const {
+    TreeMask tree_mask;
+    std::stack<size_t> rootward_stack, leafward_stack;
+
+    // Rootward Pass: Capture parent and sister edges above focal edge.
+    // For central edge, add children to stack for leafward pass.
+    size_t focal_edge_id = central_edge_id;
+    const auto &focal_choices = edge_choice_vector_[focal_edge_id];
+    if (focal_choices.left_child_edge_id != NoId) {
+      rootward_stack.push(focal_choices.left_child_edge_id);
+    }
+    if (focal_choices.right_child_edge_id != NoId) {
+      rootward_stack.push(focal_choices.right_child_edge_id);
+    }
+    // Follow parentage upward until root.
+    while (true) {
+      tree_mask.push_back(focal_edge_id);
+      const auto &focal_choices = edge_choice_vector_[focal_edge_id];
+      // End upward pass if we are at the root.
+      focal_edge_id = focal_choices.parent_edge_id;
+      if (focal_edge_id == NoId) {
+        break;
+      }
+      // If not at root, add sister for leafward pass.
+      rootward_stack.push(focal_choices.sister_edge_id);
+    }
+
+    // Leafward Pass: Capture all children from parentage.
+    while (!rootward_stack.empty()) {
+      const auto parent_edge_id = rootward_stack.top();
+      rootward_stack.pop();
+      leafward_stack.push(parent_edge_id);
+    }
+    while (!leafward_stack.empty()) {
+      const auto edge_id = leafward_stack.top();
+      leafward_stack.pop();
+      tree_mask.push_back(edge_id);
+      const auto edge_choice = edge_choice_vector_[edge_id];
+      if (edge_choice.left_child_edge_id != NoId) {
+        leafward_stack.push(edge_choice.left_child_edge_id);
+      }
+      if (edge_choice.right_child_edge_id != NoId) {
+        leafward_stack.push(edge_choice.right_child_edge_id);
+      }
+    }
+
+    return tree_mask;
+  }
+
+  // Checks that TreeMask represents a valid, complete tree in the DAG.
+  // Specifically, checks that:
+  // - There is a single edge that goes to the root.
+  // - There is a single edge to each leave in the DAG.
+  // - For each internal node reached by the mask, there is a single parent, left and
+  // right child.
+  bool TreeMaskIsValid(const TreeMask &tree_mask, const bool is_quiet = true) const {
+    SizeVector node_ids;
+    bool root_check = false;
+    BoolVector leaf_check(dag_.TaxonCount(), false);
+    // Node map for checking connectivity: Array is an ordered as [left_child,
+    // right_child, parent].
+    using NodeMap = std::map<size_t, std::array<bool, 3>>;
+    NodeMap nodemap_check;
+
+    for (size_t i = 0; i < tree_mask.size(); i++) {
+      const auto edge_idx = tree_mask[i];
+      const auto &edge = dag_.GetDAGEdge(edge_idx);
+      const auto &parent_node = dag_.GetDAGNode(edge.GetParent());
+      const auto &child_node = dag_.GetDAGNode(edge.GetChild());
+      // Check if edge goes to root.
+      if (dag_.IsNodeRoot(parent_node.Id())) {
+        if (root_check == true) {
+          return false;
+        }
+        root_check = true;
+      }
+      // Check if edge goes to leaf.
+      if (dag_.IsNodeLeaf(child_node.Id())) {
+        const auto taxon_id = child_node.Id();
+        if (leaf_check.at(taxon_id) == true) {
+        }
+        leaf_check.at(taxon_id) = true;
+      }
+      // Update node map. If a node already has parent or child, invalid tree.
+      for (const auto node_id : {parent_node.Id(), child_node.Id()}) {
+        if (nodemap_check.find(node_id) == nodemap_check.end()) {
+          nodemap_check.insert({node_id, {false, false, false}});
+        }
+      }
+      const size_t which_child =
+          (edge.GetSubsplitClade() == SubsplitClade::Left) ? 0 : 1;
+      if (nodemap_check[parent_node.Id()][which_child] == true) {
+        return false;
+      }
+      nodemap_check[parent_node.Id()][which_child] = true;
+      if (nodemap_check[child_node.Id()][2] == true) {
+        return false;
+      }
+      nodemap_check[child_node.Id()][2] = true;
+    }
+    // Final check if all nodes are fully connected.
+    for (const auto &[node_id, connections] : nodemap_check) {
+      // Check children.
+      if (!(connections[0] || connections[1])) {
+        if (connections[0] ^ connections[1]) {
+          return false;
+        }
+        if (!dag_.IsNodeLeaf(node_id)) {
+          return false;
+        }
+      }
+      // Check parent.
+      if (!connections[2]) {
+        if (!dag_.IsNodeRoot(node_id)) {
+          return false;
+        }
+      }
+    }
+
+    return true;
+  }
+
+  // ** Printing
+
+  // Output edge choice to string.
+  static std::string EdgeChoiceToString(const EdgeChoice &edge_choice) {
+    std::stringstream os;
+    os << "{ ";
+    os << "parent: " << edge_choice.parent_edge_id << ", ";
+    os << "sister: " << edge_choice.sister_edge_id << ", ";
+    os << "left_child: " << edge_choice.left_child_edge_id << ", ";
+    os << "right_child: " << edge_choice.right_child_edge_id;
+    os << " }";
+    return os.str();
+  }
+
+  // Output edge choice vector to string.
+  static std::string EdgeChoiceVectorToString(
+      const EdgeChoiceVector &edge_choice_vector) {
+    std::stringstream os;
+    os << "[ " << std::endl;
+    for (size_t i = 0; i < edge_choice_vector.size(); i++) {
+      const auto &edge_choice = edge_choice_vector[i];
+      os << "\t" << EdgeChoiceToString(edge_choice) << ", " << std::endl;
+    }
+    os << "]";
+    return os.str();
+  }
+
+  // Output edge choice map to iostream.
+  friend std::ostream &operator<<(std::ostream &os, const ChoiceMap &choice_map) {
+    os << EdgeChoiceVectorToString(choice_map.edge_choice_vector_);
+    return os;
+  }
+
+ private:
+  // Un-owned reference DAG.
+  GPDAG &dag_;
+  // A vector that stores a map of each edge's best adjacent edges.
+  EdgeChoiceVector edge_choice_vector_;
+};

--- a/src/choice_map.hpp
+++ b/src/choice_map.hpp
@@ -203,7 +203,7 @@ class ChoiceMap {
     SizeVector node_ids;
     bool root_check = false;
     BoolVector leaf_check(dag_.TaxonCount(), false);
-    // Node map for checking connectivity: Array is an ordered as [left_child,
+    // Node map for checking node connectivity: Array is ordered as [left_child,
     // right_child, parent].
     using NodeMap = std::map<size_t, std::array<bool, 3>>;
     NodeMap nodemap_check;
@@ -227,7 +227,7 @@ class ChoiceMap {
         }
         leaf_check.at(taxon_id) = true;
       }
-      // Update node map. If a node already has parent or child, invalid tree.
+      // Update node map. If a node already has parent or child, it is an invalid tree.
       for (const auto node_id : {parent_node.Id(), child_node.Id()}) {
         if (nodemap_check.find(node_id) == nodemap_check.end()) {
           nodemap_check.insert({node_id, {false, false, false}});

--- a/src/gp_doctest.cpp
+++ b/src/gp_doctest.cpp
@@ -1568,9 +1568,9 @@ TEST_CASE("NNI Engine: NNI Likelihoods") {
 // (all edges have mapped valid edge choices, except for root and leaves).  Then creates
 // TreeMasks for each edge in DAG, a list of edge ids which represent a embedded tree in
 // the DAG.  Tests that each TreeMask contains its central edge and is valid (tree spans
-// root and all leaf nodes, and every node in tree has one parent, one left child and
-// one right child)..
-TEST_CASE("NNI Engine: Choice Map") {
+// root and all leaf nodes, and every node in tree has a single parent, left child and
+// right child).
+TEST_CASE("Top-Pruning: ChoiceMap") {
   const std::string fasta_path = "data/six_taxon_longer.fasta";
   const std::string newick_path = "data/six_taxon_rooted_simple.nwk";
   auto inst =

--- a/src/gp_doctest.cpp
+++ b/src/gp_doctest.cpp
@@ -1568,7 +1568,7 @@ TEST_CASE("NNI Engine: NNI Likelihoods") {
 // (all edges have mapped valid edge choices, except for root and leaves).  Then creates
 // TreeMasks for each edge in DAG, a list of edge ids which represent a embedded tree in
 // the DAG.  Tests that each TreeMask contains its central edge and is valid (tree spans
-// root and all leaf nodes, each node reached by tree has one parent, one left child and
+// root and all leaf nodes, and every node in tree has one parent, one left child and
 // one right child)..
 TEST_CASE("NNI Engine: Choice Map") {
   const std::string fasta_path = "data/six_taxon_longer.fasta";

--- a/src/gp_doctest.cpp
+++ b/src/gp_doctest.cpp
@@ -1563,13 +1563,13 @@ TEST_CASE("NNI Engine: NNI Likelihoods") {
   }
 }
 
-// Builds a SubsplitDAG. Uses a naive method that picks the first listed neighbor for
-// each parent, sister, left and right child. Tests that results is a valid selection
-// (all edges have mapped valid edge choices, except for root and leaves).  Then creates
-// TreeMasks for each edge in DAG, a list of edge ids which represent a embedded tree in
-// the DAG.  Tests that each TreeMask contains its central edge and is valid (tree spans
-// root and all leaf nodes, and every node in tree has a single parent, left child and
-// right child).
+// Initializes a ChoiceMap for a DAG. Then uses a naive method that picks the first
+// listed neighbor for each parent, sister, left and right child. Tests that results is
+// a valid selection (all edges have mapped valid edge choices, except for root and
+// leaves). Then creates TreeMasks for each edge in DAG, a list of edge ids which
+// represent a embedded tree in the DAG.  Tests that each TreeMask contains its central
+// edge and is valid (tree spans root and all leaf nodes, and every node in tree has a
+// single parent, left child and right child).
 TEST_CASE("Top-Pruning: ChoiceMap") {
   const std::string fasta_path = "data/six_taxon_longer.fasta";
   const std::string newick_path = "data/six_taxon_rooted_simple.nwk";
@@ -1628,7 +1628,7 @@ TEST_CASE("Top-Pruning: ChoiceMap") {
   }
   CHECK_FALSE_MESSAGE(choice_map.TreeMaskIsValid(tree_mask),
                       "TreeMask is incorrectly valid when missing internal edge.");
-  // Additional edge.
+  // Tree contains additional edge.
   tree_mask = choice_map.ExtractTreeMask(0);
   for (size_t i = 0; i < dag.EdgeCountWithLeafSubsplits(); i++) {
     const auto contains_edge =
@@ -1646,9 +1646,8 @@ TEST_CASE("Top-Pruning: ChoiceMap") {
       }
     }
   }
-  CHECK_FALSE_MESSAGE(
-      choice_map.TreeMaskIsValid(tree_mask),
-      "TreeMask is incorrectly valid when containing an extra unconnected edge.");
+  CHECK_FALSE_MESSAGE(choice_map.TreeMaskIsValid(tree_mask),
+                      "TreeMask is incorrectly valid when containing an extra edge.");
 
   // Test TreeMasks created from all DAG edges result in valid tree.
   for (size_t edge_idx = 0; edge_idx < dag.EdgeCountWithLeafSubsplits(); edge_idx++) {

--- a/src/nni_engine.hpp
+++ b/src/nni_engine.hpp
@@ -22,6 +22,7 @@
 #include "sugar.hpp"
 #include "gp_operation.hpp"
 #include "reindexer.hpp"
+#include "choice_map.hpp"
 
 using NNIDoubleMap = std::map<NNIOperation, double>;
 
@@ -173,7 +174,6 @@ class NNIEngine {
   void ScoreAdjacentNNIsByLikelihood();
 
   // ** Filtering
-  // !ISSUE #429: Need filtering scheme.
 
   // Initialize filter before first NNI sweep.
   void FilterInit(std::optional<StaticFilterInitFunction> FilterInitFn = std::nullopt);

--- a/src/subsplit_dag.cpp
+++ b/src/subsplit_dag.cpp
@@ -976,6 +976,24 @@ bool SubsplitDAG::ContainsEdge(const size_t edge_id) const {
   return storage_.GetLine(edge_id).has_value();
 }
 
+bool SubsplitDAG::IsNodeRoot(const size_t node_id) const {
+  return (node_id == GetDAGRootNodeId());
+}
+
+bool SubsplitDAG::IsNodeLeaf(const size_t node_id) const {
+  return (node_id < TaxonCount());
+}
+
+bool SubsplitDAG::IsEdgeRoot(const size_t edge_id) const {
+  const auto parent_id = GetDAGEdge(edge_id).GetParent();
+  return IsNodeRoot(parent_id);
+}
+
+bool SubsplitDAG::IsEdgeLeaf(const size_t edge_id) const {
+  const auto child_id = GetDAGEdge(edge_id).GetChild();
+  return IsNodeLeaf(child_id);
+}
+
 // ** Build Output Indexers/Vectors
 
 std::pair<SizeVector, SizeVector> SubsplitDAG::BuildParentIdVectors(

--- a/src/subsplit_dag.cpp
+++ b/src/subsplit_dag.cpp
@@ -140,7 +140,7 @@ size_t SubsplitDAG::NodeCount() const { return storage_.GetVertices().size(); }
 
 size_t SubsplitDAG::NodeCountWithoutDAGRoot() const { return NodeCount() - 1; }
 
-double SubsplitDAG::TopologyCount() const { return topology_count_; }
+SizePair SubsplitDAG::NodeIdRange() const { return {0, NodeCount()}; }
 
 size_t SubsplitDAG::RootsplitCount() const { return GetRootsplitNodeIds().size(); }
 
@@ -149,6 +149,10 @@ size_t SubsplitDAG::EdgeCount() const { return edge_count_without_leaf_subsplits
 size_t SubsplitDAG::EdgeCountWithLeafSubsplits() const {
   return storage_.GetLines().size();
 }
+
+SizePair SubsplitDAG::EdgeIdxRange() const { return {0, EdgeCountWithLeafSubsplits()}; }
+
+double SubsplitDAG::TopologyCount() const { return topology_count_; }
 
 // ** Output methods:
 

--- a/src/subsplit_dag.hpp
+++ b/src/subsplit_dag.hpp
@@ -73,6 +73,8 @@ class SubsplitDAG {
   // The total number of nodes in the DAG (excluding the root, but including the
   // leaves).
   size_t NodeCountWithoutDAGRoot() const;
+  // The current minimum and maximum node Id values.
+  SizePair NodeIdRange() const;
   // The total number of rootsplits in DAG. These count all direct descendants of the
   // root (also, the union of each rootsplits clades cover the set of all taxa in the
   // DAG).
@@ -83,6 +85,8 @@ class SubsplitDAG {
   // The total number of edges in the DAG (including edges which terminat at a root of
   // leaf node).
   size_t EdgeCountWithLeafSubsplits() const;
+  // The current minimum and maximum edge Idx values.
+  SizePair EdgeIdxRange() const;
   // The total number of tree topologies expressable by the DAG.
   double TopologyCount() const;
 

--- a/src/subsplit_dag.hpp
+++ b/src/subsplit_dag.hpp
@@ -318,6 +318,14 @@ class SubsplitDAG {
   bool ContainsEdge(const size_t parent_id, const size_t child_id) const;
   bool ContainsEdge(const Bitset &edge_subsplit) const;
   bool ContainsEdge(const size_t edge_id) const;
+  // Is node the root?
+  bool IsNodeRoot(const size_t node_id) const;
+  // Is node a leaf?
+  bool IsNodeLeaf(const size_t node_id) const;
+  // Does edge connect to the root node?
+  bool IsEdgeRoot(const size_t edge_id) const;
+  // Does edge connect to a leaf node?
+  bool IsEdgeLeaf(const size_t edge_id) const;
 
   // ** Modify DAG
   // These methods are for directly modifying the DAG by adding or removing nodes and


### PR DESCRIPTION
## Description

- ChoiceMap
  - ChoiceMap contains a per-edge mapping from a SubsplitDAG to the candidate adjacent parent, sister, left and right child edges for the best tree containing that edge.
  - Currently only implements a naive selector, which simply takes the first valid neighbor from each category.
- TreeMask
  - With a DAG and a central edge, the ChoiceMap can generate a TreeMask. A TreeMask is a subset of the DAG's edge Ids, which forms one of the valid, complete trees embedded in the DAG.

Closes #442


## Tests

TEST_CASE("NNI Engine: Choice Map"): This test builds a ChoiceMap from a reference SubsplitDAG.  It uses the SelectFirstEdge() method and tests that resulting ChoiceMap is valid.  Then iterates over all edges in the DAG and generates the associated TreeMask, and tests that the TreeMask contains the given edge and represents a valid tree in the DAG (spans all leaf nodes and root node, no orphan nodes).


## Checklist:

* [x] Code follows our detailed [contribution guidelines](CONTRIBUTING.md)
* [x] `clang-format` has been run
* [x] TODOs have been eliminated from the code
* [x] Comments are up to date, document intent, and there are no commented-out code blocks
* [x] Issue branch has been squashed and rebased on main branch
* [ ] GitHub CI build on PR branch completed successfully
