### PR TITLE
TPEngine Parsimony

### DIFF
--- a/src/gp_doctest.cpp
+++ b/src/gp_doctest.cpp
@@ -2111,3 +2111,9 @@ TEST_CASE("Top-Pruning: Likelihoods with Proposed NNIs") {
                 "Likelihoods from proposed NNIs in smaller DAG do not match "
                 "likelihoods in larger DAG.");
 }
+
+TEST_CASE("Top-Pruning: Parsimony") {
+  auto fasta_file = "data/parsimony_leaf_seqs.fasta";
+  auto newick_file = "data/parsimony_tree_0_score_75.0.nwk";
+  double parsimony_score_correct = 75.;
+}

--- a/src/gp_doctest.cpp
+++ b/src/gp_doctest.cpp
@@ -1856,18 +1856,17 @@ std::ostream& operator<<(std::ostream& os, EigenConstMatrixXdRef mx) {
   return os;
 }
 
-// Compare TPEngine's top tree to true tree and, in the single tree cases,
-// compares its PLVs to GPEngine's.
+// Compare TPEngine's top tree to verfied ture tree and, in the single tree cases,
+// compares the partial vectors of verified method vs TPEngine method.
 // Note: The input newick file does not need to contain every possible tree
 // expressible in the DAG.  The input tree collection only needs to be ordered in
-// terms of likelihood.  The DAG edges will then each be assigned according to the
+// terms of score.  The DAG edges will then each be assigned according to the
 // best/first tree containing the given edge.
 bool TestTPEngineScoresAndPVs(const std::string fasta_path,
                               const std::string newick_path,
                               const bool test_likelihood = true,
                               const bool test_parsimony = true,
-                              const bool test_pvs = false, const bool is_quiet = true,
-                              const bool print_all = false) {
+                              const bool test_pvs = false, const bool is_quiet = true) {
   bool test_passes = true;
   std::stringstream dev_null;
   std::ostream& os = (is_quiet ? dev_null : std::cerr);
@@ -1928,20 +1927,17 @@ bool TestTPEngineScoresAndPVs(const std::string fasta_path,
           }
           if (!match_found) {
             test_passes = false;
-          }
-          if ((!match_found && !is_quiet) || print_all) {
-            std::cout << "::" << test_name << (!match_found ? "_FAILURE" : "")
-                      << ":: EdgeId: " << edge_id
+            std::cout << "::" << test_name << "_FAILURE:: EdgeId: " << edge_id
                       << ", TP_Score: " << tp_score_map[edge_id]
                       << ", Correct_Score: " << correct_tree_score_map[tree_id]
                       << ", Error: " << min_error << std::endl;
           }
         }
-        if ((!test_passes && !is_quiet) || print_all) {
+        if (!test_passes) {
           std::cout << "TestMatchingScore: " << tp_score_map.size() << std::endl;
           std::cout << "TP_Scores: " << tp_score_map.size() << " " << tp_score_map
                     << std::endl;
-          std::cout << "correct_Score: " << correct_tree_score_map.size() << " "
+          std::cout << "Correct_Score: " << correct_tree_score_map.size() << " "
                     << correct_tree_score_map << std::endl;
         }
       };
@@ -1983,10 +1979,7 @@ bool TestTPEngineScoresAndPVs(const std::string fasta_path,
           bool is_equal = (tp_pvs.GetPV(pv_type, i) == gp_pvs.GetPV(pv_type, i));
           if (!is_equal) {
             test_passes = false;
-          }
-          if (!is_equal) {
-            os << "!!! *** " << (!is_equal ? "NOT_EQUAL" : "EQUAL") << " ***"
-               << std::endl;
+            os << "!!! *** NOT EQUAL ***" << std::endl;
             os << "TP_" << tp_pvs.ToString(pv_type, i);
             os << "GP_" << gp_pvs.ToString(pv_type, i);
           }
@@ -2031,10 +2024,7 @@ bool TestTPEngineScoresAndPVs(const std::string fasta_path,
           bool is_equal = (tp_pvs.GetPV(pv_type, i) == sankoff_pvs.GetPV(pv_type, i));
           if (!is_equal) {
             test_passes = false;
-          }
-          if (!is_equal || print_all) {
-            os << "!!! *** " << (!is_equal ? "NOT EQUAL" : "EQUAL") << " ***"
-               << std::endl;
+            os << "!!! *** NOT EQUAL ***" << std::endl;
             os << "TP_" << tp_pvs.ToString(pv_type, i);
             os << "SANK_" << sankoff_pvs.ToString(pv_type, i);
           }
@@ -2058,13 +2048,13 @@ TEST_CASE("Top-Pruning: Likelihoods") {
   const std::string newick_path_six_simple = "data/six_taxon_rooted_simple.nwk";
   // Test cases.
   const auto test_1 = TestTPEngineScoresAndPVs(fasta_path_hello, newick_path_hello,
-                                               true, false, true, false, false);
+                                               true, false, true, false);
   CHECK_MESSAGE(test_1, "Hello Example Single Tree failed.");
   const auto test_2 = TestTPEngineScoresAndPVs(fasta_path_six, newick_path_six_single,
-                                               true, false, false, false, false);
+                                               true, false, false, false);
   CHECK_MESSAGE(test_2, "Six Taxa Single Tree failed.");
   const auto test_3 = TestTPEngineScoresAndPVs(fasta_path_six, newick_path_six_simple,
-                                               true, false, false, false, false);
+                                               true, false, false, false);
   CHECK_MESSAGE(test_3, "Six Taxa Multi Tree failed.");
 }
 
@@ -2204,13 +2194,13 @@ TEST_CASE("Top-Pruning: Parsimony") {
   const std::string fasta_path_six = "data/six_taxon.fasta";
   const std::string newick_path_six = "data/six_taxon_rooted_single.nwk";
   // Test cases.
-  const auto test_0 = TestTPEngineScoresAndPVs(fasta_path_1, newick_path_1, false, true,
-                                               false, false, false);
+  const auto test_0 =
+      TestTPEngineScoresAndPVs(fasta_path_1, newick_path_1, false, true, false, false);
   CHECK_MESSAGE(test_0, "Parsimony Test Case Tree failed.");
   const auto test_1 = TestTPEngineScoresAndPVs(fasta_path_hello, newick_path_hello,
-                                               false, true, false, false, false);
+                                               false, true, false, false);
   CHECK_MESSAGE(test_1, "Hello Example Single Tree failed.");
   const auto test_2 = TestTPEngineScoresAndPVs(fasta_path_six, newick_path_six, false,
-                                               true, false, false, false);
+                                               true, false, false);
   CHECK_MESSAGE(test_2, "Six Taxa Tree failed.");
 }

--- a/src/gp_doctest.cpp
+++ b/src/gp_doctest.cpp
@@ -2202,7 +2202,7 @@ TEST_CASE("Top-Pruning: Parsimony") {
   const std::string fasta_path_hello = "data/hello_short.fasta";
   const std::string newick_path_hello = "data/hello_rooted.nwk";
   const std::string fasta_path_six = "data/six_taxon.fasta";
-  const std::string newick_path_six_single = "data/six_taxon_rooted_single.nwk";
+  const std::string newick_path_six = "data/six_taxon_rooted_single.nwk";
   // Test cases.
   const auto test_0 = TestTPEngineScoresAndPVs(fasta_path_1, newick_path_1, false, true,
                                                false, false, false);
@@ -2210,7 +2210,7 @@ TEST_CASE("Top-Pruning: Parsimony") {
   const auto test_1 = TestTPEngineScoresAndPVs(fasta_path_hello, newick_path_hello,
                                                false, true, false, false, false);
   CHECK_MESSAGE(test_1, "Hello Example Single Tree failed.");
-  const auto test_2 = TestTPEngineScoresAndPVs(fasta_path_six, newick_path_six_single,
-                                               false, true, false, false, false);
+  const auto test_2 = TestTPEngineScoresAndPVs(fasta_path_six, newick_path_six, false,
+                                               true, false, false, false);
   CHECK_MESSAGE(test_2, "Six Taxa Tree failed.");
 }

--- a/src/gp_doctest.cpp
+++ b/src/gp_doctest.cpp
@@ -32,7 +32,7 @@ enum HelloGPCSP { jupiter, mars, saturn, venus, rootsplit, root };
 
 GPInstance GPInstanceOfFiles(
     const std::string& fasta_path, const std::string& newick_path,
-    const std::string mmap_filepath = std::string("_ignore/mmapped_plv.data"),
+    const std::string mmap_filepath = std::string("_ignore/mmapped_pv.data"),
     const bool use_gradients = false) {
   GPInstance inst(mmap_filepath);
   inst.ReadFastaFile(fasta_path);
@@ -339,7 +339,7 @@ TEST_CASE("GPInstance: gather and hotstart branch lengths") {
   // 1 (outgroup,(((z0,z1),z2),z3));
   // 33 (outgroup,((z0,z1),(z2,z3)));
   const std::string tree_path = "data/hotstart_bootstrap_sample.nwk";
-  GPInstance inst("_ignore/mmapped_plv.data");
+  GPInstance inst("_ignore/mmapped_pv.data");
   // This is just a dummy fasta file, which is required to make an Engine.
   inst.ReadFastaFile("data/hotstart.fasta");
   inst.ReadNewickFile(tree_path);
@@ -393,7 +393,7 @@ TEST_CASE("GPInstance: gather and hotstart branch lengths") {
 
 TEST_CASE("GPInstance: take first branch length") {
   const std::string tree_path = "data/hotstart_bootstrap_sample.nwk";
-  GPInstance inst("_ignore/mmapped_plv.data");
+  GPInstance inst("_ignore/mmapped_pv.data");
   // This is just a dummy fasta file, which is required to make an Engine.
   inst.ReadFastaFile("data/hotstart.fasta");
   inst.ReadNewickFile(tree_path);
@@ -510,7 +510,7 @@ TEST_CASE("GPInstance: CurrentlyLoadedTreesWithGPBranchLengths") {
 }
 
 TEST_CASE("GPInstance: CurrentlyLoadedTreesWithAPCSPStringAndGPBranchLengths") {
-  GPInstance inst("_ignore/mmapped_plv.data");
+  GPInstance inst("_ignore/mmapped_pv.data");
   inst.ReadFastaFile("data/five_taxon.fasta");
   inst.ReadNewickFile("data/five_taxon_rooted_more.nwk");
   inst.MakeEngine();
@@ -1087,21 +1087,21 @@ TEST_CASE("NNI Engine: Add NNI Test") {
   // dag_A_1 is a DAG that contains pair_1.
   auto inst_A_1 =
       GPInstanceOfFiles(fasta_path, "data/four_taxon_simple_before_nni_1.nwk",
-                        "_ignore/mmapped_plv_A_1.data");
+                        "_ignore/mmapped_pv_A_1.data");
   GPDAG& dag_A_1 = inst_A_1.GetDAG();
   // dag_A_2 is a DAG that contains pair_2.
   auto inst_A_2 =
       GPInstanceOfFiles(fasta_path, "data/four_taxon_simple_before_nni_2.nwk",
-                        "_ignore/mmapped_plv_A_2.data");
+                        "_ignore/mmapped_pv_A_2.data");
   GPDAG& dag_A_2 = inst_A_2.GetDAG();
   // dag_A_2b is a DAG that contains pair_2 with a different taxon mapping.
   auto inst_A_2b =
       GPInstanceOfFiles(fasta_path, "data/four_taxon_simple_before_nni_2b.nwk",
-                        "_ignore/mmapped_plv_A_2.data");
+                        "_ignore/mmapped_pv_A_2.data");
   GPDAG& dag_A_2b = inst_A_2b.GetDAG();
   // dag_B is a DAG containing dag_A_1 after adding node pair_2.
   auto inst_B = GPInstanceOfFiles(fasta_path, "data/four_taxon_simple_after_nni.nwk",
-                                  "_ignore/mmapped_plv_B.data");
+                                  "_ignore/mmapped_pv_B.data");
   GPDAG& dag_B = inst_B.GetDAG();
   // pair_1: NNI pair missing from dag_A_1.
   NNIOperation pair_1(Bitset::Subsplit("0110", "0001"),   // 12|3
@@ -1519,7 +1519,7 @@ TEST_CASE("NNI Engine: NNI Likelihoods") {
 
   // Instance with unaltered DAG.
   auto pre_inst =
-      GPInstanceOfFiles(fasta_path, newick_path, "_ignore/mmapped_plv_pre.data");
+      GPInstanceOfFiles(fasta_path, newick_path, "_ignore/mmapped_pv_pre.data");
   GPDAG& pre_dag = pre_inst.GetDAG();
   GPEngine& pre_gpengine = *pre_inst.GetEngine();
   pre_dag.FullyConnect();
@@ -1532,7 +1532,7 @@ TEST_CASE("NNI Engine: NNI Likelihoods") {
 
   // Instance that is used by grafted DAG.
   auto graft_inst =
-      GPInstanceOfFiles(fasta_path, newick_path, "_ignore/mmapped_plv_graft.data");
+      GPInstanceOfFiles(fasta_path, newick_path, "_ignore/mmapped_pv_graft.data");
   graft_inst.MakeNNIEngine();
   GPEngine& graft_gpengine = *graft_inst.GetEngine();
   NNIEngine& graft_nni_engine = graft_inst.GetNNIEngine();
@@ -1612,7 +1612,7 @@ TEST_CASE("NNI Engine: NNI Likelihoods") {
   nni_count = 0;
   for (const auto& [nni, pre_nni] : nni_to_prenni_map) {
     auto truth_inst =
-        GPInstanceOfFiles(fasta_path, newick_path, "_ignore/mmapped_plv_truth.data");
+        GPInstanceOfFiles(fasta_path, newick_path, "_ignore/mmapped_pv_truth.data");
     auto& truth_dag = truth_inst.GetDAG();
     truth_dag.FullyConnect();
     auto& truth_gpengine = *truth_inst.GetEngine();
@@ -1663,7 +1663,7 @@ TEST_CASE("NNI Engine: NNI Likelihoods") {
 TEST_CASE("Top-Pruning: ChoiceMap") {
   const std::string fasta_path = "data/six_taxon_longer.fasta";
   const std::string newick_path = "data/six_taxon_rooted_simple.nwk";
-  auto inst = GPInstanceOfFiles(fasta_path, newick_path, "_ignore/mmapped_plv.data");
+  auto inst = GPInstanceOfFiles(fasta_path, newick_path, "_ignore/mmapped_pv.data");
   auto dag = inst.GetDAG();
 
   auto choice_map = ChoiceMap(dag);
@@ -1811,8 +1811,8 @@ TEST_CASE("Top-Pruning: Initialize TPEngine and ChoiceMap") {
   inst.EstimateBranchLengths(0.00001, 100, true);
   auto all_trees = inst.GenerateCompleteRootedTreeCollection();
   SitePattern site_pattern = inst.MakeSitePattern();
-  TPEngine tpengine =
-      TPEngine(dag, site_pattern, "_ignore/mmapped_plv.data", false, false);
+  TPEngine tpengine = TPEngine(dag, site_pattern, "_ignore/mmapped_pv.tpl.data", false,
+                               "_ignore/mmapped_pv.tpp.data", false);
   tpengine.InitializeChoiceMap();
 
   auto TopologyExistsInTreeCollection = [](const Node::NodePtr tree_topology,
@@ -1856,120 +1856,200 @@ std::ostream& operator<<(std::ostream& os, EigenConstMatrixXdRef mx) {
   return os;
 }
 
-// Builds a TPEngine instance from a set of input trees. Then populates TPEngine's PVs
-// and computes the top tree likelihood for each edge in the DAG.  Compares these
-// likelihoods against the tree's likelihood computed using BEAGLE engine.
-TEST_CASE("Top-Pruning: Likelihoods") {
-  // Compare TPEngine's top tree likelihoods to BEAGLE and, in the single tree cases,
-  // compares its PLVs to GPEngine's.
-  // Note: The input newick file does not need to contain every possible tree
-  // expressible in the DAG.  The input tree collection only needs to be ordered in
-  // terms of likelihood.  The DAG edges will then each be assigned according to the
-  // best/first tree containing the given edge.
-  auto TestTPEngineLikelihoodsAndPVs = [](const std::string fasta_path,
-                                          const std::string newick_path,
-                                          const bool compare_gp_pvs = false,
-                                          const bool is_quiet = true) {
-    bool test_passes = true;
-    std::stringstream dev_null;
-    std::ostream& os = (is_quiet ? dev_null : std::cerr);
-    // Map of trees and likelihoods.
-    std::vector<RootedTree> tree_vector;
-    std::unordered_map<EdgeId, size_t> tree_id_map;
-    std::unordered_map<size_t, double> golden_tree_likelihood_map;
-    std::unordered_map<EdgeId, double> tp_likelihood_map;
-    // Make GPInstance and TPEngine.
-    auto inst =
-        GPInstanceOfFiles(fasta_path, newick_path, "_ignore/mmapped_plv.gp.data");
-    inst.MakeEngine();
-    GPEngine& gpengine = *inst.GetEngine();
-    GPDAG& dag = inst.GetDAG();
-    inst.EstimateBranchLengths(0.00001, 100, true);
-    inst.PopulatePLVs();
-    inst.ComputeLikelihoods();
-    auto tree_collection = inst.GenerateCompleteRootedTreeCollection();
-    auto edge_indexer = dag.BuildEdgeIndexer();
-    SitePattern site_pattern = inst.MakeSitePattern();
-    TPEngine tpengine =
-        TPEngine(dag, site_pattern, "_ignore/mmapped_plv.tp.data", true, true);
-    tpengine.SetBranchLengths(gpengine.GetBranchLengths());
-    tpengine.SetChoiceMapByTakingFirst(tree_collection, edge_indexer);
-    tpengine.InitializeLikelihood();
-    tpengine.ComputeLikelihoods();
-    const auto tree_source = tpengine.GetTreeSource();
-    // Populate tree vector.
-    for (const auto tree : tree_collection) {
-      tree_vector.push_back(tree);
-    }
-    for (EdgeId edge_id = 0; edge_id < dag.EdgeCountWithLeafSubsplits(); edge_id++) {
+// Compare TPEngine's top tree to true tree and, in the single tree cases,
+// compares its PLVs to GPEngine's.
+// Note: The input newick file does not need to contain every possible tree
+// expressible in the DAG.  The input tree collection only needs to be ordered in
+// terms of likelihood.  The DAG edges will then each be assigned according to the
+// best/first tree containing the given edge.
+bool TestTPEngineScoresAndPVs(const std::string fasta_path,
+                              const std::string newick_path,
+                              const bool test_likelihood = true,
+                              const bool test_parsimony = true,
+                              const bool test_pvs = false, const bool is_quiet = true,
+                              const bool print_all = false) {
+  bool test_passes = true;
+  std::stringstream dev_null;
+  std::ostream& os = (is_quiet ? dev_null : std::cerr);
+  // Map of trees and likelihoods / parsimony.
+  std::vector<RootedTree> tree_vector;
+  std::unordered_map<EdgeId, size_t> tree_id_map;
+  // Make GPInstance and TPEngine.
+  auto inst = GPInstanceOfFiles(fasta_path, newick_path, "_ignore/mmapped_pv.gp.data");
+  inst.MakeEngine();
+  GPEngine& gpengine = *inst.GetEngine();
+  GPDAG& dag = inst.GetDAG();
+  inst.EstimateBranchLengths(0.00001, 100, true);
+  inst.PopulatePLVs();
+  inst.ComputeLikelihoods();
+  auto tree_collection = inst.GenerateCompleteRootedTreeCollection();
+  auto edge_indexer = dag.BuildEdgeIndexer();
+  SitePattern site_pattern = inst.MakeSitePattern();
+  inst.MakeTPEngine("_ignore/mmapped_pv.tpl.data", true, "_ignore/mmapped_pv.tpp.data",
+                    true);
+  // Make TPEngine.
+  TPEngine& tpengine = inst.GetTPEngine();
+  tpengine.SetBranchLengths(gpengine.GetBranchLengths());
+  tpengine.SetChoiceMapByTakingFirst(tree_collection, edge_indexer);
+  const auto tree_source = tpengine.GetTreeSource();
+  // Populate tree vector.
+  for (const auto tree : tree_collection) {
+    tree_vector.push_back(tree);
+  }
+  for (EdgeId edge_id = 0; edge_id < dag.EdgeCountWithLeafSubsplits(); edge_id++) {
+    if (!dag.IsEdgeRoot(edge_id)) {
       tree_id_map[edge_id] = tree_source[edge_id.value_];
     }
+  }
+
+  // Check that scores from TPEngine match the golden scores from the individual trees.
+  // Note, if the test only contains a single tree, then this amounts to checking if
+  // each edge's likelihood matches that one tree.
+  auto TestMatchingScores =
+      [is_quiet, print_all, &tree_id_map, &test_passes](
+          const std::string& test_name,
+          std::unordered_map<size_t, double>& golden_tree_score_map,
+          std::unordered_map<EdgeId, double>& tp_score_map) {
+        for (const auto& [edge_id, tree_id] : tree_id_map) {
+          std::ignore = tree_id;
+          const auto tp_score = tp_score_map[edge_id];
+          bool match_found = false;
+          double min_error = std::numeric_limits<double>::max();
+          for (const auto& [tree_id, golden_score] : golden_tree_score_map) {
+            std::ignore = tree_id;
+            double error = abs(golden_score - tp_score);
+            if (min_error > error) {
+              min_error = error;
+              if (error < 1e-3) {
+                match_found = true;
+                break;
+              }
+            }
+          }
+          if (!match_found) {
+            test_passes = false;
+          }
+          if ((!match_found && !is_quiet) || print_all) {
+            std::cout << "::" << test_name << (!match_found ? "_FAILURE" : "")
+                      << ":: EdgeId: " << edge_id
+                      << ", TP_Score: " << tp_score_map[edge_id]
+                      << ", Golden_Score: " << golden_tree_score_map[tree_id]
+                      << ", Error: " << min_error << std::endl;
+          }
+        }
+        if ((!test_passes && !is_quiet) || print_all) {
+          std::cout << "TestMatchingScore: " << tp_score_map.size() << std::endl;
+          std::cout << "TP_Scores: " << tp_score_map.size() << " " << tp_score_map
+                    << std::endl;
+          std::cout << "Golden_Score: " << golden_tree_score_map.size() << " "
+                    << golden_tree_score_map << std::endl;
+        }
+      };
+
+  if (test_likelihood) {
+    std::unordered_map<size_t, double> golden_tree_likelihood_map;
+    std::unordered_map<EdgeId, double> tp_likelihood_map;
     // BEAGLE Engine for "golden", i.e. correct, tree likelihoods.
     PhyloModelSpecification simple_spec{"JC69", "constant", "strict"};
     auto rooted_sbn_inst = MakeRootedSBNInstance(newick_path, fasta_path, simple_spec);
-    auto& beagle_engine = *rooted_sbn_inst.GetEngine();
-    const auto& first_beagle = *beagle_engine.GetFirstFatBeagle();
-    // Compute likelihoods with BEAGLE Engine.
+    auto& beagle_engine = *rooted_sbn_inst.GetEngine()->GetFirstFatBeagle();
     size_t tree_id = 0;
     for (const auto& tree : tree_collection) {
-      auto likelihood = first_beagle.UnrootedLogLikelihood(tree);
-      golden_tree_likelihood_map[tree_id] = likelihood;
+      auto golden_likelihood = beagle_engine.UnrootedLogLikelihood(tree);
+      golden_tree_likelihood_map[tree_id] = golden_likelihood;
       tree_id++;
     }
     // Compute likelihoods with TPEngine.
+    tpengine.InitializeLikelihood();
+    tpengine.ComputeLikelihoods();
     for (const auto& [edge_id, tree_id] : tree_id_map) {
       std::ignore = tree_id;
       auto likelihood = tpengine.GetTopTreeLikelihoodWithEdge(edge_id);
       tp_likelihood_map[edge_id] = likelihood;
     }
-    // Check that likelihoods from TPEngine match a tree likelihood from BEAGLE.  Note,
-    // if the test only contains a single tree, then this amounts to checking if each
-    // edge's likelihood matches that one tree.
-    for (const auto& [edge_id, tree_id] : tree_id_map) {
-      std::ignore = tree_id;
-      const auto tp_likelihood = tp_likelihood_map[edge_id];
-      bool match_found = false;
-      for (const auto& [tree_id, golden_likelihood] : golden_tree_likelihood_map) {
-        std::ignore = tree_id;
-        if (abs(golden_likelihood - tp_likelihood) < 1e-3) {
-          match_found = true;
-          break;
-        }
-      }
-      if (!match_found) {
-        test_passes = false;
-        if (!is_quiet) {
-          std::cout << "FAILURE: EdgeId = " << edge_id
-                    << ", TP_Likelihood: " << tp_likelihood_map[edge_id]
-                    << ", Golden_Likelihood: " << golden_tree_likelihood_map[tree_id]
-                    << std::endl;
-        }
-      }
-    }
+    // Check that scores from TPEngine match the golden scores from the individual
+    // trees computed by BEAGLE engine.
+    TestMatchingScores(std::string("LIKELIHOODS"), golden_tree_likelihood_map,
+                       tp_likelihood_map);
     // Compare GP and TP partial vectors. Note, this test is only relevant with single
     // trees, as GP and TP PVs are only equal in the case of single tree DAGs.
     auto& tp_pvs = tpengine.GetLikelihoodPVs();
     auto& gp_pvs = gpengine.GetPLVHandler();
-    if (compare_gp_pvs) {
-      std::vector<PLVType> plv_types = {PLVType::RHat, PLVType::RLeft, PLVType::RRight};
-      for (const auto& plv_type : PLVTypeEnum::Iterator()) {
-        std::string plv_name = PLVTypeEnum::Labels[plv_type];
+    if (test_pvs) {
+      std::vector<PLVType> pv_types = {PLVType::RHat, PLVType::RLeft, PLVType::RRight};
+      for (const auto& pv_type : PLVTypeEnum::Iterator()) {
+        std::string pv_name = PLVTypeEnum::Labels[pv_type];
         for (NodeId i = 0; i < gp_pvs.GetNodeCount(); i++) {
-          bool is_equal = (tp_pvs.GetPV(plv_type, i) == gp_pvs.GetPV(plv_type, i));
+          bool is_equal = (tp_pvs.GetPV(pv_type, i) == gp_pvs.GetPV(pv_type, i));
           if (!is_equal) {
             test_passes = false;
           }
           if (!is_equal) {
-            os << "!!! *** NOT EQUAL ***" << std::endl;
-            os << "TP_" << tp_pvs.ToString(plv_type, i);
-            os << "GP_" << gp_pvs.ToString(plv_type, i);
+            os << "!!! *** " << (!is_equal ? "NOT_EQUAL" : "EQUAL") << " ***"
+               << std::endl;
+            os << "TP_" << tp_pvs.ToString(pv_type, i);
+            os << "GP_" << gp_pvs.ToString(pv_type, i);
           }
         }
       }
     }
+  }
 
-    return test_passes;
-  };
+  if (test_parsimony) {
+    std::unordered_map<size_t, double> golden_tree_parsimony_map;
+    std::unordered_map<EdgeId, double> tp_parsimony_map;
+    // Sankoff Handler for "golden", i.e. correct, tree parsimonies.
+    SankoffHandler sankoff_engine(site_pattern, "_ignore.mmapped_pv.sankoff.data");
+    size_t tree_id = 0;
+    for (const auto& tree : tree_collection) {
+      sankoff_engine.RunSankoff(tree.Topology());
+      auto golden_parsimony = sankoff_engine.ParsimonyScore(tree.Topology()->Id());
+      golden_tree_parsimony_map[tree_id] = golden_parsimony;
+      tree_id++;
+    }
+    // Compute parsimonies with TPEngine.
+    tpengine.InitializeParsimony();
+    tpengine.ComputeParsimonies();
+    for (const auto& [edge_id, tree_id] : tree_id_map) {
+      std::ignore = tree_id;
+      auto parsimony = tpengine.GetTopTreeParsimonyWithEdge(edge_id);
+      tp_parsimony_map[edge_id] = parsimony;
+    }
+    // Check that scores from TPEngine match the golden scores from the individual
+    // trees computed by BEAGLE engine.
+    TestMatchingScores(std::string("PARSIMONY"), golden_tree_parsimony_map,
+                       tp_parsimony_map);
+    // Compare GP and TP partial vectors. Note, this test is only relevant with single
+    // trees, as GP and TP PVs are only equal in the case of single tree DAGs.
+    auto& tp_pvs = tpengine.GetParsimonyPVs();
+    auto& sankoff_pvs = sankoff_engine.GetPSVHandler();
+    if (test_pvs) {
+      std::vector<PSVType> plv_types = {PSVType::Q, PSVType::PLeft, PSVType::PRight};
+      for (const auto& pv_type : PSVTypeEnum::Iterator()) {
+        std::string pv_name = PSVTypeEnum::Labels[pv_type];
+        for (NodeId i = 0; i < sankoff_pvs.GetNodeCount(); i++) {
+          bool is_equal = (tp_pvs.GetPV(pv_type, i) == sankoff_pvs.GetPV(pv_type, i));
+          if (!is_equal) {
+            test_passes = false;
+          }
+          if (!is_equal || print_all) {
+            os << "!!! *** " << (!is_equal ? "NOT EQUAL" : "EQUAL") << " ***"
+               << std::endl;
+            os << "TP_" << tp_pvs.ToString(pv_type, i);
+            os << "SANK_" << sankoff_pvs.ToString(pv_type, i);
+          }
+        }
+      }
+    }
+  }
+
+  return test_passes;
+};
+
+// Builds a TPEngine instance from a set of input trees. Then populates TPEngine's PVs
+// and computes the top tree likelihood for each edge in the DAG.  Compares these
+// likelihoods against the tree's likelihood computed using BEAGLE engine.
+TEST_CASE("Top-Pruning: Likelihoods") {
   // Input files.
   const std::string fasta_path_hello = "data/hello_short.fasta";
   const std::string newick_path_hello = "data/hello_rooted.nwk";
@@ -1977,14 +2057,14 @@ TEST_CASE("Top-Pruning: Likelihoods") {
   const std::string newick_path_six_single = "data/six_taxon_rooted_single.nwk";
   const std::string newick_path_six_simple = "data/six_taxon_rooted_simple.nwk";
   // Test cases.
-  const auto test_1 =
-      TestTPEngineLikelihoodsAndPVs(fasta_path_hello, newick_path_hello, true, false);
+  const auto test_1 = TestTPEngineScoresAndPVs(fasta_path_hello, newick_path_hello,
+                                               true, false, true, false, false);
   CHECK_MESSAGE(test_1, "Hello Example Single Tree failed.");
-  const auto test_2 = TestTPEngineLikelihoodsAndPVs(
-      fasta_path_six, newick_path_six_single, true, false);
+  const auto test_2 = TestTPEngineScoresAndPVs(fasta_path_six, newick_path_six_single,
+                                               true, false, false, false, false);
   CHECK_MESSAGE(test_2, "Six Taxa Single Tree failed.");
-  const auto test_3 = TestTPEngineLikelihoodsAndPVs(
-      fasta_path_six, newick_path_six_simple, false, false);
+  const auto test_3 = TestTPEngineScoresAndPVs(fasta_path_six, newick_path_six_simple,
+                                               true, false, false, false, false);
   CHECK_MESSAGE(test_3, "Six Taxa Multi Tree failed.");
 }
 
@@ -1999,7 +2079,8 @@ TEST_CASE("Top-Pruning: Likelihoods") {
 TEST_CASE("Top-Pruning: Likelihoods with Proposed NNIs") {
   // Build GPInstance with TPEngine and NNIEngine.
   auto MakeTPEngine = [](const std::string& fasta_path, const std::string& newick_path,
-                         const std::string& tp_mmap_path,
+                         const std::string& tpl_mmap_path,
+                         const std::string& tpp_mmap_path,
                          const std::string& gp_mmap_path) {
     // Make GPInstance and TPEngine.
     auto inst = GPInstanceOfFiles(fasta_path, newick_path, gp_mmap_path);
@@ -2007,7 +2088,7 @@ TEST_CASE("Top-Pruning: Likelihoods with Proposed NNIs") {
     inst.MakeEngine();
     GPEngine& gpengine = *inst.GetEngine();
     auto edge_indexer = dag.BuildEdgeIndexer();
-    inst.MakeTPEngine(tp_mmap_path, true, true);
+    inst.MakeTPEngine(tpl_mmap_path, true, tpp_mmap_path, true);
     inst.MakeNNIEngine();
     TPEngine& tpengine = inst.GetTPEngine();
     tpengine.SetBranchLengths(gpengine.GetBranchLengths());
@@ -2072,8 +2153,8 @@ TEST_CASE("Top-Pruning: Likelihoods with Proposed NNIs") {
   const std::string fasta_path_2 = "data/six_taxon.fasta";
   const std::string newick_path_2 = "data/six_taxon_rooted_simple_plus_adj_nnis.nwk";
   auto inst_2 =
-      MakeTPEngine(fasta_path_2, newick_path_2, "_ignore/mmapped_plv.tp.2.data",
-                   "_ignore/mmapped_plv.gp.2.data");
+      MakeTPEngine(fasta_path_2, newick_path_2, "_ignore/mmapped_pv.tpl.2.data",
+                   "_ignore/mmapped_pv.tpp.2.data", "_ignore/mmapped_pv.gp.2.data");
   auto likelihoods_2 = BuildEdgeLikelihoodMap(inst_2);
   auto dag_2 = inst_2.GetDAG();
 
@@ -2081,8 +2162,8 @@ TEST_CASE("Top-Pruning: Likelihoods with Proposed NNIs") {
   const std::string fasta_path_1 = "data/six_taxon.fasta";
   const std::string newick_path_1 = "data/six_taxon_rooted_simple.nwk";
   auto inst_1 =
-      MakeTPEngine(fasta_path_1, newick_path_1, "_ignore/mmapped_plv.tp.1.data",
-                   "_ignore/mmapped_plv.gp.1.data");
+      MakeTPEngine(fasta_path_1, newick_path_1, "_ignore/mmapped_pv.tpl.1.data",
+                   "_ignore/mmapped_pv.tpp.1.data", "_ignore/mmapped_pv.gp.1.data");
   auto likelihoods_1 = BuildEdgeLikelihoodMap(inst_1);
   auto dag_1 = inst_1.GetDAG();
 
@@ -2112,8 +2193,24 @@ TEST_CASE("Top-Pruning: Likelihoods with Proposed NNIs") {
                 "likelihoods in larger DAG.");
 }
 
+// Builds a TPEngine instance from a set of input trees. Then populates TPEngine's PVs
+// and computes the top tree parsimony for each edge in the DAG.  Compares these
+// likelihoods against the tree's likelihood computed using the `sankoff handler`.
 TEST_CASE("Top-Pruning: Parsimony") {
-  auto fasta_file = "data/parsimony_leaf_seqs.fasta";
-  auto newick_file = "data/parsimony_tree_0_score_75.0.nwk";
-  double parsimony_score_correct = 75.;
+  auto fasta_path_1 = "data/parsimony_leaf_seqs.fasta";
+  auto newick_path_1 = "data/parsimony_tree_0_score_75.0.nwk";
+  const std::string fasta_path_hello = "data/hello_short.fasta";
+  const std::string newick_path_hello = "data/hello_rooted.nwk";
+  const std::string fasta_path_six = "data/six_taxon.fasta";
+  const std::string newick_path_six_single = "data/six_taxon_rooted_single.nwk";
+  // Test cases.
+  const auto test_0 = TestTPEngineScoresAndPVs(fasta_path_1, newick_path_1, false, true,
+                                               false, false, false);
+  CHECK_MESSAGE(test_0, "Parsimony Test Case Tree failed.");
+  const auto test_1 = TestTPEngineScoresAndPVs(fasta_path_hello, newick_path_hello,
+                                               false, true, false, false, false);
+  CHECK_MESSAGE(test_1, "Hello Example Single Tree failed.");
+  const auto test_2 = TestTPEngineScoresAndPVs(fasta_path_six, newick_path_six_single,
+                                               false, true, false, false, false);
+  CHECK_MESSAGE(test_2, "Six Taxa Tree failed.");
 }

--- a/src/gp_doctest.cpp
+++ b/src/gp_doctest.cpp
@@ -2016,7 +2016,7 @@ bool TestTPEngineScoresAndPVs(const std::string fasta_path,
       tp_parsimony_map[edge_id] = parsimony;
     }
     // Check that scores from TPEngine match the correct scores from the individual
-    // trees computed by BEAGLE engine.
+    // trees computed by Sankoff Handler.
     TestMatchingScores(std::string("PARSIMONY"), correct_tree_parsimony_map,
                        tp_parsimony_map);
     // Compare GP and TP partial vectors. Note, this test is only relevant with single

--- a/src/gp_instance.cpp
+++ b/src/gp_instance.cpp
@@ -633,12 +633,13 @@ void GPInstance::SubsplitDAGToDot(const std::string &out_path,
   out_stream.close();
 }
 
-void GPInstance::MakeTPEngine(const std::string mmap_file_path,
+void GPInstance::MakeTPEngine(const std::string mmap_likelihood_path,
                               const bool using_likelihoods,
+                              const std::string mmap_parsimony_path,
                               const bool using_parsimony) {
   auto site_pattern = MakeSitePattern();
-  tp_engine_ =
-      std::make_unique<TPEngine>(dag_, site_pattern, mmap_file_path, true, true);
+  tp_engine_ = std::make_unique<TPEngine>(dag_, site_pattern, mmap_likelihood_path,
+                                          true, mmap_parsimony_path, true);
 }
 
 TPEngine &GPInstance::GetTPEngine() {

--- a/src/gp_instance.hpp
+++ b/src/gp_instance.hpp
@@ -128,7 +128,8 @@ class GPInstance {
 
   // ** TP Engine
   // Initialize Top-Pruning Engine.
-  void MakeTPEngine(const std::string mmap_file_path, const bool using_likelihoods,
+  void MakeTPEngine(const std::string mmap_likelihood_path,
+                    const bool using_likelihoods, const std::string mmap_parsimony_path,
                     const bool using_parsimony);
   // Get Top-Pruning Engine.
   TPEngine &GetTPEngine();

--- a/src/sankoff_handler.cpp
+++ b/src/sankoff_handler.cpp
@@ -75,8 +75,7 @@ void SankoffHandler::PopulateRootwardParsimonyPVForNode(const NodeId parent_id,
   for (size_t pattern_idx = 0; pattern_idx < site_pattern_.PatternCount();
        pattern_idx++) {
     // Which child partial is in right or left doesn't actually matter because they
-    // are summed when calculating q_partials. In DAG case, will want to ensure that
-    // left children partials are in p_partials_left
+    // are summed when calculating q_partials.
     psv_handler_.GetPV(PSVType::PLeft, parent_id).col(pattern_idx) =
         ParentPartial(TotalPPartial(left_child_id, pattern_idx));
 

--- a/src/sankoff_handler.hpp
+++ b/src/sankoff_handler.hpp
@@ -44,6 +44,7 @@ class SankoffHandler {
     psv_handler_.Resize(site_pattern_.TaxonCount(),
                         psv_handler_.GetAllocatedNodeCount());
   }
+
   SankoffHandler(CostMatrix cost_matrix, SitePattern site_pattern,
                  const std::string &mmap_file_path, double resizing_factor = 2.0)
       : mutation_costs_(SankoffMatrix(cost_matrix)),

--- a/src/sankoff_handler.hpp
+++ b/src/sankoff_handler.hpp
@@ -12,6 +12,7 @@
 #include "node.hpp"
 #include "driver.hpp"
 #include "pv_handler.hpp"
+#include "gp_dag.hpp"
 
 // Partial vector for one node across all sites
 using SankoffPartial = NucleotidePLV;
@@ -27,7 +28,7 @@ class SankoffHandler {
   static constexpr size_t state_count_ = 4;
   static constexpr double big_double_ = static_cast<double>(INT_MAX);
 
-  // constructors
+  // Constructors
   SankoffHandler(SitePattern site_pattern, const std::string &mmap_file_path,
                  double resizing_factor = 2.0)
       : mutation_costs_(SankoffMatrix()),
@@ -79,6 +80,12 @@ class SankoffHandler {
                         psv_handler_.GetAllocatedNodeCount());
   }
 
+  PSVHandler &GetPSVHandler() { return psv_handler_; }
+  SankoffMatrix &GetCostMatrix() { return mutation_costs_; }
+
+  // Resize PVs to fit model.
+  void Resize(const size_t new_node_count);
+
   // Partial Sankoff Vector Handler.
   SankoffPartialVec PartialsAtPattern(PSVType psv_type, size_t pattern_idx) {
     SankoffPartialVec partials_at_pattern(psv_handler_.GetNodeCount());
@@ -88,19 +95,28 @@ class SankoffHandler {
     return partials_at_pattern;
   }
 
-  // sum p-partials for right and left children of node 'node_id'
+  // Fill in leaf-values for P partials.
+  void GenerateLeafPartials();
+
+  // Sum p-partials for right and left children of node 'node_id'
   // In this case, we get the full p-partial of the given node after all p-partials
   // have been concatenated into one SankoffPartialVector
   EigenVectorXd TotalPPartial(NodeId node_id, size_t site_idx);
 
-  // fill in leaf-values for P partials
-  void GenerateLeafPartials();
-
-  // calculate the partial for a given parent-child pair
+  // Calculate the partial for a given parent-child pair
   EigenVectorXd ParentPartial(EigenVectorXd child_partials);
 
+  // Populate rootward parsimony PV for node.
+  void PopulateRootwardParsimonyPVForNode(const NodeId parent_id,
+                                          const NodeId left_child_id,
+                                          const NodeId right_child_id);
+  // Populate leafward parsimony PV for node.
+  void PopulateLeafwardParsimonyPVForNode(const NodeId parent_id,
+                                          const NodeId left_child_id,
+                                          const NodeId right_child_id);
+
   // Calculates left p_partials, right p_partials, and q_partials for all nodes at all
-  // sites.
+  // sites in tree topology.
   void RunSankoff(Node::NodePtr topology);
 
   // Calculates parsimony score on given node across all sites.

--- a/src/tp_engine.cpp
+++ b/src/tp_engine.cpp
@@ -435,7 +435,6 @@ void TPEngine::PopulateLeafwardParsimonyPVForNode(const NodeId node_id) {
   if (!dag_.IsNodeLeaf(node_id)) {
     best_edge_id = FindBestEdgeAdjacentToNode(node_id, Direction::Leafward);
     const auto best_edge = dag_.GetDAGEdge(best_edge_id);
-    const NodeId parent_node_id = best_edge.GetParent();
     const NodeId focal_node_id = best_edge.GetChild();
     const EdgeId sister_edge_id =
         choice_map_.GetEdgeChoice(best_edge_id).sister_edge_id;

--- a/src/tp_engine.hpp
+++ b/src/tp_engine.hpp
@@ -46,7 +46,7 @@ class TPEngine {
   // Compute top tree likelihoods for all edges in DAG. Result stored in
   // log_likelihoods_ matrix.
   void ComputeLikelihoods();
-  //
+  // After adding an NNI to the DAG, update the likelihoods over the
   void UpdateLikelihoodsAfterDAGAddNodePair(
       const NNIOperation &post_nni, const NNIOperation &pre_nni,
       std::optional<size_t> new_tree_id = std::nullopt);


### PR DESCRIPTION
## Description

- Adds Parsimony computation to TPEngine. 
- Some refactoring of Sankoff Handler and TPEngine tests.

Closes #460 


## Tests

TEST_CASE("Top-Pruning: Parsimony"): Builds a TPEngine and uses it to compute the tree parsimony, then uses this to test against the golden tree parsimony scores produced by the sankoff handler.


## Checklist:

* [x] Code follows our detailed [contribution guidelines](CONTRIBUTING.md)
* [x] `clang-format` has been run
* [x] TODOs have been eliminated from the code
* [x] Comments are up to date, document intent, and there are no commented-out code blocks
* [ ] Issue branch has been squashed and rebased on main branch
* [ ] GitHub CI build on PR branch completed successfully
